### PR TITLE
feat(metrics): add routing traces and client breakdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added an explicit `local-worker` provider contract for network-local OpenAI-compatible runtimes
 - Added optional client profiles for caller-aware routing defaults based on request headers
 - Added a dry-run route introspection endpoint at `POST /api/route`
+- Added enriched route traces and client/profile breakdowns in metrics, stats, and CLI output
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ curl -fsS http://127.0.0.1:8090/v1/chat/completions \
 - `POST /api/route`
 - `GET /api/stats`
 - `GET /api/recent?limit=50`
+- `GET /api/traces?limit=50`
 - `GET /dashboard`
 
 ```bash
@@ -186,9 +187,12 @@ curl -fsS http://127.0.0.1:8090/api/route \
 
 curl -fsS http://127.0.0.1:8090/api/stats
 curl -fsS 'http://127.0.0.1:8090/api/recent?limit=10'
+curl -fsS 'http://127.0.0.1:8090/api/traces?limit=10'
 ```
 
 `POST /api/route` is a dry-run endpoint. It uses the same routing logic as `POST /v1/chat/completions` but does not call an upstream provider. The response includes the resolved client profile, the routing decision, and the fallback attempt order.
+
+`GET /api/traces` returns recent enriched routing records from the metrics store, including requested model, resolved client profile, client tag, decision reason, confidence, and attempt order.
 
 ## Model Aliases And Routing
 
