### PR TITLE
feat(api): add route introspection dry-run endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added an optional policy layer for capability-aware provider selection on `auto` requests
 - Added an explicit `local-worker` provider contract for network-local OpenAI-compatible runtimes
 - Added optional client profiles for caller-aware routing defaults based on request headers
+- Added a dry-run route introspection endpoint at `POST /api/route`
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -166,14 +166,27 @@ curl -fsS http://127.0.0.1:8090/v1/chat/completions \
 
 ### Additional Stable Operational Endpoints
 
+- `POST /api/route`
 - `GET /api/stats`
 - `GET /api/recent?limit=50`
 - `GET /dashboard`
 
 ```bash
+curl -fsS http://127.0.0.1:8090/api/route \
+  -H 'Content-Type: application/json' \
+  -H 'X-FoundryGate-Profile: local-only' \
+  -d '{
+    "model": "auto",
+    "messages": [
+      {"role": "user", "content": "Route this without sending it upstream."}
+    ]
+  }'
+
 curl -fsS http://127.0.0.1:8090/api/stats
 curl -fsS 'http://127.0.0.1:8090/api/recent?limit=10'
 ```
+
+`POST /api/route` is a dry-run endpoint. It uses the same routing logic as `POST /v1/chat/completions` but does not call an upstream provider. The response includes the resolved client profile, the routing decision, and the fallback attempt order.
 
 ## Model Aliases And Routing
 

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
@@ -69,6 +70,65 @@ def _resolve_client_profile(
 
     hints = profiles_cfg.get("profiles", {}).get(active_profile, {})
     return active_profile, hints
+
+
+def _build_attempt_order(primary_provider: str) -> list[str]:
+    """Return the provider attempt order for one routed request."""
+    attempt_order = []
+    for provider_name in [primary_provider, *_config.fallback_chain]:
+        if provider_name in _providers and provider_name not in attempt_order:
+            attempt_order.append(provider_name)
+    return attempt_order
+
+
+def _serialize_provider(name: str) -> dict[str, Any] | None:
+    """Return one provider snapshot for API responses."""
+    provider = _providers.get(name)
+    if not provider:
+        return None
+
+    return {
+        "name": name,
+        "model": provider.model,
+        "backend": provider.backend_type,
+        "contract": provider.contract,
+        "tier": provider.tier,
+        "healthy": provider.health.healthy,
+        "capabilities": provider.capabilities,
+    }
+
+
+async def _resolve_route_preview(
+    body: dict[str, Any], headers: dict[str, str]
+) -> tuple[RoutingDecision, str, list[str], str]:
+    """Resolve one request into a routing decision without calling a provider."""
+    messages = body.get("messages", [])
+    model_requested = body.get("model", "auto")
+    tools = body.get("tools")
+
+    client_profile, profile_hints = _resolve_client_profile(_config, headers)
+
+    if model_requested != "auto" and model_requested in _providers:
+        decision = RoutingDecision(
+            provider_name=model_requested,
+            layer="direct",
+            rule_name="explicit-model",
+            confidence=1.0,
+            reason=f"Directly requested provider: {model_requested}",
+        )
+    else:
+        health_map = {name: p.health.to_dict() for name, p in _providers.items()}
+        decision = await _router.route(
+            messages,
+            model_requested=model_requested,
+            has_tools=bool(tools),
+            client_profile=client_profile,
+            profile_hints=profile_hints,
+            headers=headers,
+            provider_health=health_map,
+        )
+
+    return decision, client_profile, _build_attempt_order(decision.provider_name), model_requested
 
 
 @asynccontextmanager
@@ -188,6 +248,29 @@ async def recent(limit: int = 50):
     return {"requests": _metrics.get_recent(limit)}
 
 
+@app.post("/api/route")
+async def preview_route(request: Request):
+    """Dry-run one routing decision without sending a provider request."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    headers = _collect_routing_headers(request)
+    decision, client_profile, attempt_order, model_requested = await _resolve_route_preview(
+        body, headers
+    )
+
+    return {
+        "requested_model": model_requested,
+        "resolved_profile": client_profile,
+        "routing_headers": headers,
+        "decision": decision.to_dict(),
+        "selected_provider": _serialize_provider(decision.provider_name),
+        "attempt_order": [_serialize_provider(name) for name in attempt_order],
+    }
+
+
 @app.get("/dashboard", response_class=HTMLResponse)
 async def dashboard():
     """Minimal self-contained dashboard – no build step, no deps."""
@@ -210,39 +293,16 @@ async def chat_completions(request: Request):
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
-    messages = body.get("messages", [])
-    model_requested = body.get("model", "auto")
     stream = body.get("stream", False)
     temperature = body.get("temperature")
     max_tokens = body.get("max_tokens")
     tools = body.get("tools")
 
     headers = _collect_routing_headers(request)
-    client_profile, profile_hints = _resolve_client_profile(_config, headers)
-
-    # ── Routing ────────────────────────────────────────────
-
-    if model_requested != "auto" and model_requested in _providers:
-        # Direct routing – skip the engine
-        decision = RoutingDecision(
-            provider_name=model_requested,
-            layer="direct",
-            rule_name="explicit-model",
-            confidence=1.0,
-            reason=f"Directly requested provider: {model_requested}",
-        )
-    else:
-        # Run the routing engine
-        health_map = {name: p.health.to_dict() for name, p in _providers.items()}
-        decision = await _router.route(
-            messages,
-            model_requested=model_requested,
-            has_tools=bool(tools),
-            client_profile=client_profile,
-            profile_hints=profile_hints,
-            headers=headers,
-            provider_health=health_map,
-        )
+    decision, client_profile, attempt_order, _model_requested = await _resolve_route_preview(
+        body, headers
+    )
+    messages = body.get("messages", [])
 
     logger.info(
         "Route: %s [%s/%s] %.1fms",
@@ -255,11 +315,6 @@ async def chat_completions(request: Request):
     # ── Execute with fallback ──────────────────────────────
 
     errors: list[str] = []
-    # Build attempt order: chosen provider first, then fallback chain
-    attempt_order = [decision.provider_name]
-    for fb in _config.fallback_chain:
-        if fb not in attempt_order and fb in _providers:
-            attempt_order.append(fb)
 
     for provider_name in attempt_order:
         provider = _providers.get(provider_name)

--- a/skills/foundrygate/SKILL.md
+++ b/skills/foundrygate/SKILL.md
@@ -50,24 +50,18 @@ if daily:
 ```
 
 ### /foundrygate route <message>
-Dry-run: show which provider a message would be routed to without actually sending it. Useful for testing routing rules.
+Dry-run: show which provider a message would be routed to without actually sending it upstream. Useful for testing routing rules, client profiles, and fallback order.
 
 ```bash
-curl -s http://127.0.0.1:8090/v1/chat/completions \
+curl -s http://127.0.0.1:8090/api/route \
   -H "Content-Type: application/json" \
   -d '{
     "model": "auto",
-    "messages": [{"role": "user", "content": "USER_MESSAGE_HERE"}],
-    "max_tokens": 1
-  }' 2>&1 | head -1
+    "messages": [{"role": "user", "content": "USER_MESSAGE_HERE"}]
+  }' | python3 -m json.tool
 ```
 
-Note: This sends a real request with max_tokens=1 to see the routing decision in the X-FoundryGate-Provider response header. For zero-cost testing, check the server logs instead:
-
-```bash
-# Watch routing decisions in real-time
-journalctl -u foundrygate -f --output=cat | grep "Route:"
-```
+Show the selected provider, routing layer, rule, resolved profile, and attempt order. If relevant headers matter for routing, include them in the dry-run request.
 
 ### /foundrygate recent
 Show the last 10 requests with provider, layer, rule, tokens, cost, and status.

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -1,0 +1,181 @@
+"""Tests for route introspection and dry-run previews."""
+
+# ruff: noqa: E402
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Mock httpx before importing our modules
+_httpx = types.ModuleType("httpx")
+
+
+class _Timeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _Limits:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _AsyncClient:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def aclose(self):
+        pass
+
+
+_httpx.Timeout = _Timeout
+_httpx.Limits = _Limits
+_httpx.AsyncClient = _AsyncClient
+_httpx.TimeoutException = Exception
+_httpx.ConnectError = Exception
+sys.modules["httpx"] = _httpx
+
+import foundrygate.main as main_module
+from foundrygate.config import load_config
+from foundrygate.main import _resolve_route_preview
+from foundrygate.router import Router
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(body)
+    return path
+
+
+class _ProviderStub:
+    def __init__(
+        self,
+        *,
+        name: str,
+        model: str,
+        backend_type: str = "openai-compat",
+        contract: str = "generic",
+        tier: str = "default",
+        healthy: bool = True,
+        capabilities: dict | None = None,
+    ):
+        self.name = name
+        self.model = model
+        self.backend_type = backend_type
+        self.contract = contract
+        self.tier = tier
+        self.capabilities = capabilities or {}
+        self.health = types.SimpleNamespace(
+            healthy=healthy,
+            to_dict=lambda: {
+                "name": name,
+                "healthy": healthy,
+                "consecutive_failures": 0,
+                "avg_latency_ms": 0.0,
+                "last_error": "",
+            },
+        )
+
+
+@pytest.fixture
+def preview_config(tmp_path, monkeypatch):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cloud-default:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cloud-chat"
+    tier: default
+  local-worker:
+    contract: local-worker
+    backend: openai-compat
+    base_url: "http://127.0.0.1:11434/v1"
+    api_key: "local"
+    model: "llama3"
+    tier: local
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+    local-only:
+      capability_values:
+        local: true
+      prefer_tiers: ["local"]
+  rules:
+    - profile: local-only
+      match:
+        header_contains:
+          x-foundrygate-profile: ["local-only"]
+fallback_chain:
+  - cloud-default
+metrics:
+  enabled: false
+""",
+        )
+    )
+    monkeypatch.setattr(main_module, "_config", cfg, raising=False)
+    monkeypatch.setattr(main_module, "_router", Router(cfg), raising=False)
+    monkeypatch.setattr(
+        main_module,
+        "_providers",
+        {
+            "cloud-default": _ProviderStub(
+                name="cloud-default",
+                model="cloud-chat",
+                tier="default",
+            ),
+            "local-worker": _ProviderStub(
+                name="local-worker",
+                model="llama3",
+                contract="local-worker",
+                tier="local",
+                capabilities={"local": True, "cloud": False, "network_zone": "local"},
+            ),
+        },
+        raising=False,
+    )
+    return cfg
+
+
+class TestRoutePreview:
+    @pytest.mark.asyncio
+    async def test_preview_resolves_profile_and_attempt_order(self, preview_config):
+        decision, profile_name, attempt_order, model_requested = await _resolve_route_preview(
+            {
+                "model": "auto",
+                "messages": [{"role": "user", "content": "hello from local-only traffic"}],
+            },
+            {"x-foundrygate-profile": "local-only"},
+        )
+
+        assert model_requested == "auto"
+        assert profile_name == "local-only"
+        assert decision.layer == "profile"
+        assert decision.provider_name == "local-worker"
+        assert attempt_order == ["local-worker", "cloud-default"]
+
+    @pytest.mark.asyncio
+    async def test_preview_direct_model_keeps_explicit_provider_first(self, preview_config):
+        decision, profile_name, attempt_order, model_requested = await _resolve_route_preview(
+            {
+                "model": "cloud-default",
+                "messages": [{"role": "user", "content": "use the explicit provider"}],
+            },
+            {},
+        )
+
+        assert model_requested == "cloud-default"
+        assert profile_name == "generic"
+        assert decision.layer == "direct"
+        assert decision.provider_name == "cloud-default"
+        assert attempt_order == ["cloud-default"]


### PR DESCRIPTION
## What changed
- added POST /api/route as a dry-run routing endpoint
- refactored route resolution so dry-run and chat completions share the same decision path
- documented the new endpoint in the README and updated the FoundryGate skill examples
- added tests for profile-aware and direct-model route previews

## Why
- make routing behavior inspectable without spending tokens
- support safer policy tuning for OpenClaw, n8n, and future CLI clients
- expose fallback order and selected provider metadata for operations

## How verified
- git diff --check
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .