### PR TITLE
feat(config): add client profile presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added optional client profiles for caller-aware routing defaults based on request headers
 - Added a dry-run route introspection endpoint at `POST /api/route`
 - Added enriched route traces and client/profile breakdowns in metrics, stats, and CLI output
+- Added built-in `client_profiles` presets for `openclaw`, `n8n`, and `cli`
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
 - Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
 

--- a/README.md
+++ b/README.md
@@ -266,26 +266,28 @@ Profile rules can match on:
 
 Profile hints use the same selector keys as policy rules, for example `prefer_tiers`, `allow_providers`, `require_capabilities`, or `capability_values`.
 
+FoundryGate also ships built-in presets for common callers:
+
+- `openclaw`
+- `n8n`
+- `cli`
+
+Enable them via `client_profiles.presets`. Presets add a default profile and header-matching rule, and you can still override the generated profile or rule explicitly in your own config.
+
 Example:
 
 ```yaml
 client_profiles:
   enabled: true
   default: generic
+  presets: ["openclaw", "n8n", "cli"]
   profiles:
     generic: {}
-    openclaw:
-      prefer_tiers: ["default", "reasoning"]
-    n8n:
-      prefer_tiers: ["cheap", "default"]
   rules:
-    - profile: openclaw
-      match:
-        header_present: ["x-openclaw-source"]
-    - profile: n8n
+    - profile: cli
       match:
         header_contains:
-          x-foundrygate-client: ["n8n"]
+          x-foundrygate-client: ["codex"]
 ```
 
 ## Configuration

--- a/config.yaml
+++ b/config.yaml
@@ -656,6 +656,7 @@ routing_policies:
 client_profiles:
   enabled: false
   default: generic
+  presets: []   # Built-ins: ["openclaw", "n8n", "cli"]
   profiles:
     generic: {}
     openclaw:

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -56,6 +56,44 @@ _POLICY_SELECT_KEYS = {
     "capability_values",
 }
 _CLIENT_PROFILE_MATCH_KEYS = {"header_contains", "header_present", "any", "all"}
+_SUPPORTED_CLIENT_PROFILE_PRESETS = {"openclaw", "n8n", "cli"}
+
+_CLIENT_PROFILE_PRESET_SPECS: dict[str, dict[str, Any]] = {
+    "openclaw": {
+        "profile": {"prefer_tiers": ["default", "reasoning"]},
+        "rule": {
+            "profile": "openclaw",
+            "match": {
+                "any": [
+                    {"header_present": ["x-openclaw-source"]},
+                    {"header_contains": {"x-foundrygate-client": ["openclaw"]}},
+                ]
+            },
+        },
+    },
+    "n8n": {
+        "profile": {"prefer_tiers": ["cheap", "default"]},
+        "rule": {
+            "profile": "n8n",
+            "match": {
+                "header_contains": {
+                    "x-foundrygate-client": ["n8n"],
+                }
+            },
+        },
+    },
+    "cli": {
+        "profile": {"prefer_tiers": ["default", "reasoning"]},
+        "rule": {
+            "profile": "cli",
+            "match": {
+                "header_contains": {
+                    "x-foundrygate-client": ["cli", "codex", "claude", "kilocode", "deepseek"],
+                }
+            },
+        },
+    },
+}
 
 
 class ConfigError(ValueError):