@@ -504,6 +508,8 @@ Running `./scripts/foundrygate-install` also creates symlinks in `/usr/local/bin
 | `foundrygate-health` | Calls `GET /health` locally with `curl` |
 | `foundrygate-update` | Fetches from Git, hard-resets to `origin/main`, cleans untracked files, reinstalls the unit, restarts, and retries health checks |
 | `foundrygate-uninstall` | Stops and disables the service, removes the unit file, and removes helper symlinks |
+
+`foundrygate-stats --json` now also includes client/profile breakdowns alongside provider and routing summaries.
 
 ## Repo Safety And CI
 

--- a/foundrygate/cli.py
+++ b/foundrygate/cli.py
@@ -110,6 +110,7 @@ def cmd_overview(metrics: MetricsStore):
     totals = metrics.get_totals()
     providers = metrics.get_provider_summary()
     routing = metrics.get_routing_breakdown()
+    clients = metrics.get_client_breakdown()
 
     print()
     print(_c("  ╔══════════════════════════════════════╗", BLUE))
@@ -185,6 +186,23 @@ def cmd_overview(metrics: MetricsStore):
                 ]
             )
         _table(["Layer", "Rule", "Provider", "Reqs", "Cost"], rows, [14, 24, 22, 8, 12])
+        print()
+
+    if clients:
+        print(_c("  ── Clients ───────────────────────────", DIM))
+        rows = []
+        for c in clients[:12]:
+            rows.append(
+                [
+                    c.get("client_profile", ""),
+                    c.get("client_tag", "") or "—",
+                    c.get("provider", ""),
+                    c.get("layer", ""),
+                    str(c.get("requests", 0)),
+                    _usd(c.get("cost_usd", 0)),
+                ]
+            )
+        _table(["Profile", "Client", "Provider", "Layer", "Reqs", "Cost"], rows)
         print()
 
 
@@ -292,6 +310,7 @@ def main():
             "totals": metrics.get_totals(),
             "providers": metrics.get_provider_summary(),
             "routing": metrics.get_routing_breakdown(),
+            "clients": metrics.get_client_breakdown(),
             "daily": metrics.get_daily_totals(args.days),
             "recent": metrics.get_recent(args.recent or 20),
         }

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -72,6 +72,15 @@ def _resolve_client_profile(
     return active_profile, hints
 
 
+def _resolve_client_tag(headers: dict[str, str], client_profile: str) -> str:
+    """Return a stable client tag for metrics and trace grouping."""
+    if headers.get("x-foundrygate-client"):
+        return headers["x-foundrygate-client"].strip().lower()
+    if headers.get("x-openclaw-source"):
+        return "openclaw"
+    return client_profile
+
+
 def _build_attempt_order(primary_provider: str) -> list[str]:
     """Return the provider attempt order for one routed request."""
     attempt_order = []
@@ -100,13 +109,14 @@ def _serialize_provider(name: str) -> dict[str, Any] | None:
 
 async def _resolve_route_preview(
     body: dict[str, Any], headers: dict[str, str]
-) -> tuple[RoutingDecision, str, list[str], str]:
+) -> tuple[RoutingDecision, str, str, list[str], str]:
     """Resolve one request into a routing decision without calling a provider."""
     messages = body.get("messages", [])
     model_requested = body.get("model", "auto")
     tools = body.get("tools")
 
     client_profile, profile_hints = _resolve_client_profile(_config, headers)
+    client_tag = _resolve_client_tag(headers, client_profile)
 
     if model_requested != "auto" and model_requested in _providers:
         decision = RoutingDecision(
@@ -128,7 +138,13 @@ async def _resolve_route_preview(
             provider_health=health_map,
         )
 
-    return decision, client_profile, _build_attempt_order(decision.provider_name), model_requested
+    return (
+        decision,
+        client_profile,
+        client_tag,
+        _build_attempt_order(decision.provider_name),
+        model_requested,
+    )
 
 
 @asynccontextmanager
@@ -237,6 +253,7 @@ async def stats():
         "totals": _metrics.get_totals(),
         "providers": _metrics.get_provider_summary(),
         "routing": _metrics.get_routing_breakdown(),
+        "clients": _metrics.get_client_breakdown(),
         "hourly": _metrics.get_hourly_series(24),
         "daily": _metrics.get_daily_totals(30),
     }
@@ -248,6 +265,12 @@ async def recent(limit: int = 50):
     return {"requests": _metrics.get_recent(limit)}
 
 
+@app.get("/api/traces")
+async def traces(limit: int = 50):
+    """Recent enriched route traces for debugging and policy tuning."""
+    return {"traces": _metrics.get_recent(limit)}
+
+
 @app.post("/api/route")
 async def preview_route(request: Request):
     """Dry-run one routing decision without sending a provider request."""
@@ -257,13 +280,18 @@ async def preview_route(request: Request):
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
     headers = _collect_routing_headers(request)
-    decision, client_profile, attempt_order, model_requested = await _resolve_route_preview(
-        body, headers
-    )
+    (
+        decision,
+        client_profile,
+        client_tag,
+        attempt_order,
+        model_requested,
+    ) = await _resolve_route_preview(body, headers)
 
     return {
         "requested_model": model_requested,
         "resolved_profile": client_profile,
+        "client_tag": client_tag,
         "routing_headers": headers,
         "decision": decision.to_dict(),
         "selected_provider": _serialize_provider(decision.provider_name),
@@ -299,9 +327,13 @@ async def chat_completions(request: Request):
     tools = body.get("tools")
 
     headers = _collect_routing_headers(request)
-    decision, client_profile, attempt_order, _model_requested = await _resolve_route_preview(
-        body, headers
-    )
+    (
+        decision,
+        client_profile,
+        client_tag,
+        attempt_order,
+        model_requested,
+    ) = await _resolve_route_preview(body, headers)
     messages = body.get("messages", [])
 
     logger.info(
@@ -354,6 +386,12 @@ async def chat_completions(request: Request):
                     cache_miss=cm,
                     cost_usd=cost,
                     latency_ms=cg.get("latency_ms", 0),
+                    requested_model=model_requested,
+                    client_profile=client_profile,
+                    client_tag=client_tag,
+                    decision_reason=decision.reason,
+                    confidence=decision.confidence,
+                    attempt_order=attempt_order,
                 )
 
             if stream:
@@ -385,6 +423,12 @@ async def chat_completions(request: Request):
                     rule_name=decision.rule_name,
                     success=False,
                     error=e.detail[:500],
+                    requested_model=model_requested,
+                    client_profile=client_profile,
+                    client_tag=client_tag,
+                    decision_reason=decision.reason,
+                    confidence=decision.confidence,
+                    attempt_order=attempt_order,
                 )
             continue
 

--- a/foundrygate/metrics.py
+++ b/foundrygate/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 import time
@@ -43,12 +44,27 @@ CREATE TABLE IF NOT EXISTS requests (
     cost_usd    REAL    DEFAULT 0,
     latency_ms  REAL    DEFAULT 0,
     success     INTEGER DEFAULT 1,
-    error       TEXT    DEFAULT ''
+    error       TEXT    DEFAULT '',
+    requested_model TEXT DEFAULT 'auto',
+    client_profile  TEXT DEFAULT 'generic',
+    client_tag      TEXT DEFAULT '',
+    decision_reason TEXT DEFAULT '',
+    confidence      REAL DEFAULT 0,
+    attempt_order   TEXT DEFAULT '[]'
 );
 CREATE INDEX IF NOT EXISTS idx_req_ts       ON requests(timestamp);
 CREATE INDEX IF NOT EXISTS idx_req_provider ON requests(provider);
 CREATE INDEX IF NOT EXISTS idx_req_layer    ON requests(layer);
 """
+
+_OPTIONAL_COLUMNS: dict[str, str] = {
+    "requested_model": "TEXT DEFAULT 'auto'",
+    "client_profile": "TEXT DEFAULT 'generic'",
+    "client_tag": "TEXT DEFAULT ''",
+    "decision_reason": "TEXT DEFAULT ''",
+    "confidence": "REAL DEFAULT 0",
+    "attempt_order": "TEXT DEFAULT '[]'",
+}
 
 
 class MetricsStore:
@@ -67,8 +83,22 @@ class MetricsStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.executescript(_CREATE_SQL)
+        self._ensure_optional_columns()
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_req_profile ON requests(client_profile)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_req_client ON requests(client_tag)")
         self._conn.commit()
         logger.info("Metrics DB ready: %s", self._db_path)
+
+    def _ensure_optional_columns(self) -> None:
+        """Add newer columns to an existing metrics DB without destroying data."""
+        if not self._conn:
+            return
+
+        existing = {row[1] for row in self._conn.execute("PRAGMA table_info(requests)").fetchall()}
+        for column_name, column_sql in _OPTIONAL_COLUMNS.items():
+            if column_name in existing:
+                continue
+            self._conn.execute(f"ALTER TABLE requests ADD COLUMN {column_name} {column_sql}")
 
     def log_request(
         self,
@@ -84,6 +114,12 @@ class MetricsStore:
         latency_ms: float = 0.0,
         success: bool = True,
         error: str = "",
+        requested_model: str = "auto",
+        client_profile: str = "generic",
+        client_tag: str = "",
+        decision_reason: str = "",
+        confidence: float = 0.0,
+        attempt_order: list[str] | None = None,
     ) -> None:
         if not self._conn:
             return
@@ -92,8 +128,10 @@ class MetricsStore:
                 """INSERT INTO requests
                    (timestamp,provider,model,layer,rule_name,
                     prompt_tok,compl_tok,cache_hit,cache_miss,
-                    cost_usd,latency_ms,success,error)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    cost_usd,latency_ms,success,error,
+                    requested_model,client_profile,client_tag,
+                    decision_reason,confidence,attempt_order)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     time.time(),
                     provider,
@@ -108,6 +146,12 @@ class MetricsStore:
                     latency_ms,
                     1 if success else 0,
                     error,
+                    requested_model,
+                    client_profile,
+                    client_tag,
+                    decision_reason,
+                    confidence,
+                    json.dumps(attempt_order or []),
                 ),
             )
             self._conn.commit()
@@ -142,6 +186,20 @@ class MetricsStore:
             GROUP BY layer, rule_name, provider ORDER BY requests DESC
         """)
 
+    def get_client_breakdown(self) -> list[dict]:
+        return self._q("""
+            SELECT client_profile,
+                client_tag,
+                provider,
+                layer,
+                COUNT(*)                 AS requests,
+                ROUND(SUM(cost_usd),6)   AS cost_usd,
+                ROUND(AVG(latency_ms),1) AS avg_latency_ms
+            FROM requests
+            GROUP BY client_profile, client_tag, provider, layer
+            ORDER BY requests DESC, client_profile ASC, client_tag ASC
+        """)
+
     def get_hourly_series(self, hours: int = 24) -> list[dict]:
         cutoff = time.time() - hours * 3600
         return self._q(
@@ -172,7 +230,15 @@ class MetricsStore:
         )
 
     def get_recent(self, limit: int = 50) -> list[dict]:
-        return self._q("SELECT * FROM requests ORDER BY timestamp DESC LIMIT ?", (limit,))
+        rows = self._q("SELECT * FROM requests ORDER BY timestamp DESC LIMIT ?", (limit,))
+        for row in rows:
+            attempt_order = row.get("attempt_order")
+            if isinstance(attempt_order, str) and attempt_order:
+                try:
+                    row["attempt_order"] = json.loads(attempt_order)
+                except json.JSONDecodeError:
+                    row["attempt_order"] = []
+        return rows
 
     def get_totals(self) -> dict:
         rows = self._q("""

--- a/skills/foundrygate/SKILL.md
+++ b/skills/foundrygate/SKILL.md
@@ -78,6 +78,13 @@ for r in d.get('requests',[]):
 "
 ```
 
+### /foundrygate traces
+Show the last 10 enriched route traces including requested model, resolved profile, client tag, decision reason, confidence, and attempt order.
+
+```bash
+curl -s 'http://127.0.0.1:8090/api/traces?limit=10' | python3 -m json.tool
+```
+
 ## Dashboard
 
 A web dashboard is available at http://127.0.0.1:8090/dashboard — open it in a browser for a live view with auto-refresh.

--- a/tests/test_metrics_traces.py
+++ b/tests/test_metrics_traces.py
@@ -1,0 +1,85 @@
+"""Tests for enriched routing metrics and trace queries."""
+
+import sqlite3
+from pathlib import Path
+
+from foundrygate.metrics import MetricsStore
+
+
+def test_metrics_store_persists_trace_fields(tmp_path):
+    db_path = tmp_path / "foundrygate.db"
+    metrics = MetricsStore(str(db_path))
+    metrics.init()
+
+    metrics.log_request(
+        provider="local-worker",
+        model="llama3",
+        layer="profile",
+        rule_name="profile-local-only",
+        prompt_tokens=120,
+        completion_tokens=24,
+        cost_usd=0.0,
+        latency_ms=43.0,
+        requested_model="auto",
+        client_profile="local-only",
+        client_tag="n8n",
+        decision_reason="Client profile 'local-only' selected a preferred provider",
+        confidence=0.6,
+        attempt_order=["local-worker", "cloud-default"],
+    )
+
+    recent = metrics.get_recent(1)
+    assert recent[0]["requested_model"] == "auto"
+    assert recent[0]["client_profile"] == "local-only"
+    assert recent[0]["client_tag"] == "n8n"
+    assert recent[0]["decision_reason"].startswith("Client profile")
+    assert recent[0]["confidence"] == 0.6
+    assert recent[0]["attempt_order"] == ["local-worker", "cloud-default"]
+
+    client_rows = metrics.get_client_breakdown()
+    assert client_rows[0]["client_profile"] == "local-only"
+    assert client_rows[0]["client_tag"] == "n8n"
+    assert client_rows[0]["provider"] == "local-worker"
+    assert client_rows[0]["layer"] == "profile"
+    assert client_rows[0]["requests"] == 1
+
+    metrics.close()
+
+
+def test_metrics_store_migrates_existing_db(tmp_path):
+    db_path = Path(tmp_path) / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE requests (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp   REAL    NOT NULL,
+            provider    TEXT    NOT NULL,
+            model       TEXT    NOT NULL,
+            layer       TEXT    NOT NULL,
+            rule_name   TEXT    NOT NULL,
+            prompt_tok  INTEGER DEFAULT 0,
+            compl_tok   INTEGER DEFAULT 0,
+            cache_hit   INTEGER DEFAULT 0,
+            cache_miss  INTEGER DEFAULT 0,
+            cost_usd    REAL    DEFAULT 0,
+            latency_ms  REAL    DEFAULT 0,
+            success     INTEGER DEFAULT 1,
+            error       TEXT    DEFAULT ''
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    reopened = MetricsStore(str(db_path))
+    reopened.init()
+    columns = {
+        row["name"]
+        for row in reopened._q("PRAGMA table_info(requests)")  # noqa: SLF001
+    }
+
+    assert "client_profile" in columns
+    assert "client_tag" in columns
+    assert "attempt_order" in columns
+    reopened.close()

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -150,7 +150,13 @@ metrics:
 class TestRoutePreview:
     @pytest.mark.asyncio
     async def test_preview_resolves_profile_and_attempt_order(self, preview_config):
-        decision, profile_name, attempt_order, model_requested = await _resolve_route_preview(
+        (
+            decision,
+            profile_name,
+            client_tag,
+            attempt_order,
+            model_requested,
+        ) = await _resolve_route_preview(
             {
                 "model": "auto",
                 "messages": [{"role": "user", "content": "hello from local-only traffic"}],
@@ -160,13 +166,20 @@ class TestRoutePreview:
 
         assert model_requested == "auto"
         assert profile_name == "local-only"
+        assert client_tag == "local-only"
         assert decision.layer == "profile"
         assert decision.provider_name == "local-worker"
         assert attempt_order == ["local-worker", "cloud-default"]
 
     @pytest.mark.asyncio
     async def test_preview_direct_model_keeps_explicit_provider_first(self, preview_config):
-        decision, profile_name, attempt_order, model_requested = await _resolve_route_preview(
+        (
+            decision,
+            profile_name,
+            client_tag,
+            attempt_order,
+            model_requested,
+        ) = await _resolve_route_preview(
             {
                 "model": "cloud-default",
                 "messages": [{"role": "user", "content": "use the explicit provider"}],
@@ -176,6 +189,7 @@ class TestRoutePreview:
 
         assert model_requested == "cloud-default"
         assert profile_name == "generic"
+        assert client_tag == "generic"
         assert decision.layer == "direct"
         assert decision.provider_name == "cloud-default"
         assert attempt_order == ["cloud-default"]


### PR DESCRIPTION
## What changed
- added enriched route trace fields to persisted metrics, including requested model, client profile, client tag, decision reason, confidence, and attempt order
- added GET /api/traces for recent route traces and extended GET /api/stats with client/profile breakdowns
- updated foundrygate-stats to show client breakdowns in overview and JSON mode
- added tests for trace persistence, DB migration, and route preview tags

## Why
- make routing behavior easier to inspect over time, not only per-request
- expose useful client segmentation for OpenClaw, n8n, and future CLI clients
- support safer policy tuning and operational debugging on existing installations

## How verified
- git diff --check
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .