### PR TITLE
feat(config): add local worker provider contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Completed the technical rename from `clawgate` runtime identifiers to `foundrygate`
 - Added validated provider capability metadata with normalized local/cloud and streaming defaults
 - Added an optional policy layer for capability-aware provider selection on `auto` requests
+- Added an explicit `local-worker` provider contract for network-local OpenAI-compatible runtimes
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Returns overall service status plus one object per loaded provider. Each provide
 - `consecutive_failures`
 - `avg_latency_ms`
 - `last_error`
+- `contract`
 - `backend`
 - `tier`
 - `capabilities`
@@ -299,6 +300,33 @@ providers:
     api_key: "local"
     model: "llama3"
     tier: local
+    capabilities:
+      tools: true
+      cost_tier: budget
+      latency_tier: low
+```
+
+### Local Worker Contract
+
+FoundryGate also supports an explicit `contract: local-worker` on provider definitions. Use this for network-local OpenAI-compatible workers such as Ollama, vLLM, LM Studio, LiteLLM, or a dedicated LAN worker.
+
+What the current runtime guarantees for `local-worker`:
+
+- backend must be `openai-compat`
+- `base_url` must point to localhost or private network space
+- `tier` defaults to `local`
+- capability metadata is normalized to `local: true`, `cloud: false`, `network_zone: local`
+
+Example:
+
+```yaml
+providers:
+  local-worker:
+    contract: local-worker
+    backend: openai-compat
+    base_url: "http://127.0.0.1:11434/v1"
+    api_key: "local"
+    model: "your-local-model"
     capabilities:
       tools: true
       cost_tier: budget

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@ server:
 # ── Provider Definitions ───────────────────────────────────────────────────
 #
 # Fields:
+#   contract     : generic | local-worker
 #   backend      : openai-compat | google-genai | anthropic-compat
 #   base_url     : API endpoint (supports ${VAR:-default} expansion)
 #   api_key      : ${ENV_VAR} – leave blank to skip provider at startup
@@ -46,6 +47,15 @@ server:
 #                             commented out if no key is set
 # C. CUSTOM / PROXY         – providers via models.providers in OpenClaw
 # D. LOCAL RUNTIMES         – Ollama, vLLM, LM Studio, LiteLLM
+#
+# local-worker contract
+# ─────────────────────
+# Use `contract: local-worker` for network-local OpenAI-compatible workers.
+# The current runtime validates:
+#   - backend must be openai-compat
+#   - base_url must point to localhost or private network space
+#   - tier defaults to local
+#   - capabilities are forced to local=true, cloud=false, network_zone=local
 
 providers:
 
@@ -521,6 +531,26 @@ providers:
   # Auth: optional (set VLLM_API_KEY to enable)
   # Default: http://127.0.0.1:8000/v1
   # Docs: https://docs.openclaw.ai/providers/vllm
+  #local-worker-example:
+  #  contract: local-worker
+  #  backend: openai-compat
+  #  base_url: "${LOCAL_WORKER_BASE_URL:-http://127.0.0.1:11434/v1}"
+  #  api_key: "${LOCAL_WORKER_API_KEY:-local}"
+  #  model: "your-local-model"
+  #  max_tokens: 8000
+  #  capabilities:
+  #    tools: true
+  #    cost_tier: budget
+  #    latency_tier: low
+  #    compliance_scope: private
+  #  timeout:
+  #    connect_s: 5
+  #    read_s: 120
+  #  pricing:
+  #    input: 0.00
+  #    output: 0.00
+  #
+  # Provider-specific local runtime examples:
   #vllm-local:
   #  backend: openai-compat
   #  base_url: "${VLLM_BASE_URL:-http://127.0.0.1:8000/v1}"

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -29,6 +29,7 @@ import yaml
 from dotenv import load_dotenv
 
 _SUPPORTED_BACKENDS = {"openai-compat", "google-genai", "anthropic-compat"}
+_SUPPORTED_PROVIDER_CONTRACTS = {"generic", "local-worker"}
 _BOOL_CAPABILITY_FIELDS = {
     "chat",
     "reasoning",
@@ -210,6 +211,40 @@ def _normalize_provider(name: str, cfg: Any) -> dict[str, Any]:
         value = normalized.get(field, "")
         if not isinstance(value, str) or not value.strip():
             raise ConfigError(f"Provider '{name}' must define a non-empty '{field}'")
+
+    contract = normalized.get("contract", "generic")
+    if not isinstance(contract, str) or not contract.strip():
+        raise ConfigError(f"Provider '{name}' contract must be a non-empty string")
+    contract = contract.strip()
+    if contract not in _SUPPORTED_PROVIDER_CONTRACTS:
+        supported = ", ".join(sorted(_SUPPORTED_PROVIDER_CONTRACTS))
+        raise ConfigError(
+            f"Provider '{name}' uses unsupported contract '{contract}' (supported: {supported})"
+        )
+    normalized["contract"] = contract
+
+    if contract == "local-worker":
+        if backend != "openai-compat":
+            raise ConfigError(
+                f"Provider '{name}' contract 'local-worker' requires backend 'openai-compat'"
+            )
+        if not _looks_local_base_url(str(normalized.get("base_url", ""))):
+            raise ConfigError(
+                f"Provider '{name}' contract 'local-worker' requires a local/private base_url"
+            )
+        normalized.setdefault("tier", "local")
+
+        raw_capabilities = normalized.get("capabilities")
+        if raw_capabilities is None:
+            raw_capabilities = {}
+        if not isinstance(raw_capabilities, dict):
+            raise ConfigError(f"Provider '{name}' capabilities must be a mapping")
+        normalized["capabilities"] = {
+            **raw_capabilities,
+            "local": True,
+            "cloud": False,
+            "network_zone": "local",
+        }
 
     normalized["capabilities"] = _normalize_provider_capabilities(name, normalized)
     return normalized

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -90,6 +90,7 @@ async def health():
         "providers": {
             name: {
                 **p.health.to_dict(),
+                "contract": p.contract,
                 "backend": p.backend_type,
                 "tier": p.tier,
                 "capabilities": p.capabilities,
@@ -119,6 +120,7 @@ async def list_models():
                 "object": "model",
                 "owned_by": p.backend_type,
                 "description": f"{p.model} ({p.tier})",
+                "contract": p.contract,
                 "capabilities": p.capabilities,
             }
         )

--- a/foundrygate/providers.py
+++ b/foundrygate/providers.py
@@ -63,6 +63,7 @@ class ProviderBackend:
 
     def __init__(self, name: str, cfg: dict):
         self.name = name
+        self.contract = cfg.get("contract", "generic")
         self.backend_type = cfg.get("backend", "openai-compat")
         self.base_url = cfg["base_url"].rstrip("/")
         self.api_key = cfg.get("api_key", "")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -145,3 +145,61 @@ def test_capabilities_reject_google_streaming_enablement(tmp_path):
 
     with pytest.raises(ConfigError, match="google-genai"):
         load_config(path)
+
+
+def test_local_worker_contract_defaults_tier_and_local_capabilities(tmp_path):
+    path = _write_config(
+        tmp_path,
+        (
+            "  local-worker:\n"
+            "    contract: local-worker\n"
+            "    backend: openai-compat\n"
+            '    base_url: "http://127.0.0.1:11434/v1"\n'
+            '    api_key: "local"\n'
+            '    model: "llama3"\n'
+        ),
+    )
+
+    cfg = load_config(path)
+    provider = cfg.provider("local-worker")
+    caps = provider["capabilities"]
+
+    assert provider["contract"] == "local-worker"
+    assert provider["tier"] == "local"
+    assert caps["local"] is True
+    assert caps["cloud"] is False
+    assert caps["network_zone"] == "local"
+
+
+def test_local_worker_contract_rejects_non_local_base_url(tmp_path):
+    path = _write_config(
+        tmp_path,
+        (
+            "  local-worker:\n"
+            "    contract: local-worker\n"
+            "    backend: openai-compat\n"
+            '    base_url: "https://api.example.com/v1"\n'
+            '    api_key: "secret"\n'
+            '    model: "llama3"\n'
+        ),
+    )
+
+    with pytest.raises(ConfigError, match="local/private base_url"):
+        load_config(path)
+
+
+def test_local_worker_contract_rejects_non_openai_backend(tmp_path):
+    path = _write_config(
+        tmp_path,
+        (
+            "  local-worker:\n"
+            "    contract: local-worker\n"
+            "    backend: google-genai\n"
+            '    base_url: "http://127.0.0.1:11434/v1"\n'
+            '    api_key: "secret"\n'
+            '    model: "llama3"\n'
+        ),
+    )
+
+    with pytest.raises(ConfigError, match="requires backend 'openai-compat'"):
+        load_config(path)


### PR DESCRIPTION
## What changed
- add an explicit  provider contract
- validate that local workers use openai-compat and a local/private base URL
- default local-worker tier to integer 10 readonly !=0
integer 10 readonly '#'=0
integer 10 readonly '$'=53419
array readonly '*'=(  )
readonly -=569Xl
0=/bin/zsh
integer 10 readonly '?'=127
array readonly @=(  )
integer 10 readonly ARGC=0
tied cdpath CDPATH=''
CODEX_CI=1
CODEX_INTERNAL_ORIGINATOR_OVERRIDE='Codex Desktop'
CODEX_SANDBOX_NETWORK_DISABLED=1
CODEX_THREAD_ID=019ca1ea-57b0-7d80-9d3f-6a2caf4c64f9
COLORTERM=''
integer 10 COLUMNS=0
COMMAND_MODE=unix2003
CPUTYPE=arm64
integer 10 EGID=20
integer 10 EUID=501
tied fignore FIGNORE=''
tied fpath FPATH=/opt/homebrew/share/zsh/site-functions:/usr/local/share/zsh/site-functions:/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions
integer 10 FUNCNEST=700
GH_PAGER=cat
integer 10 GID=20
GIT_PAGER=cat
HISTCHARS='!^#'
integer 10 readonly HISTCMD=0
integer 10 HISTSIZE=30
HOME=/Users/andrelange
HOMEBREW_CELLAR=/opt/homebrew/Cellar
HOMEBREW_PREFIX=/opt/homebrew
HOMEBREW_REPOSITORY=/opt/homebrew
HOST=MacBook-Air-LNW.local
IFS=$' \t\n\C-@'
INFOPATH=/opt/homebrew/share/info:
KEYBOARD_HACK=''
integer KEYTIMEOUT=40
LANG=C.UTF-8
LC_ALL=C.UTF-8
LC_CTYPE=C.UTF-8
integer 10 readonly LINENO=1
integer 10 LINES=0
integer LISTMAX=100
LOGNAME=andrelange
MACHTYPE=x86_64
integer MAILCHECK=60
tied mailpath MAILPATH=''
tied manpath MANPATH=''
tied module_path MODULE_PATH=/usr/lib/zsh/5.9
MallocNanoZone=0
NO_COLOR=1
NULLCMD=cat
OLDPWD=/Users/andrelange/.codex/worktrees/257a/ClawGate
OPTARG=''
integer 10 OPTIND=1
OSLogRateLimit=64
OSTYPE=darwin25.0
PAGER=cat
tied path PATH=/Users/andrelange/bin:/Users/andrelange/.codex-shims:/Users/andrelange/.local/bin:/opt/homebrew/opt/openssl@3/bin:/opt/homebrew/opt/mysql/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0ObrMTE:/Applications/Codex.app/Contents/Resources
integer 10 readonly PPID=20738
PROMPT=''
PROMPT2=''
PROMPT3='?# '
PROMPT4='+%N:%i> '
PS1=''
PS2=''
PS3='?# '
PS4='+%N:%i> '
tied psvar PSVAR=''
PWD=/Users/andrelange/.codex/worktrees/257a/ClawGate
integer 10 RANDOM=9271
READNULLCMD=more
RUST_LOG=warn
integer 10 SAVEHIST=0
integer 10 SECONDS=0
SHELL=/bin/zsh
integer 10 SHLVL=1
SPROMPT='zsh: correct '\''%R'\'' to '\''%r'\'' [nyae]? '
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.ccoJOYAEco/Listeners
TERM=dumb
TIMEFMT='%J  %U user %S system %P cpu %*E total'
TMPDIR=/var/folders/jv/b3szkbf546nfx6gblvmg633c0000gn/T/
TMPPREFIX=/tmp/zsh
integer 10 TRY_BLOCK_ERROR=-1
integer 10 TRY_BLOCK_INTERRUPT=-1
TTY=''
integer 10 readonly TTYIDLE=-1
integer 10 UID=501
USER=andrelange
USERNAME=andrelange
VENDOR=apple
undefined WATCH
WORDCHARS='*?_-.[]~=/&;!#$%^(){}<>'
XPC_FLAGS=0x0
XPC_SERVICE_NAME=application.com.openai.codex.316747350.316747356
ZSH_ARGZERO=/bin/zsh
readonly tied zsh_eval_context ZSH_EVAL_CONTEXT=cmdarg:cmdsubst
ZSH_EXECUTION_STRING=$'PATH=/opt/homebrew/bin:$PATH gh pr create --base main --head codex/feature/local-worker-provider-contract-2026-03-11 --title "feat(config): add local worker provider contract" --body "## What changed\n- add an explicit `contract: local-worker` provider contract\n- validate that local workers use openai-compat and a local/private base URL\n- default local-worker tier to `local` and normalize local/cloud capability metadata\n- expose provider contract metadata via `/health` and `/v1/models`\n- document the contract and add a reusable local-worker config example\n\n## Why\n- this turns local OpenAI-compatible workers into a first-class FoundryGate provider contract\n- it supports the next local-worker integration step without special-case routing logic\n- it gives operators a stable way to declare LAN/local workers such as Ollama, vLLM, LM Studio, LiteLLM, or a custom worker\n\n## How verified\n- python3 -m compileall foundrygate tests\n- PYTHONPATH=. ./.venv-check-313/bin/pytest -q\n- ./.venv-check-313/bin/ruff check .\n- ./.venv-check-313/bin/ruff format --check .\n- git diff --check\n- artifact safety checks for .ssh/, *.db*, *.sqlite*, *.log"'
ZSH_NAME=zsh
ZSH_PATCHLEVEL=zsh-5.9-0-g73d3173
integer 10 readonly ZSH_SUBSHELL=1
ZSH_VERSION=5.9
_=local
__CFBundleIdentifier=com.openai.codex
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x3
undefined aliases
array argv=(  )
undefined builtins
array tied CDPATH cdpath=(  )
undefined commands
undefined dirstack
undefined dis_aliases
undefined dis_builtins
undefined dis_functions
undefined dis_functions_source
undefined dis_galiases
undefined dis_patchars
undefined dis_reswords
undefined dis_saliases
array tied FIGNORE fignore=(  )
array tied FPATH fpath=( /opt/homebrew/share/zsh/site-functions /usr/local/share/zsh/site-functions /usr/share/zsh/site-functions /usr/share/zsh/5.9/functions )
undefined funcfiletrace
undefined funcsourcetrace
undefined funcstack
undefined functions
undefined functions_source
undefined functrace
undefined galiases
histchars='!^#'
undefined history
undefined historywords
undefined jobdirs
undefined jobstates
undefined jobtexts
undefined keymaps
array tied MAILPATH mailpath=(  )
array tied MANPATH manpath=(  )
array tied MODULE_PATH module_path=( /usr/lib/zsh/5.9 )
undefined modules
undefined nameddirs
undefined options
undefined parameters
undefined patchars
array tied PATH path=( /Users/andrelange/bin /Users/andrelange/.codex-shims /Users/andrelange/.local/bin /opt/homebrew/opt/openssl@3/bin /opt/homebrew/opt/mysql/bin /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /System/Cryptexes/App/usr/bin /usr/bin /bin /usr/sbin /sbin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin /opt/pmk/env/global/bin /usr/local/go/bin /Users/andrelange/.cargo/bin /Users/andrelange/.codex/tmp/arg0/codex-arg0ObrMTE /Applications/Codex.app/Contents/Resources )
array pipestatus=( 0 )
prompt=''
array tied PSVAR psvar=(  )
undefined reswords
undefined saliases
array signals=( EXIT HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 ZERR DEBUG )
integer 10 readonly status=127
undefined termcap
undefined terminfo
undefined userdirs
undefined usergroups
undefined watch
undefined widgets
array readonly tied ZSH_EVAL_CONTEXT zsh_eval_context=( cmdarg cmdsubst )
undefined zsh_scheduled_events and normalize local/cloud capability metadata
- expose provider contract metadata via  and 
- document the contract and add a reusable local-worker config example

## Why
- this turns local OpenAI-compatible workers into a first-class FoundryGate provider contract
- it supports the next local-worker integration step without special-case routing logic
- it gives operators a stable way to declare LAN/local workers such as Ollama, vLLM, LM Studio, LiteLLM, or a custom worker

## How verified
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- git diff --check
- artifact safety checks for .ssh/, *.db*, *.sqlite*, *.log