@@ -500,7 +538,29 @@ def _normalize_client_profiles(data: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(profiles, dict):
         raise ConfigError("'client_profiles.profiles' must be a mapping")
 
+    presets = raw.get("presets", [])
+    if presets is None:
+        presets = []
+    presets = _normalize_string_list(
+        presets,
+        field_name="presets",
+        rule_name="client_profiles",
+        allow_empty=True,
+    )
+    unknown_presets = sorted(set(presets) - _SUPPORTED_CLIENT_PROFILE_PRESETS)
+    if unknown_presets:
+        unknown_list = ", ".join(unknown_presets)
+        raise ConfigError(f"'client_profiles.presets' has unknown preset names: {unknown_list}")
+
     normalized_profiles = {}
+    for preset_name in presets:
+        preset = _CLIENT_PROFILE_PRESET_SPECS[preset_name]
+        normalized_profiles[preset_name] = _normalize_policy_select(
+            f"client profile '{preset_name}'",
+            dict(preset["profile"]),
+            data.get("providers", {}),
+        )
+
     for profile_name, hints in profiles.items():
         if not isinstance(profile_name, str) or not profile_name.strip():
             raise ConfigError("Client profile names must be non-empty strings")
@@ -527,6 +587,17 @@ def _normalize_client_profiles(data: dict[str, Any]) -> dict[str, Any]:
         raise ConfigError("'client_profiles.rules' must be a list")
 
     normalized_rules = []
+    seen_rule_profiles = set()
+    for preset_name in presets:
+        preset_rule = _CLIENT_PROFILE_PRESET_SPECS[preset_name]["rule"]
+        normalized_rules.append(
+            {
+                "profile": preset_name,
+                "match": _normalize_client_profile_match(preset_name, dict(preset_rule["match"])),
+            }
+        )
+        seen_rule_profiles.add(preset_name)
+
     for idx, rule in enumerate(rules, start=1):
         if not isinstance(rule, dict):
             raise ConfigError(f"Client profile rule #{idx} must be a mapping")
@@ -538,17 +609,21 @@ def _normalize_client_profiles(data: dict[str, Any]) -> dict[str, Any]:
             raise ConfigError(
                 f"Client profile rule #{idx} references unknown profile '{profile_name}'"
             )
+        if profile_name in seen_rule_profiles:
+            normalized_rules = [r for r in normalized_rules if r["profile"] != profile_name]
         normalized_rules.append(
             {
                 "profile": profile_name,
                 "match": _normalize_client_profile_match(profile_name, rule.get("match", {})),
             }
         )
+        seen_rule_profiles.add(profile_name)
 
     normalized = dict(data)
     normalized["client_profiles"] = {
         "enabled": enabled,
         "default": default_profile,
+        "presets": presets,
         "profiles": normalized_profiles,
         "rules": normalized_rules,
     }

--- a/tests/test_client_profiles.py
+++ b/tests/test_client_profiles.py
@@ -121,6 +121,81 @@ metrics:
         with pytest.raises(ConfigError, match="unknown profile"):
             load_config(path)
 
+    def test_preset_profiles_are_added_and_resolved(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cheap-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cheap-model"
+    tier: cheap
+  default-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "default-model"
+    tier: default
+client_profiles:
+  enabled: true
+  default: generic
+  presets: ["openclaw", "n8n", "cli"]
+  profiles:
+    generic: {}
+fallback_chain:
+  - default-worker
+metrics:
+  enabled: false
+""",
+            )
+        )
+
+        assert cfg.client_profiles["presets"] == ["openclaw", "n8n", "cli"]
+        assert cfg.client_profiles["profiles"]["openclaw"]["prefer_tiers"] == [
+            "default",
+            "reasoning",
+        ]
+        assert cfg.client_profiles["profiles"]["n8n"]["prefer_tiers"] == ["cheap", "default"]
+        assert cfg.client_profiles["profiles"]["cli"]["prefer_tiers"] == ["default", "reasoning"]
+
+        profile_name, hints = _resolve_client_profile(cfg, {"x-openclaw-source": "subagent-42"})
+        assert profile_name == "openclaw"
+        assert hints["prefer_tiers"] == ["default", "reasoning"]
+
+    def test_rejects_unknown_profile_preset(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  default-provider:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+client_profiles:
+  enabled: true
+  default: generic
+  presets: ["missing"]
+  profiles:
+    generic: {}
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+
+        with pytest.raises(ConfigError, match="unknown preset"):
+            load_config(path)
+
 
 class TestClientProfileRouting:
     @pytest.mark.asyncio
@@ -187,3 +262,62 @@ metrics:
         assert decision.layer == "profile"
         assert decision.rule_name == "profile-n8n"
         assert decision.provider_name == "cheap-worker"
+
+    @pytest.mark.asyncio
+    async def test_cli_preset_prefers_default_tier(self, tmp_path):
+        cfg = load_config(
+            _write_config(
+                tmp_path,
+                """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cheap-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "cheap-model"
+    tier: cheap
+  default-worker:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "default-model"
+    tier: default
+client_profiles:
+  enabled: true
+  default: generic
+  presets: ["cli"]
+  profiles:
+    generic: {}
+static_rules:
+  enabled: false
+  rules: []
+heuristic_rules:
+  enabled: false
+  rules: []
+fallback_chain:
+  - cheap-worker
+metrics:
+  enabled: false
+""",
+            )
+        )
+        router = Router(cfg)
+        profile_name, hints = _resolve_client_profile(
+            cfg,
+            {"x-foundrygate-client": "codex-cli"},
+        )
+
+        decision = await router.route(
+            [{"role": "user", "content": "inspect the repository"}],
+            model_requested="auto",
+            client_profile=profile_name,
+            profile_hints=hints,
+            headers={"x-foundrygate-client": "codex-cli"},
+        )
+
+        assert profile_name == "cli"
+        assert decision.layer == "profile"
+        assert decision.provider_name == "default-worker"


### PR DESCRIPTION
## What changed
- added built-in client profile presets for openclaw, n8n, and cli
- presets now seed profile hints and default header-match rules inside client_profiles
- explicit local profiles or rules can still override the generated preset entries
- documented the presets in the stock config and README and added tests for preset resolution and routing

## Why
- give common callers a fast starting point without repeating the same profile boilerplate
- keep the new behavior inside the existing client_profiles layer instead of adding another routing DSL
- make OpenClaw, n8n, and CLI integration easier to standardize across deployments

## How verified
- git diff --check
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .