### PR TITLE
feat(router): add policy-based provider selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Rebranded the public documentation around the FoundryGate product name
 - Completed the technical rename from `clawgate` runtime identifiers to `foundrygate`
 - Added validated provider capability metadata with normalized local/cloud and streaming defaults
+- Added an optional policy layer for capability-aware provider selection on `auto` requests
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [How It Works](#how-it-works)
 - [API](#api)
 - [Model Aliases And Routing](#model-aliases-and-routing)
+- [Policy Routing](#policy-routing)
 - [Configuration](#configuration)
 - [Deployment](#deployment)
 - [Helper Scripts](#helper-scripts)
@@ -86,6 +87,7 @@ Client (OpenClaw or any OpenAI-style client)
   v
 http://127.0.0.1:8090/v1
   |
+  +--> Layer 0: optional policy rules
   +--> Layer 1: static rules
   +--> Layer 2: heuristic rules
   +--> Layer 3: optional LLM classifier
@@ -100,9 +102,10 @@ http://127.0.0.1:8090/v1
 
 Routing decisions happen in order:
 
-1. Static rules for known patterns such as heartbeat, explicit model hints, and sub-agent traffic
-2. Heuristic rules for user-message content, tools, and rough token size
-3. An optional LLM classifier if you enable it in `config.yaml`
+1. Optional policy rules for client-specific, governance, or local/cloud constraints
+2. Static rules for known patterns such as heartbeat, explicit model hints, and sub-agent traffic
+3. Heuristic rules for user-message content, tools, and rough token size
+4. An optional LLM classifier if you enable it in `config.yaml`
 
 Important implementation detail: heuristic keyword scoring only evaluates user messages, not the system prompt. This avoids over-routing to expensive tiers because of long system prompts.
 
@@ -194,6 +197,36 @@ If you use OpenClaw, the recommended client-side aliases live in [openclaw-integ
 
 Those aliases are defined on the OpenClaw side. FoundryGate only sees the resulting `model` value and routes accordingly.
 
+## Policy Routing
+
+FoundryGate now supports an optional `routing_policies` layer for `auto` requests. This sits in front of the existing static and heuristic rules and is meant for constraints that are broader than a single keyword rule, for example:
+
+- prefer local providers for private or LAN-only traffic
+- keep a client or workflow on a subset of allowed providers
+- require capabilities such as `tools` before a request is sent
+- prefer one provider order while still falling through to another eligible provider
+
+Each rule has:
+
+- `match`: request conditions such as `header_contains`, `model_requested`, `has_tools`, `estimated_tokens`, or `message_keywords`
+- `select`: provider filters and preference order via `allow_providers`, `deny_providers`, `prefer_providers`, `prefer_tiers`, `require_capabilities`, and `capability_values`
+
+Minimal example:
+
+```yaml
+routing_policies:
+  enabled: true
+  rules:
+    - name: local-only-profile
+      match:
+        header_contains:
+          x-foundrygate-profile: ["local-only"]
+      select:
+        capability_values:
+          local: true
+        prefer_tiers: ["local"]
+```
+
 ## Configuration
 
 FoundryGate loads configuration from:
@@ -271,6 +304,19 @@ providers:
       cost_tier: budget
       latency_tier: low
 ```
+
+### Routing Policy Schema
+
+The optional `routing_policies` block is validated at startup. FoundryGate rejects unknown provider references, unknown capability names, and unsupported select keys before the service comes up.
+
+Supported `select` keys today:
+
+- `allow_providers`
+- `deny_providers`
+- `prefer_providers`
+- `prefer_tiers`
+- `require_capabilities`
+- `capability_values`
 
 ### Configuration Examples
 

--- a/config.yaml
+++ b/config.yaml
@@ -582,6 +582,32 @@ fallback_chain:
   - openrouter-fallback
 
 
+# ── Layer 0: Policy-Auswahl (optional) ────────────────────────────────────
+# Diese Schicht läuft vor den statischen und heuristischen Regeln.
+# Gedacht für client-, governance- oder netzwerkbezogene Auswahl, ohne
+# bestehende explizite Provider-Pins im API-Layer zu brechen.
+#
+# select:
+#   allow_providers      : nur diese Provider dürfen gewählt werden
+#   deny_providers       : diese Provider werden ausgeschlossen
+#   prefer_providers     : bevorzugte Reihenfolge innerhalb der Kandidaten
+#   prefer_tiers         : bevorzugte tier-Werte innerhalb der Kandidaten
+#   require_capabilities : boolesche Capability-Namen, die true sein müssen
+#   capability_values    : exakte Capability-Werte, z. B. local=true
+routing_policies:
+  enabled: false
+  rules:
+    # Beispiel: lokalen Worker für interne/local-only Requests bevorzugen
+    # - name: prefer-local-worker
+    #   match:
+    #     header_contains:
+    #       x-foundrygate-profile: ["local-only", "private"]
+    #   select:
+    #     capability_values:
+    #       local: true
+    #     prefer_tiers: ["local"]
+
+
 # ── Layer 1: Statische Regeln ──────────────────────────────────────────────
 # Schnellste Schicht – Pattern-Matching auf bekannte Muster
 static_rules:

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -46,6 +46,14 @@ _STRING_CAPABILITY_FIELDS = {
     "compliance_scope",
 }
 _ALL_CAPABILITY_FIELDS = _BOOL_CAPABILITY_FIELDS | _STRING_CAPABILITY_FIELDS
+_POLICY_SELECT_KEYS = {
+    "allow_providers",
+    "deny_providers",
+    "prefer_providers",
+    "prefer_tiers",
+    "require_capabilities",
+    "capability_values",
+}
 
 
 class ConfigError(ValueError):
@@ -220,6 +228,169 @@ def _normalize_providers(data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _normalize_string_list(
+    value: Any, *, field_name: str, rule_name: str, allow_empty: bool = False
+) -> list[str]:
+    """Normalize a config field to a list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        items = [value]
+    elif isinstance(value, list):
+        items = value
+    else:
+        raise ConfigError(f"Policy '{rule_name}' field '{field_name}' must be a string or list")
+
+    normalized = []
+    for item in items:
+        if not isinstance(item, str) or not item.strip():
+            raise ConfigError(
+                f"Policy '{rule_name}' field '{field_name}' must contain non-empty strings"
+            )
+        normalized.append(item.strip())
+
+    if not allow_empty and not normalized:
+        raise ConfigError(f"Policy '{rule_name}' field '{field_name}' must not be empty")
+    return normalized
+
+
+def _normalize_policy_match(name: str, match: Any) -> dict[str, Any]:
+    """Validate a policy match block."""
+    if not isinstance(match, dict):
+        raise ConfigError(f"Policy '{name}' match must be a mapping")
+    return match
+
+
+def _normalize_policy_select(name: str, select: Any, providers: dict[str, Any]) -> dict[str, Any]:
+    """Validate a policy select block."""
+    if not isinstance(select, dict):
+        raise ConfigError(f"Policy '{name}' select must be a mapping")
+
+    unknown = sorted(set(select) - _POLICY_SELECT_KEYS)
+    if unknown:
+        unknown_list = ", ".join(unknown)
+        raise ConfigError(f"Policy '{name}' has unknown select keys: {unknown_list}")
+
+    normalized = dict(select)
+    provider_names = set(providers)
+
+    for field_name in ("allow_providers", "deny_providers", "prefer_providers"):
+        values = _normalize_string_list(
+            normalized.get(field_name, []),
+            field_name=field_name,
+            rule_name=name,
+            allow_empty=True,
+        )
+        unknown_providers = sorted(value for value in values if value not in provider_names)
+        if unknown_providers:
+            unknown_list = ", ".join(unknown_providers)
+            raise ConfigError(
+                f"Policy '{name}' field '{field_name}' references unknown providers: {unknown_list}"
+            )
+        normalized[field_name] = values
+
+    normalized["prefer_tiers"] = _normalize_string_list(
+        normalized.get("prefer_tiers", []),
+        field_name="prefer_tiers",
+        rule_name=name,
+        allow_empty=True,
+    )
+
+    required_caps = _normalize_string_list(
+        normalized.get("require_capabilities", []),
+        field_name="require_capabilities",
+        rule_name=name,
+        allow_empty=True,
+    )
+    unknown_caps = sorted(cap for cap in required_caps if cap not in _ALL_CAPABILITY_FIELDS)
+    if unknown_caps:
+        unknown_list = ", ".join(unknown_caps)
+        raise ConfigError(
+            f"Policy '{name}' require_capabilities has unknown capability names: {unknown_list}"
+        )
+    normalized["require_capabilities"] = required_caps
+
+    cap_values = normalized.get("capability_values", {})
+    if cap_values is None:
+        cap_values = {}
+    if not isinstance(cap_values, dict):
+        raise ConfigError(f"Policy '{name}' capability_values must be a mapping")
+
+    normalized_cap_values: dict[str, list[Any]] = {}
+    for cap_name, raw_values in cap_values.items():
+        if cap_name not in _ALL_CAPABILITY_FIELDS:
+            raise ConfigError(
+                f"Policy '{name}' capability_values references unknown capability '{cap_name}'"
+            )
+        values = raw_values if isinstance(raw_values, list) else [raw_values]
+        if not values:
+            raise ConfigError(
+                f"Policy '{name}' capability_values '{cap_name}' must not be an empty list"
+            )
+        normalized_values = []
+        for value in values:
+            if cap_name in _BOOL_CAPABILITY_FIELDS and not isinstance(value, bool):
+                raise ConfigError(
+                    f"Policy '{name}' capability_values '{cap_name}' must use boolean values"
+                )
+            if cap_name in _STRING_CAPABILITY_FIELDS:
+                if not isinstance(value, str) or not value.strip():
+                    raise ConfigError(
+                        f"Policy '{name}' capability_values '{cap_name}' must use non-empty strings"
+                    )
+                value = value.strip()
+            normalized_values.append(value)
+        normalized_cap_values[cap_name] = normalized_values
+    normalized["capability_values"] = normalized_cap_values
+
+    if normalized["allow_providers"] and normalized["deny_providers"]:
+        overlap = sorted(set(normalized["allow_providers"]) & set(normalized["deny_providers"]))
+        if overlap:
+            overlap_list = ", ".join(overlap)
+            raise ConfigError(
+                f"Policy '{name}' cannot allow and deny the same provider(s): {overlap_list}"
+            )
+
+    return normalized
+
+
+def _normalize_routing_policies(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the optional routing policy layer."""
+    raw = data.get("routing_policies", {"enabled": False, "rules": []})
+    if not isinstance(raw, dict):
+        raise ConfigError("'routing_policies' must be a mapping")
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'routing_policies.enabled' must be a boolean")
+
+    rules = raw.get("rules", [])
+    if rules is None:
+        rules = []
+    if not isinstance(rules, list):
+        raise ConfigError("'routing_policies.rules' must be a list")
+
+    providers = data.get("providers", {})
+    normalized_rules = []
+    for idx, rule in enumerate(rules, start=1):
+        if not isinstance(rule, dict):
+            raise ConfigError(f"Policy rule #{idx} must be a mapping")
+        name = rule.get("name", "").strip()
+        if not name:
+            raise ConfigError(f"Policy rule #{idx} must define a non-empty 'name'")
+        normalized_rules.append(
+            {
+                "name": name,
+                "match": _normalize_policy_match(name, rule.get("match", {})),
+                "select": _normalize_policy_select(name, rule.get("select", {}), providers),
+            }
+        )
+
+    normalized = dict(data)
+    normalized["routing_policies"] = {"enabled": enabled, "rules": normalized_rules}
+    return normalized
+
+
 class Config:
     """Holds the parsed and expanded configuration."""
 
@@ -247,6 +418,10 @@ class Config:
     @property
     def heuristic_rules(self) -> dict:
         return self._data.get("heuristic_rules", {"enabled": False, "rules": []})
+
+    @property
+    def routing_policies(self) -> dict:
+        return self._data.get("routing_policies", {"enabled": False, "rules": []})
 
     @property
     def llm_classifier(self) -> dict:
@@ -291,5 +466,5 @@ def load_config(path: str | Path | None = None) -> Config:
     with path.open() as f:
         raw = yaml.safe_load(f)
 
-    expanded = _normalize_providers(_walk_expand(raw))
+    expanded = _normalize_routing_policies(_normalize_providers(_walk_expand(raw)))
     return Config(expanded)

--- a/foundrygate/router.py
+++ b/foundrygate/router.py
@@ -17,7 +17,7 @@ class RoutingDecision:
     """Result of the routing process."""
 
     provider_name: str
-    layer: str  # "static", "heuristic", "llm-classify", "fallback"
+    layer: str  # "policy", "static", "heuristic", "llm-classify", "fallback"
     rule_name: str  # Which rule matched
     confidence: float  # 0.0–1.0
     reason: str  # Human-readable explanation
@@ -96,7 +96,14 @@ class Router:
             has_tools=has_tools,
             headers=headers or {},
             provider_health=provider_health or {},
+            providers=self.config.providers,
         )
+
+        # Layer 0: Policy rules
+        decision = self._layer_policy(ctx)
+        if decision:
+            decision.elapsed_ms = (time.time() - t0) * 1000
+            return self._validate_health(decision, ctx)
 
         # Layer 1: Static rules
         decision = self._layer_static(ctx)
@@ -128,6 +135,118 @@ class Router:
             reason="No routing layer matched, using first fallback",
             elapsed_ms=elapsed,
         )
+
+    # ── Layer 0: Policy Rules ──────────────────────────────────
+
+    def _layer_policy(self, ctx: _RoutingContext) -> RoutingDecision | None:
+        cfg = self.config.routing_policies
+        if not cfg.get("enabled"):
+            return None
+
+        for rule in cfg.get("rules", []):
+            match = rule.get("match", {})
+            if not self._match_policy(match, ctx):
+                continue
+
+            provider_name = self._select_policy_provider(rule.get("select", {}), ctx)
+            if not provider_name:
+                logger.debug("Policy rule matched but no provider was eligible: %s", rule["name"])
+                continue
+
+            logger.debug("Policy rule matched: %s → %s", rule["name"], provider_name)
+            return RoutingDecision(
+                provider_name=provider_name,
+                layer="policy",
+                rule_name=rule["name"],
+                confidence=0.95,
+                reason=f"Policy rule '{rule['name']}' matched",
+            )
+
+        return None
+
+    def _match_policy(self, match: dict, ctx: _RoutingContext) -> bool:
+        """Evaluate a policy match block using the existing static/heuristic primitives."""
+        if not match:
+            return True
+
+        if "all" in match:
+            return all(self._match_policy(sub, ctx) for sub in match["all"])
+        if "any" in match:
+            return any(self._match_policy(sub, ctx) for sub in match["any"])
+
+        static_keys = {"model_requested", "system_prompt_contains", "header_contains", "any"}
+        heuristic_keys = {"has_tools", "estimated_tokens", "message_keywords", "fallthrough"}
+
+        static_match = {k: match[k] for k in static_keys if k in match}
+        heuristic_match = {k: match[k] for k in heuristic_keys if k in match}
+
+        if static_match and not self._match_static(static_match, ctx):
+            return False
+        if heuristic_match and not self._match_heuristic(heuristic_match, ctx):
+            return False
+
+        return bool(static_match or heuristic_match)
+
+    def _select_policy_provider(self, select: dict, ctx: _RoutingContext) -> str | None:
+        """Choose a provider from the current config based on a policy rule."""
+        candidates = [
+            name
+            for name, provider in ctx.providers.items()
+            if self._provider_matches_policy(provider, name, select)
+        ]
+        if not candidates:
+            return None
+
+        ranked = self._rank_policy_candidates(candidates, select)
+        for provider_name in ranked:
+            if ctx.provider_health.get(provider_name, {}).get("healthy", True):
+                return provider_name
+        return ranked[0] if ranked else None
+
+    def _provider_matches_policy(self, provider: dict, name: str, select: dict) -> bool:
+        """Return whether a provider is eligible for a policy rule."""
+        capabilities = provider.get("capabilities", {})
+        allow = select.get("allow_providers", [])
+        deny = set(select.get("deny_providers", []))
+
+        if allow and name not in allow:
+            return False
+        if name in deny:
+            return False
+
+        for capability in select.get("require_capabilities", []):
+            if not capabilities.get(capability):
+                return False
+
+        for capability, expected_values in select.get("capability_values", {}).items():
+            if capabilities.get(capability) not in expected_values:
+                return False
+
+        return True
+
+    def _rank_policy_candidates(self, candidates: list[str], select: dict) -> list[str]:
+        """Rank eligible policy candidates by explicit preference, then provider order."""
+        preferred = []
+        prefer_providers = select.get("prefer_providers", [])
+        prefer_tiers = set(select.get("prefer_tiers", []))
+
+        def _append(name: str) -> None:
+            if name in candidates and name not in preferred:
+                preferred.append(name)
+
+        for name in prefer_providers:
+            _append(name)
+
+        if prefer_tiers:
+            for name in candidates:
+                provider = self.config.provider(name) or {}
+                if provider.get("tier") in prefer_tiers:
+                    _append(name)
+
+        for name in candidates:
+            _append(name)
+
+        return preferred
 
     # ── Layer 1: Static Rules ──────────────────────────────────
 
@@ -310,6 +429,7 @@ class _RoutingContext:
         "has_tools",
         "headers",
         "provider_health",
+        "providers",
         "_classify_fn",
     )
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,0 +1,225 @@
+"""Tests for policy-based provider selection."""
+
+# ruff: noqa: E402
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Mock httpx before importing our modules
+_httpx = types.ModuleType("httpx")
+
+
+class _Timeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _Limits:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _AsyncClient:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def aclose(self):
+        pass
+
+
+_httpx.Timeout = _Timeout
+_httpx.Limits = _Limits
+_httpx.AsyncClient = _AsyncClient
+_httpx.TimeoutException = Exception
+_httpx.ConnectError = Exception
+sys.modules["httpx"] = _httpx
+
+from foundrygate.config import ConfigError, load_config
+from foundrygate.router import Router
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(body)
+    return path
+
+
+class TestRoutingPolicies:
+    @pytest.mark.asyncio
+    async def test_policy_prefers_local_provider_for_matching_profile(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cloud-default:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cloud-chat"
+    tier: default
+  local-worker:
+    backend: openai-compat
+    base_url: "http://127.0.0.1:11434/v1"
+    api_key: "local"
+    model: "llama3"
+    tier: local
+routing_policies:
+  enabled: true
+  rules:
+    - name: local-only-profile
+      match:
+        header_contains:
+          x-foundrygate-profile: ["local-only"]
+      select:
+        capability_values:
+          local: true
+        prefer_tiers: ["local"]
+fallback_chain:
+  - cloud-default
+metrics:
+  enabled: false
+""",
+            )
+        )
+        router = Router(cfg)
+
+        decision = await router.route(
+            [{"role": "user", "content": "hello"}],
+            model_requested="auto",
+            headers={"x-foundrygate-profile": "local-only"},
+        )
+
+        assert decision.layer == "policy"
+        assert decision.rule_name == "local-only-profile"
+        assert decision.provider_name == "local-worker"
+
+    @pytest.mark.asyncio
+    async def test_policy_falls_to_next_healthy_preferred_candidate(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  tool-primary:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "tool-primary"
+    tier: default
+    capabilities:
+      tools: true
+  tool-secondary:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "tool-secondary"
+    tier: default
+    capabilities:
+      tools: true
+  cheap-chat:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cheap-chat"
+    tier: cheap
+routing_policies:
+  enabled: true
+  rules:
+    - name: tool-traffic
+      match:
+        has_tools: true
+      select:
+        require_capabilities: ["tools"]
+        prefer_providers: ["tool-primary", "tool-secondary"]
+fallback_chain:
+  - cheap-chat
+metrics:
+  enabled: false
+""",
+            )
+        )
+        router = Router(cfg)
+
+        decision = await router.route(
+            [{"role": "user", "content": "search files"}],
+            model_requested="auto",
+            has_tools=True,
+            provider_health={
+                "tool-primary": {"healthy": False},
+                "tool-secondary": {"healthy": True},
+            },
+        )
+
+        assert decision.layer == "policy"
+        assert decision.provider_name == "tool-secondary"
+
+
+class TestPolicyValidation:
+    def test_policy_rejects_unknown_provider_reference(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  primary:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+routing_policies:
+  enabled: true
+  rules:
+    - name: invalid-provider
+      match: {}
+      select:
+        allow_providers: ["missing-provider"]
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+
+        with pytest.raises(ConfigError, match="unknown providers"):
+            load_config(path)
+
+    def test_policy_rejects_unknown_capability_reference(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  primary:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+routing_policies:
+  enabled: true
+  rules:
+    - name: invalid-capability
+      match: {}
+      select:
+        capability_values:
+          not_real: true
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+
+        with pytest.raises(ConfigError, match="unknown capability"):
+            load_config(path)


### PR DESCRIPTION
## What changed
- add an optional routing_policies config layer in front of static and heuristic routing
- validate policy match/select blocks and provider/capability references at startup
- select providers by capabilities, allow/deny lists, and preference order
- document the policy schema and add focused tests for local-only and tool-traffic scenarios

## Why
- this is the next Phase 1 step after provider capabilities
- it creates the first capability-aware policy layer without breaking explicit provider pinning
- it prepares FoundryGate for local workers, client profiles, and later policy packs

## How verified
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- git diff --check
- artifact safety checks for .ssh/, *.db*, *.sqlite*, *.log