### PR TITLE
feat(api): add client profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added validated provider capability metadata with normalized local/cloud and streaming defaults
 - Added an optional policy layer for capability-aware provider selection on `auto` requests
 - Added an explicit `local-worker` provider contract for network-local OpenAI-compatible runtimes
+- Added optional client profiles for caller-aware routing defaults based on request headers
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [API](#api)
 - [Model Aliases And Routing](#model-aliases-and-routing)
 - [Policy Routing](#policy-routing)
+- [Client Profiles](#client-profiles)
 - [Configuration](#configuration)
 - [Deployment](#deployment)
 - [Helper Scripts](#helper-scripts)
@@ -226,6 +227,46 @@ routing_policies:
         capability_values:
           local: true
         prefer_tiers: ["local"]
+```
+
+## Client Profiles
+
+FoundryGate also supports optional `client_profiles` for caller-aware defaults. Profiles are resolved from request headers and apply routing hints only when policy, static, and heuristic layers did not already pick a provider.
+
+This is useful for giving different default behavior to:
+
+- OpenClaw
+- n8n workflows
+- local/private-only callers
+- future CLI wrappers or other automation clients
+
+Profile rules can match on:
+
+- `header_present`
+- `header_contains`
+
+Profile hints use the same selector keys as policy rules, for example `prefer_tiers`, `allow_providers`, `require_capabilities`, or `capability_values`.
+
+Example:
+
+```yaml
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+    openclaw:
+      prefer_tiers: ["default", "reasoning"]
+    n8n:
+      prefer_tiers: ["cheap", "default"]
+  rules:
+    - profile: openclaw
+      match:
+        header_present: ["x-openclaw-source"]
+    - profile: n8n
+      match:
+        header_contains:
+          x-foundrygate-client: ["n8n"]
 ```
 
 ## Configuration

--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,12 @@ server:
 #   - base_url must point to localhost or private network space
 #   - tier defaults to local
 #   - capabilities are forced to local=true, cloud=false, network_zone=local
+#
+# client_profiles
+# ───────────────
+# Optional caller-aware defaults. Profiles are resolved from request headers and
+# applied as default provider preferences only when policy/static/heuristic
+# routing did not already make a stronger decision.
 
 providers:
 
@@ -636,6 +642,41 @@ routing_policies:
     #     capability_values:
     #       local: true
     #     prefer_tiers: ["local"]
+
+
+# ── Client Profiles (optional) ────────────────────────────────────────────
+# Detects callers from headers and applies default routing hints when no
+# policy/static/heuristic rule has already selected a provider.
+#
+# match:
+#   header_present  : all listed headers must exist
+#   header_contains : any listed substring match activates the profile rule
+#
+# profile hints use the same selector keys as routing_policies.select.
+client_profiles:
+  enabled: false
+  default: generic
+  profiles:
+    generic: {}
+    openclaw:
+      prefer_tiers: ["default", "reasoning"]
+    n8n:
+      prefer_tiers: ["cheap", "default"]
+    local-only:
+      capability_values:
+        local: true
+  rules:
+    # - profile: openclaw
+    #   match:
+    #     header_present: ["x-openclaw-source"]
+    # - profile: n8n
+    #   match:
+    #     header_contains:
+    #       x-foundrygate-client: ["n8n"]
+    # - profile: local-only
+    #   match:
+    #     header_contains:
+    #       x-foundrygate-profile: ["local-only", "private"]
 
 
 # ── Layer 1: Statische Regeln ──────────────────────────────────────────────

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -55,6 +55,7 @@ _POLICY_SELECT_KEYS = {
     "require_capabilities",
     "capability_values",
 }
+_CLIENT_PROFILE_MATCH_KEYS = {"header_contains", "header_present", "any", "all"}
 
 
 class ConfigError(ValueError):
@@ -426,6 +427,134 @@ def _normalize_routing_policies(data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _normalize_client_profile_match(name: str, match: Any) -> dict[str, Any]:
+    """Validate a client profile match block."""
+    if not isinstance(match, dict):
+        raise ConfigError(f"Client profile rule '{name}' match must be a mapping")
+    unknown = sorted(set(match) - _CLIENT_PROFILE_MATCH_KEYS)
+    if unknown:
+        unknown_list = ", ".join(unknown)
+        raise ConfigError(f"Client profile rule '{name}' has unknown match keys: {unknown_list}")
+
+    if "header_present" in match:
+        match["header_present"] = _normalize_string_list(
+            match["header_present"],
+            field_name="header_present",
+            rule_name=f"client profile rule '{name}'",
+            allow_empty=False,
+        )
+
+    if "header_contains" in match:
+        if not isinstance(match["header_contains"], dict):
+            raise ConfigError(
+                f"Client profile rule '{name}' field 'header_contains' must be a mapping"
+            )
+        normalized_header_contains = {}
+        for header_name, values in match["header_contains"].items():
+            if not isinstance(header_name, str) or not header_name.strip():
+                raise ConfigError(
+                    f"Client profile rule '{name}' field 'header_contains' "
+                    "must use non-empty header names"
+                )
+            normalized_header_contains[header_name.strip().lower()] = _normalize_string_list(
+                values,
+                field_name="header_contains",
+                rule_name=f"client profile rule '{name}'",
+                allow_empty=False,
+            )
+        match["header_contains"] = normalized_header_contains
+
+    for compound in ("any", "all"):
+        if compound in match:
+            values = match[compound]
+            if not isinstance(values, list) or not values:
+                raise ConfigError(
+                    f"Client profile rule '{name}' field '{compound}' must be a non-empty list"
+                )
+            match[compound] = [_normalize_client_profile_match(name, item) for item in values]
+
+    return match
+
+
+def _normalize_client_profiles(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the optional client profile layer."""
+    raw = data.get(
+        "client_profiles",
+        {"enabled": False, "default": "generic", "profiles": {"generic": {}}, "rules": []},
+    )
+    if not isinstance(raw, dict):
+        raise ConfigError("'client_profiles' must be a mapping")
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ConfigError("'client_profiles.enabled' must be a boolean")
+
+    default_profile = raw.get("default", "generic")
+    if not isinstance(default_profile, str) or not default_profile.strip():
+        raise ConfigError("'client_profiles.default' must be a non-empty string")
+    default_profile = default_profile.strip()
+
+    profiles = raw.get("profiles", {})
+    if profiles is None:
+        profiles = {}
+    if not isinstance(profiles, dict):
+        raise ConfigError("'client_profiles.profiles' must be a mapping")
+
+    normalized_profiles = {}
+    for profile_name, hints in profiles.items():
+        if not isinstance(profile_name, str) or not profile_name.strip():
+            raise ConfigError("Client profile names must be non-empty strings")
+        if hints is None:
+            hints = {}
+        normalized_profiles[profile_name.strip()] = _normalize_policy_select(
+            f"client profile '{profile_name.strip()}'",
+            hints,
+            data.get("providers", {}),
+        )
+
+    if default_profile not in normalized_profiles:
+        normalized_profiles.setdefault(
+            default_profile,
+            _normalize_policy_select(
+                f"client profile '{default_profile}'", {}, data.get("providers", {})
+            ),
+        )
+
+    rules = raw.get("rules", [])
+    if rules is None:
+        rules = []
+    if not isinstance(rules, list):
+        raise ConfigError("'client_profiles.rules' must be a list")
+
+    normalized_rules = []
+    for idx, rule in enumerate(rules, start=1):
+        if not isinstance(rule, dict):
+            raise ConfigError(f"Client profile rule #{idx} must be a mapping")
+        profile_name = rule.get("profile", "")
+        if not isinstance(profile_name, str) or not profile_name.strip():
+            raise ConfigError(f"Client profile rule #{idx} must define a non-empty 'profile'")
+        profile_name = profile_name.strip()
+        if profile_name not in normalized_profiles:
+            raise ConfigError(
+                f"Client profile rule #{idx} references unknown profile '{profile_name}'"
+            )
+        normalized_rules.append(
+            {
+                "profile": profile_name,
+                "match": _normalize_client_profile_match(profile_name, rule.get("match", {})),
+            }
+        )
+
+    normalized = dict(data)
+    normalized["client_profiles"] = {
+        "enabled": enabled,
+        "default": default_profile,
+        "profiles": normalized_profiles,
+        "rules": normalized_rules,
+    }
+    return normalized
+
+
 class Config:
     """Holds the parsed and expanded configuration."""
 
@@ -457,6 +586,13 @@ class Config:
     @property
     def routing_policies(self) -> dict:
         return self._data.get("routing_policies", {"enabled": False, "rules": []})
+
+    @property
+    def client_profiles(self) -> dict:
+        return self._data.get(
+            "client_profiles",
+            {"enabled": False, "default": "generic", "profiles": {"generic": {}}, "rules": []},
+        )
 
     @property
     def llm_classifier(self) -> dict:
@@ -501,5 +637,7 @@ def load_config(path: str | Path | None = None) -> Config:
     with path.open() as f:
         raw = yaml.safe_load(f)
 
-    expanded = _normalize_routing_policies(_normalize_providers(_walk_expand(raw)))
+    expanded = _normalize_client_profiles(
+        _normalize_routing_policies(_normalize_providers(_walk_expand(raw)))
+    )
     return Config(expanded)

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -28,6 +28,49 @@ _router: Router
 _metrics: MetricsStore
 
 
+def _collect_routing_headers(request: Request) -> dict[str, str]:
+    """Return the request headers that are relevant for routing decisions."""
+    prefixes = ("x-openclaw", "x-foundrygate")
+    return {k.lower(): v for k, v in request.headers.items() if k.lower().startswith(prefixes)}
+
+
+def _match_client_profile_rule(match: dict, headers: dict[str, str]) -> bool:
+    """Evaluate one client profile match block."""
+    if not match:
+        return True
+    if "all" in match:
+        return all(_match_client_profile_rule(item, headers) for item in match["all"])
+    if "any" in match:
+        return any(_match_client_profile_rule(item, headers) for item in match["any"])
+    if "header_present" in match:
+        return all(header_name in headers for header_name in match["header_present"])
+    if "header_contains" in match:
+        for header_name, patterns in match["header_contains"].items():
+            header_value = headers.get(header_name, "").lower()
+            if any(pattern.lower() in header_value for pattern in patterns):
+                return True
+        return False
+    return False
+
+
+def _resolve_client_profile(
+    config: Config, headers: dict[str, str]
+) -> tuple[str, dict[str, object]]:
+    """Resolve the active client profile and its routing hints from request headers."""
+    profiles_cfg = config.client_profiles
+    default_profile = profiles_cfg.get("default", "generic")
+    active_profile = default_profile
+
+    if profiles_cfg.get("enabled"):
+        for rule in profiles_cfg.get("rules", []):
+            if _match_client_profile_rule(rule.get("match", {}), headers):
+                active_profile = rule["profile"]
+                break
+
+    hints = profiles_cfg.get("profiles", {}).get(active_profile, {})
+    return active_profile, hints
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown lifecycle."""
@@ -174,10 +217,8 @@ async def chat_completions(request: Request):
     max_tokens = body.get("max_tokens")
     tools = body.get("tools")
 
-    # Extract headers that OpenClaw might send
-    headers = {
-        k.lower(): v for k, v in request.headers.items() if k.lower().startswith("x-openclaw")
-    }
+    headers = _collect_routing_headers(request)
+    client_profile, profile_hints = _resolve_client_profile(_config, headers)
 
     # ── Routing ────────────────────────────────────────────
 
@@ -197,6 +238,8 @@ async def chat_completions(request: Request):
             messages,
             model_requested=model_requested,
             has_tools=bool(tools),
+            client_profile=client_profile,
+            profile_hints=profile_hints,
             headers=headers,
             provider_health=health_map,
         )
@@ -262,12 +305,16 @@ async def chat_completions(request: Request):
                 return StreamingResponse(
                     result,
                     media_type="text/event-stream",
-                    headers={"X-FoundryGate-Provider": provider_name},
+                    headers={
+                        "X-FoundryGate-Provider": provider_name,
+                        "X-FoundryGate-Profile": client_profile,
+                    },
                 )
 
             # Add routing info to response headers (non-streaming)
             resp = JSONResponse(result)
             resp.headers["X-FoundryGate-Provider"] = provider_name
+            resp.headers["X-FoundryGate-Profile"] = client_profile
             resp.headers["X-FoundryGate-Layer"] = decision.layer
             resp.headers["X-FoundryGate-Rule"] = decision.rule_name
             return resp

--- a/foundrygate/router.py
+++ b/foundrygate/router.py
@@ -17,7 +17,7 @@ class RoutingDecision:
     """Result of the routing process."""
 
     provider_name: str
-    layer: str  # "policy", "static", "heuristic", "llm-classify", "fallback"
+    layer: str  # "policy", "profile", "static", "heuristic", "llm-classify", "fallback"
     rule_name: str  # Which rule matched
     confidence: float  # 0.0–1.0
     reason: str  # Human-readable explanation
@@ -76,6 +76,8 @@ class Router:
         *,
         model_requested: str = "",
         has_tools: bool = False,
+        client_profile: str = "generic",
+        profile_hints: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         provider_health: dict[str, Any] | None = None,
     ) -> RoutingDecision:
@@ -94,6 +96,8 @@ class Router:
             total_tokens=total_tokens,
             model_requested=model_requested.lower().strip(),
             has_tools=has_tools,
+            client_profile=client_profile,
+            profile_hints=profile_hints or {},
             headers=headers or {},
             provider_health=provider_health or {},
             providers=self.config.providers,
@@ -113,6 +117,12 @@ class Router:
 
         # Layer 2: Heuristic rules
         decision = self._layer_heuristic(ctx)
+        if decision:
+            decision.elapsed_ms = (time.time() - t0) * 1000
+            return self._validate_health(decision, ctx)
+
+        # Layer 3: Client profile hints
+        decision = self._layer_profile(ctx)
         if decision:
             decision.elapsed_ms = (time.time() - t0) * 1000
             return self._validate_health(decision, ctx)
@@ -173,6 +183,11 @@ class Router:
             return all(self._match_policy(sub, ctx) for sub in match["all"])
         if "any" in match:
             return any(self._match_policy(sub, ctx) for sub in match["any"])
+        if "client_profile" in match:
+            profiles = match["client_profile"]
+            if isinstance(profiles, str):
+                profiles = [profiles]
+            return ctx.client_profile in profiles
 
         static_keys = {"model_requested", "system_prompt_contains", "header_contains", "any"}
         heuristic_keys = {"has_tools", "estimated_tokens", "message_keywords", "fallthrough"}
@@ -247,6 +262,25 @@ class Router:
             _append(name)
 
         return preferred
+
+    # ── Layer 3: Client Profiles ──────────────────────────────
+
+    def _layer_profile(self, ctx: _RoutingContext) -> RoutingDecision | None:
+        """Apply default provider preferences for the resolved client profile."""
+        if not ctx.profile_hints:
+            return None
+
+        provider_name = self._select_policy_provider(ctx.profile_hints, ctx)
+        if not provider_name:
+            return None
+
+        return RoutingDecision(
+            provider_name=provider_name,
+            layer="profile",
+            rule_name=f"profile-{ctx.client_profile}",
+            confidence=0.6,
+            reason=f"Client profile '{ctx.client_profile}' selected a preferred provider",
+        )
 
     # ── Layer 1: Static Rules ──────────────────────────────────
 
@@ -427,6 +461,8 @@ class _RoutingContext:
         "total_tokens",
         "model_requested",
         "has_tools",
+        "client_profile",
+        "profile_hints",
         "headers",
         "provider_health",
         "providers",

--- a/tests/test_client_profiles.py
+++ b/tests/test_client_profiles.py
@@ -1,0 +1,189 @@
+"""Tests for client profile resolution and profile-based routing."""
+
+# ruff: noqa: E402
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Mock httpx before importing our modules
+_httpx = types.ModuleType("httpx")
+
+
+class _Timeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _Limits:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _AsyncClient:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def aclose(self):
+        pass
+
+
+_httpx.Timeout = _Timeout
+_httpx.Limits = _Limits
+_httpx.AsyncClient = _AsyncClient
+_httpx.TimeoutException = Exception
+_httpx.ConnectError = Exception
+sys.modules["httpx"] = _httpx
+
+from foundrygate.config import ConfigError, load_config
+from foundrygate.main import _resolve_client_profile
+from foundrygate.router import Router
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(body)
+    return path
+
+
+class TestClientProfileResolution:
+    def test_resolve_n8n_profile_from_headers(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  default-provider:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+    n8n:
+      prefer_tiers: ["cheap", "default"]
+  rules:
+    - profile: n8n
+      match:
+        header_contains:
+          x-foundrygate-client: ["n8n"]
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+            )
+        )
+
+        profile_name, hints = _resolve_client_profile(
+            cfg,
+            {"x-foundrygate-client": "n8n-workflow"},
+        )
+
+        assert profile_name == "n8n"
+        assert hints["prefer_tiers"] == ["cheap", "default"]
+
+    def test_rejects_unknown_profile_reference(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  default-provider:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+  rules:
+    - profile: missing
+      match:
+        header_present: ["x-foundrygate-client"]
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+
+        with pytest.raises(ConfigError, match="unknown profile"):
+            load_config(path)
+
+
+class TestClientProfileRouting:
+    @pytest.mark.asyncio
+    async def test_profile_prefers_cheaper_provider_when_no_semantic_rule_matches(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cheap-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cheap-model"
+    tier: cheap
+  default-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "default-model"
+    tier: default
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+    n8n:
+      prefer_tiers: ["cheap", "default"]
+  rules:
+    - profile: n8n
+      match:
+        header_contains:
+          x-foundrygate-client: ["n8n"]
+static_rules:
+  enabled: false
+  rules: []
+heuristic_rules:
+  enabled: false
+  rules: []
+fallback_chain:
+  - default-worker
+metrics:
+  enabled: false
+""",
+            )
+        )
+        router = Router(cfg)
+        profile_name, hints = _resolve_client_profile(
+            cfg,
+            {"x-foundrygate-client": "n8n"},
+        )
+
+        decision = await router.route(
+            [{"role": "user", "content": "hello there"}],
+            model_requested="auto",
+            client_profile=profile_name,
+            profile_hints=hints,
+            headers={"x-foundrygate-client": "n8n"},
+        )
+
+        assert decision.layer == "profile"
+        assert decision.rule_name == "profile-n8n"
+        assert decision.provider_name == "cheap-worker"


### PR DESCRIPTION
## What changed
- add optional client_profiles config with header-based profile resolution
- apply profile routing hints only after policy/static/heuristic layers, as caller-aware defaults
- support profile hints such as prefer_tiers, allow_providers, require_capabilities, and capability_values
- expose the resolved profile in X-FoundryGate-Profile response headers
- document example profiles for OpenClaw, n8n, and local-only callers

## Why
- this gives FoundryGate a reusable caller-aware layer for OpenClaw, n8n, CLI wrappers, and future clients
- it keeps semantic routing rules intact while still letting different clients have different default provider preferences
- it prepares later client-specific policy packs without coupling them to custom code per integration

## How verified
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- git diff --check
- artifact safety checks for .ssh/, *.db*, *.sqlite*, *.log