### PR TITLE
docs: refresh roadmap and public docs

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -7,5 +7,6 @@
 - [ ] Tag is pushed to GitHub
 - [ ] GitHub Release is created from the tag
 - [ ] Release notes summarize user-visible changes
+- [ ] README and relevant docs pages match the shipped behavior
 - [ ] Compatibility notes are included if older runtime identifiers are still mentioned
 - [ ] Any upgrade notes or rollback notes are included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,14 @@ Work in small coherent steps.
 Prefer commit-sized implementation blocks.
 Stop after each major block and summarize what changed, what remains, and what is intentionally deferred.
 
+After every 4 or 5 merged PRs, do a full review pass that includes:
+
+- unit test coverage review
+- integration test coverage review
+- functional test review against real workflows where possible
+- documentation review and update across every relevant Markdown file
+- roadmap and process review if the project direction changed
+
 Follow the branch workflow defined in:
 
 - `docs/process/git-workflow.md`
@@ -122,6 +130,7 @@ Maintain:
 
 - the README as the primary public landing page,
 - roadmap documentation,
+- architecture, integration, onboarding, and troubleshooting docs for external users,
 - release and changelog documentation,
 - process documentation for workflow-critical conventions,
 - migration notes when external names and runtime names differ.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ Important: Never score the system prompt for keywords. See ClawRouter's insight 
 4. Ensure `pytest` and `ruff check` pass
 5. Open a PR with a clear description
 
+After every 4 or 5 merged PRs, do a broader review pass:
+
+- review unit, integration, and functional test coverage
+- update every relevant doc, not only the README
+- refresh roadmap/process docs if the project direction or workflow changed
+
 See [docs/process/git-workflow.md](./docs/process/git-workflow.md) for the full branch model.
 
 ## Skill Updates

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## Quick Navigation
 
 - [Quickstart](#quickstart)
+- [Docs](#docs)
 - [How It Works](#how-it-works)
 - [API](#api)
 - [Model Aliases And Routing](#model-aliases-and-routing)
@@ -82,6 +83,14 @@ If you install the project as a package, the `foundrygate` and `foundrygate-stat
 
 If every configured provider API key is empty, FoundryGate still starts, but it skips those providers at startup and `v1/models` will only expose the virtual `auto` model.
 
+## Docs
+
+- [Architecture](./docs/ARCHITECTURE.md)
+- [Integrations](./docs/INTEGRATIONS.md)
+- [Onboarding](./docs/ONBOARDING.md)
+- [Troubleshooting](./docs/TROUBLESHOOTING.md)
+- [Roadmap](./docs/FOUNDRYGATE-ROADMAP.md)
+
 ## How It Works
 
 ```text
@@ -93,7 +102,8 @@ http://127.0.0.1:8090/v1
   +--> Layer 0: optional policy rules
   +--> Layer 1: static rules
   +--> Layer 2: heuristic rules
-  +--> Layer 3: optional LLM classifier
+  +--> Layer 3: optional client profile defaults
+  +--> Layer 4: optional LLM classifier
   |
   +--> chosen provider
          |- deepseek-chat
@@ -108,9 +118,12 @@ Routing decisions happen in order:
 1. Optional policy rules for client-specific, governance, or local/cloud constraints
 2. Static rules for known patterns such as heartbeat, explicit model hints, and sub-agent traffic
 3. Heuristic rules for user-message content, tools, and rough token size
-4. An optional LLM classifier if you enable it in `config.yaml`
+4. Optional client profile defaults for callers such as OpenClaw, n8n, or CLI wrappers
+5. An optional LLM classifier if you enable it in `config.yaml`
 
 Important implementation detail: heuristic keyword scoring only evaluates user messages, not the system prompt. This avoids over-routing to expensive tiers because of long system prompts.
+
+For OpenClaw specifically, both one-agent and many-agent traffic use the same OpenAI-compatible endpoint. The built-in rules and presets can distinguish sub-agent traffic through `x-openclaw-source` when that header is present.
 
 ## API
 
@@ -543,6 +556,8 @@ The detailed workflow is documented in [docs/process/git-workflow.md](./docs/pro
 
 ## Troubleshooting
 
+The full operator guide lives in [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md).
+
 ### `GET /health` fails
 
 Check whether the service is running and listening:
@@ -595,7 +610,8 @@ The next product direction is tracked in [docs/FOUNDRYGATE-ROADMAP.md](./docs/FO
 Short version:
 
 - `FoundryGate` is the product name
-- the next steps focus on capability-aware routing, local worker support, client profiles, and optional context/optimization hooks
+- the completed foundation already covers capability-aware routing, local worker support, client profiles, route introspection, route traces, and local worker probing
+- the next steps focus on optional request hooks, multi-dimensional routing, modality expansion, onboarding, and operations polish
 
 ## Releases
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 4. Push the tag to GitHub.
 5. Create a GitHub Release from that tag.
 6. Use the changelog entry as the release notes, then add any short upgrade notes if needed.
+7. Confirm that README plus the relevant docs pages still match the shipped runtime behavior.
 
 ## Example
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,112 @@
+# FoundryGate Architecture
+
+## Purpose
+
+FoundryGate is a local-first AI gateway plane.
+
+Its job is to sit between many clients and many model backends while keeping one stable operational surface:
+
+- one OpenAI-compatible endpoint
+- many providers
+- explicit routing and fallback behavior
+- observable health and usage data
+
+## Current runtime shape
+
+Today the gateway has four main parts:
+
+1. Gateway core
+2. Provider layer
+3. Client profile and policy layer
+4. Operational surface
+
+## Gateway core
+
+The core handles:
+
+- request normalization
+- route selection
+- fallback order
+- timeout and failure handling
+- response metadata
+- metrics and traces
+
+The current chat path is:
+
+1. policy rules
+2. static rules
+3. heuristic rules
+4. client profile defaults
+5. optional LLM classifier
+6. fallback chain if the chosen provider fails
+
+## Provider layer
+
+The provider layer already supports:
+
+- OpenAI-compatible backends
+- Google GenAI backends
+- `contract: local-worker` for LAN/local OpenAI-compatible workers
+
+Each provider can expose:
+
+- capability metadata
+- tier
+- contract
+- backend type
+- health state
+
+## Client layer
+
+The public entry point stays OpenAI-compatible, but callers can still be distinguished.
+
+Current caller-aware signals:
+
+- `x-openclaw-source`
+- `x-foundrygate-client`
+- `x-foundrygate-profile`
+
+This is enough to support:
+
+- OpenClaw one-agent traffic
+- OpenClaw many-agent/sub-agent traffic
+- n8n workflows
+- CLI wrappers
+
+## Operational surface
+
+The main operational endpoints are:
+
+- `GET /health`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `POST /api/route`
+- `GET /api/stats`
+- `GET /api/recent`
+- `GET /api/traces`
+- `GET /dashboard`
+
+## Design target
+
+The longer-term design target is to outperform simpler router designs by making routing multi-dimensional instead of mostly keyword- or model-name-driven.
+
+The dimensions FoundryGate should eventually combine include:
+
+- provider capabilities
+- latency and health
+- cost tier
+- local vs cloud locality
+- client type
+- tool usage
+- context window limits
+- cache behavior and cache pricing
+- modality requirements such as chat vs image generation
+- policy and compliance constraints
+
+That is the intended shape:
+
+- one gateway core
+- many providers
+- many clients
+- optional context and optimization layers
+- clear operational boundaries

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -2,421 +2,38 @@
 
 ## Status
 
-`FoundryGate` is now the product and runtime name for this project direction.
+FoundryGate is now the public product, runtime, and repository name.
 
-This document is intentionally pragmatic. It describes the target shape of the project, the boundaries that keep it maintainable, and the next concrete implementation steps.
-
-## Why FoundryGate
-
-The current codebase already solves a real problem well:
-
-- one local OpenAI-compatible endpoint
-- multiple upstream providers
-- routing and fallback behavior
-- health and lightweight operational visibility
-
-The next step is not to turn the project into a monolithic "AI platform". The next step is to turn it into a stronger gateway plane that can sit between many clients and many model backends across local and cloud environments.
-
-That means:
-
-- local and cloud providers should look uniform to the caller
-- routing should be policy-driven, not hard-coded per client
-- new clients should integrate through stable adapters, not one-off hacks
-- memory, context, and token optimization should plug into the gateway cleanly without becoming mandatory core dependencies
-
-## Goal State
-
-FoundryGate should become:
-
-- a local-first AI gateway for self-hosted and hybrid environments
-- an OpenAI-compatible entry point for tools that already speak common LLM APIs
-- a routing layer that can choose between local workers, direct provider APIs, and proxy providers
-- an operational control point for fallback, health, latency, usage, and policy enforcement
-- an extensible integration layer for higher-level clients such as OpenClaw, n8n, SaaS platforms, and CLI wrappers
-
-## Non-Goals
-
-FoundryGate should not become all of these at once:
-
-- a full agent framework
-- a workflow engine
-- a hard-coupled long-term memory system
-- a mandatory token optimizer in the request path
-- a UI-heavy platform before the routing plane is stable
-
-Those capabilities may exist around FoundryGate, but the gateway should remain composable and operationally simple.
-
-## Who It Should Serve
-
-### Primary users
-
-- OpenClaw users who want one stable local endpoint across multiple providers
-- operators running mixed local/cloud AI stacks
-- n8n and automation builders who want routing and fallback without wiring each provider manually
-- developers using CLI-based AI tools that can benefit from a local proxy layer
-
-### Secondary users
-
-- teams building AI-native products that need a reusable gateway in development and production
-- operators who want to insert local workers, context services, or optimization layers without changing every client
-
-## Architecture Direction
-
-FoundryGate should evolve into four clear layers.
-
-### 1. Gateway Core
-
-Responsibilities:
-
-- request normalization
-- provider selection
-- fallback handling
-- timeouts and retry boundaries
-- usage and latency recording
-- stable operational endpoints
-
-This remains the center of the system.
-
-### 2. Provider Layer
-
-Responsibilities:
-
-- direct cloud providers
-- OpenAI-compatible proxies
-- local runtimes and workers
-- future network-local model workers
-
-A local worker should be modeled as a normal provider with declared capabilities, not as a special case.
-
-### 3. Client Adapter Layer
-
-Responsibilities:
-
-- OpenAI-compatible HTTP entry point
-- OpenClaw-focused configuration and alias guidance
-- automation and workflow clients such as n8n
-- optional CLI proxy or command-wrapper entry points
-
-The core rule is simple: prefer standard protocols first. Add dedicated adapters only when a client cannot cleanly use the common API surface.
-
-### 4. Optional Extension Layer
-
-Responsibilities:
-
-- context and memory hooks
-- token optimization or prompt compaction
-- policy packs
-- tenant- or client-specific routing overlays
-
-These extensions should remain optional and explicitly enabled.
-
-## Capability Model
-
-The next major technical step is a capability-aware provider model.
-
-Each provider should advertise fields such as:
-
-- `chat`
-- `reasoning`
-- `vision`
-- `tools`
-- `long_context`
-- `streaming`
-- `local`
-- `cloud`
-- `cost_tier`
-- `latency_tier`
-- `network_zone`
-- `compliance_scope`
-
-Routing can then move away from brittle model-name assumptions and toward explicit policy decisions.
-
-Examples:
-
-- interactive low-latency requests prefer cheap or local providers
-- sensitive local-only traffic is pinned to a network-local worker
-- tool-using agent tasks prefer providers with better tool reliability
-- long-context workloads prefer providers or preprocessors optimized for context handling
-
-## Policy Model
-
-FoundryGate should support policy-based routing on top of capabilities.
-
-Policies should be declarative and easy to audit. A policy can consider:
-
-- client identity
-- request class
-- explicit model request
-- capabilities required
-- budget or cost tier
-- latency preference
-- local-only or cloud-allowed constraints
-
-This is the bridge between "generic gateway" and "AI-native control plane".
-
-## Local Worker Direction
-
-A future network-local worker should be integrated as a first-class provider.
-
-Requirements:
-
-- reachable over a stable HTTP API
-- capability metadata declared in config
-- health and timeout behavior equivalent to cloud providers
-- policy addressable as `local`, `reasoning`, `private`, or similar
-
-The gateway should not care whether the backend is a cloud API, a local model server, or a worker running somewhere else in the local network, as long as the provider contract is stable.
-
-## Context And Memory Direction
-
-Context and memory are important, but they should not be forced into the core request path too early.
-
-The cleaner design is:
-
-- FoundryGate remains the gateway and routing plane
-- context services enrich or retrieve relevant context
-- memory systems remain external but pluggable
-- the gateway can call out to them through hooks or preprocessors
-
-This leaves room for integrating ideas such as structured context stores, knowledge graphs, or ICM-style memory layers without hard-coding one memory architecture into the gateway itself.
-
-## CLI Proxy And Token Optimization
-
-A CLI proxy or command-wrapper router is a good fit, but as an adapter or optional preprocessor rather than a mandatory gateway feature.
-
-Good uses:
-
-- normalize requests from CLI tools that do not share one API shape
-- compress or optimize context before forwarding
-- apply policy and observability to terminal-native AI workflows
-
-Bad uses:
-
-- hiding unstable prompt rewrites deep inside the core router
-- making every request dependent on a fragile optimizer
-
-The correct shape is likely:
-
-- client adapter or sidecar process
-- optional optimization stage
-- explicit enablement per client profile
-
-## Admin And Monitoring Direction
-
-An admin surface is useful, but it should start as an operational console, not a full control UI.
-
-### Phase 1 dashboard goals
-
-- provider health
-- last errors
-- average latency
-- recent routed requests
-- fallback counts
-- basic usage and cost summaries
-- active routing rules and policy hits
-
-### Later dashboard goals
-
-- config validation
-- dry-run route simulation
-- client profile inspection
-- policy editing
-
-Write access should come after read-heavy observability is stable.
-
-## Rename Strategy
-
-The technical rename to `FoundryGate` is complete in the runtime, operational surface, and GitHub repository name.
-
-The remaining rename work is release-facing:
-
-1. publish the first FoundryGate-branded release
-2. communicate migration notes for existing downstream users if older runtime names are still present
-
-## Phased Plan
-
-### Phase 0: Stabilize The Current Core
-
-Objective:
-
-- keep the current OpenAI-compatible routing path reliable
-- preserve current integrations while preparing for broader use
-
-Deliverables:
-
-- cleanly document the rename plan
-- tighten provider contracts
-- make health, timeout, and fallback behavior explicit in tests
-- keep the DB path and runtime state outside the repo checkout
-
-### Phase 1: Capability-Aware Routing
-
-Objective:
-
-- make routing depend on declared provider capabilities and policies
-
-Deliverables:
+The foundation that used to be the near-term buildout is largely in place:
 
 - provider capability schema
-- policy schema
-- router changes that resolve providers by capability plus policy
-- config validation for invalid or contradictory provider definitions
-
-### Phase 2: Local Worker Integration
-
-Objective:
-
-- add network-local model workers as first-class providers
-
-Deliverables:
-
+- policy-based provider selection
 - local worker provider contract
-- example config for a local worker backend
-- health and timeout handling for local workers
-- policy examples for local-only, hybrid, and fallback routing
+- client profiles and presets
+- route introspection
+- routing traces and client/profile metrics
+- local worker probing
 
-### Phase 3: Client Profiles And Adapters
-
-Objective:
-
-- support different caller types without forking the gateway logic
-
-Deliverables:
-
-- client profile system
-- OpenClaw profile
-- n8n profile
-- generic automation profile
-- initial CLI proxy design or sidecar adapter
-
-### Phase 4: Operational Console
-
-Objective:
-
-- make the system observable enough to operate confidently
-
-Deliverables:
-
-- dashboard for health, routes, fallbacks, and usage
-- route debugging or dry-run tools
-- clearer operational endpoints
-
-### Phase 5: Optional Context And Optimization Hooks
-
-Objective:
-
-- allow context and optimization layers without coupling them to the gateway core
-
-Deliverables:
-
-- request preprocessor hook interface
-- context retrieval hook interface
-- optional token optimization integration
-- policy guardrails around these extensions
-
-## Concrete Next Backlog
-
-These are the next implementation-sized work items, ordered by leverage.
-
-### 1. Define a provider capability schema
-
-Why:
-
-- this unlocks generic routing and future local worker support
-
-Work:
-
-- extend provider config with capability metadata
-- validate config at startup
-- expose capabilities in internal provider state
-
-### 2. Add a policy engine layer
-
-Why:
-
-- routing rules should be declarative and auditable
-
-Work:
-
-- introduce policy objects
-- resolve route candidates from request + provider capabilities
-- preserve direct model pinning for explicit requests
-
-### 3. Add a first-class local worker provider example
-
-Why:
-
-- this is the key differentiator versus cloud-only routers
-
-Work:
-
-- define an OpenAI-compatible local worker provider contract
-- add example config
-- verify fallback and timeout behavior
-
-### 4. Add client profiles
-
-Why:
-
-- OpenClaw, n8n, and CLI tools have different routing needs even when they share an API
-
-Work:
-
-- identify callers through config or headers
-- apply profile-specific policy defaults
-- document profile examples
-
-### 5. Add route introspection
-
-Why:
-
-- operators need to know why a route was chosen
-
-Work:
-
-- enrich response headers where safe
-- add debug metadata in logs and operational endpoints
-- expose rule and policy hit counters
-
-### 6. Define an extension contract for context and optimization hooks
-
-Why:
-
-- this creates a clean seam for memory and RTK-like integrations later
-
-Work:
-
-- define pre-route and pre-dispatch hook points
-- keep hooks optional and bounded
-- document failure handling and timeouts for extensions
-
-## Suggested Near-Term PR Sequence
-
-To keep the work reviewable, the next PRs should stay small.
-
-1. `docs: add FoundryGate roadmap and rename note`
-2. `feat(config): add provider capability schema`
-3. `feat(router): add policy-based provider selection`
-4. `feat(provider): add local worker provider contract`
-5. `feat(api): add client profile support`
-6. `feat(obs): add route introspection and policy metrics`
-7. `feat(ext): add optional request hook interfaces`
+This roadmap now shifts from "rename and foundation" to "deepen the gateway plane without bloating it".
 
 ## Big Picture
 
-The larger opportunity is not "another router". The larger opportunity is a reusable AI gateway plane that works across:
+The opportunity is not to build another thin router.
+
+The opportunity is to build a reusable AI gateway plane that works across:
 
 - local model workers
 - direct provider APIs
 - proxy providers
-- agent tools
-- workflow systems
+- OpenClaw
+- workflow systems such as n8n
 - CLI-native development environments
+- agent tools
 - future AI-native SaaS products
 
 If the core stays disciplined, FoundryGate can become the common routing and policy layer shared by several products without collapsing into a bloated platform.
 
-That is the right long-term shape:
+That is the target shape:
 
 - one gateway core
 - many providers
@@ -424,9 +41,211 @@ That is the right long-term shape:
 - optional context and optimization layers
 - clear operational boundaries
 
+## Design principles
+
+### 1. Gateway first
+
+FoundryGate should stay a gateway and control plane, not a monolithic platform.
+
+### 2. Standard protocols first
+
+If a client can use the OpenAI-compatible API cleanly, keep it on that path before building a custom adapter.
+
+### 3. Multi-dimensional routing
+
+The design target is to exceed simpler router behavior by making routing explicitly multi-dimensional.
+
+That means FoundryGate should increasingly consider:
+
+- capability support
+- health and latency
+- cost tier
+- local vs cloud locality
+- context window size
+- cache behavior and cache pricing
+- tool usage
+- client identity
+- modality requirements
+- compliance or tenancy constraints
+
+The intent is not to claim that this is fully implemented today. The intent is to make this the guiding routing architecture.
+
+### 4. Optional extension layers
+
+Context, memory, optimization, and sidecar adapters should plug into the gateway cleanly, not become mandatory core behavior.
+
+## Current runtime baseline
+
+Today the runtime already supports:
+
+- one OpenAI-compatible endpoint
+- multiple providers behind a single local base URL
+- policy, static, heuristic, client-profile, and optional LLM-assisted routing stages
+- direct model pinning and fallback chains
+- local worker contracts and health probes
+- route introspection and traces
+- client-aware routing defaults for OpenClaw, n8n, and CLI callers
+
+## OpenClaw direction
+
+OpenClaw remains a first-class integration surface.
+
+Current coverage:
+
+- one-agent traffic through the normal OpenAI-compatible path
+- many-agent or delegated traffic through the same path with `x-openclaw-source`
+- OpenClaw-side model aliases and profile defaults
+
+Near-term direction:
+
+- document one-agent and many-agent behavior explicitly
+- keep the integration header-based and OpenAI-compatible
+- avoid forking the core gateway logic just for OpenClaw
+
+## Modality expansion
+
+Inspired by the value of image-router patterns in other gateways, FoundryGate should eventually support modality-aware routing beyond chat.
+
+Planned direction:
+
+- add a provider contract for image-generation-capable backends
+- add modality-aware request classification
+- route image tasks to the right backend without polluting the chat path
+
+This is a roadmap item, not a current runtime claim.
+
+## Architecture direction
+
+### Gateway core
+
+Responsibilities:
+
+- request normalization
+- route selection
+- fallback handling
+- timeout boundaries
+- usage and trace recording
+- operational endpoints
+
+### Provider layer
+
+Responsibilities:
+
+- cloud providers
+- OpenAI-compatible proxies
+- local workers
+- future modality-specific providers
+
+### Client layer
+
+Responsibilities:
+
+- OpenClaw
+- n8n and workflow clients
+- CLI wrappers and proxy clients
+- future AI-native app integrations
+
+### Optional extension layer
+
+Responsibilities:
+
+- request hooks
+- context or memory enrichment
+- optimization hooks
+- policy overlays
+
+## Updated near-term PR sequence
+
+The original near-term sequence has mostly landed. The next sequence should now be:
+
+1. `docs: refresh roadmap, architecture, onboarding, integrations, and troubleshooting`
+2. `feat(ext): add optional request hook interfaces`
+3. `feat(router): add multi-dimensional routing inputs for cache, context windows, and provider limits`
+4. `feat(provider): add modality-aware provider contracts, starting with image generation`
+5. `feat(onboarding): add provider/client onboarding helpers and validation workflows`
+6. `feat(ops): add update alerts and an optional auto-update enabler for controlled deployments`
+
+## Check on the earlier sequence
+
+The earlier near-term sequence is now effectively complete up through the routing and observability foundation:
+
+1. `docs: add FoundryGate roadmap and rename note` -> done
+2. `feat(config): add provider capability schema` -> done
+3. `feat(router): add policy-based provider selection` -> done
+4. `feat(provider): add local worker provider contract` -> done
+5. `feat(api): add client profile support` -> done
+6. `feat(obs): add route introspection and policy metrics` -> done, and now extended with traces and local worker probing
+7. `feat(ext): add optional request hook interfaces` -> still open and should stay near the top of the next sequence
+
+## Detailed near-term backlog
+
+### 1. Optional request hook interfaces
+
+Why:
+
+- this creates the seam for context, memory, and optimization layers without hard-coupling them
+
+### 2. Multi-dimensional routing inputs
+
+Why:
+
+- routing should understand more than keywords and simple tier preferences
+
+Examples:
+
+- cache-read vs cache-miss economics
+- context window fit
+- locality and policy constraints
+- latency/health tradeoffs
+
+### 3. Image generation routing
+
+Why:
+
+- multi-modal routing is a natural next expansion for a gateway plane
+
+### 4. Provider and client onboarding helpers
+
+Why:
+
+- many-provider, many-client deployments need a clearer adoption path than manual config editing alone
+
+### 5. Update alerts and optional automatic update enablers
+
+Why:
+
+- operators need a safer path than only ad hoc manual updates
+
+This should remain opt-in and operationally conservative.
+
+## Documentation direction
+
+FoundryGate should be understandable from the outside in under a few minutes.
+
+That means keeping these docs current:
+
+- README for the landing page
+- architecture for technical orientation
+- integrations for OpenClaw, n8n, CLI, and future clients
+- onboarding for many-provider and many-client adoption
+- troubleshooting for operators
+- process docs for contributors
+
+## Review cadence
+
+Every 4 or 5 merged PRs, run a broader review pass:
+
+- review unit tests
+- review integration tests
+- review functional coverage against real workflows
+- update every relevant doc
+- refresh the roadmap and process docs if the direction changed
+
+This is necessary because FoundryGate is evolving quickly and the docs can drift even when individual PRs are clean.
+
 ## Assumptions
 
-- OpenAI-compatible HTTP remains the primary interoperability surface for the near term
-- local worker support will be easiest to operationalize if the worker speaks an OpenAI-compatible or similarly simple HTTP contract
-- memory, context, and optimization will remain optional extensions rather than mandatory core behavior
-- the GitHub repository rename, if done, will be handled as a separate external step
+- OpenAI-compatible HTTP remains the default interoperability surface in the near term
+- OpenClaw, n8n, and CLI tools should keep sharing one gateway unless a client truly requires a dedicated adapter
+- modality expansion should stay contract-driven instead of adding ad hoc special cases
+- context, memory, and optimization remain optional layers around the gateway core

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,85 @@
+# FoundryGate Integrations
+
+## Current integration model
+
+FoundryGate works best when clients use the same OpenAI-compatible base URL and let the gateway handle routing and failover.
+
+That keeps integrations shallow and makes routing policy reusable across tools.
+
+## OpenClaw
+
+OpenClaw is a first-class target for FoundryGate.
+
+Current coverage:
+
+- one-agent traffic through the normal OpenAI-compatible endpoint
+- many-agent or delegated traffic when `x-openclaw-source` is present
+- direct model aliases via the OpenClaw-side config
+- caller-aware defaults through the `openclaw` client preset or explicit profile rules
+
+Use:
+
+- [openclaw-integration.jsonc](../openclaw-integration.jsonc)
+- `client_profiles.presets: ["openclaw"]` for a standard starting point
+
+## n8n
+
+n8n can use FoundryGate as a stable local model gateway.
+
+Recommended pattern:
+
+- send requests to the OpenAI-compatible endpoint
+- set `X-FoundryGate-Client: n8n`
+- enable the `n8n` client preset or an explicit `n8n` profile
+
+This gives you:
+
+- cheaper default routing for workflow traffic
+- shared fallback behavior
+- route debugging through `POST /api/route`
+
+## CLI clients
+
+CLI tools should also use the same local gateway where possible.
+
+Examples:
+
+- Codex CLI
+- Claude Code wrappers
+- KiloCode CLI
+- future DeepSeek-oriented wrappers
+
+Recommended pattern:
+
+- point the client to FoundryGate
+- set `X-FoundryGate-Client: codex`, `claude`, `kilocode`, or another stable client tag
+- use the built-in `cli` preset or a tighter custom profile
+
+## Provider onboarding
+
+When onboarding a new provider:
+
+1. define the provider stanza in `config.yaml`
+2. declare the right contract and capabilities
+3. verify health and `/v1/models`
+4. test routing with `POST /api/route`
+5. then route real traffic
+
+## Client onboarding
+
+When onboarding a new client:
+
+1. keep the client on the OpenAI-compatible API if possible
+2. assign a stable client tag or header
+3. start with a built-in preset or a minimal custom profile
+4. use `/api/route` and `/api/traces` to validate behavior
+5. only add a dedicated adapter if the client cannot cleanly use the common API surface
+
+## Planned integration directions
+
+These are roadmap items, not current runtime features:
+
+- image generation routing
+- optional request hooks for context or optimization
+- richer CLI-sidecar adapters
+- provider and client onboarding helpers

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,92 @@
+# FoundryGate Onboarding
+
+## Goal
+
+FoundryGate should be understandable and usable for a deployment with many providers and many clients.
+
+The safest onboarding order is:
+
+1. one provider
+2. one client
+3. observability
+4. second provider
+5. client-specific defaults
+6. policy constraints
+
+## Provider onboarding sequence
+
+### 1. Add one provider
+
+- define the provider in `config.yaml`
+- set the required API key or local auth value in `.env`
+- keep the fallback chain simple
+
+### 2. Verify provider health
+
+- check `GET /health`
+- check `GET /v1/models`
+- for `contract: local-worker`, confirm that `GET /models` works on the worker
+
+### 3. Validate routing
+
+- use `POST /api/route`
+- confirm the selected provider and attempt order
+
+### 4. Only then add another provider
+
+Repeat the same path before introducing more routing complexity.
+
+## Client onboarding sequence
+
+### 1. Keep the client on the common API
+
+Prefer the standard OpenAI-compatible entry point.
+
+### 2. Add a stable client tag
+
+Examples:
+
+- `x-openclaw-source`
+- `X-FoundryGate-Client: n8n`
+- `X-FoundryGate-Client: codex`
+
+### 3. Apply a preset or custom profile
+
+Start with:
+
+- `openclaw`
+- `n8n`
+- `cli`
+
+Then tighten it only if the default is not good enough.
+
+### 4. Validate with route introspection
+
+Use:
+
+- `POST /api/route`
+- `GET /api/traces`
+
+## Many providers, many clients
+
+When the stack grows, avoid changing everything at once.
+
+Recommended rollout:
+
+1. stabilize the provider set
+2. group clients into a small number of profiles
+3. introduce policies only for real constraints
+4. keep route debugging enabled through traces and stats
+
+## Update operations
+
+Current state:
+
+- manual updates via Git or `foundrygate-update`
+
+Planned state:
+
+- update alerts
+- optional auto-update enablers for controlled environments
+
+These are roadmap items. They are not implemented as automatic runtime behavior today.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,94 @@
+# FoundryGate Troubleshooting
+
+## Health endpoint fails
+
+Check:
+
+```bash
+curl -fsS http://127.0.0.1:8090/health
+sudo ss -ltnp | grep -E '127\.0\.0\.1:8090\b' || true
+```
+
+## No providers are loaded
+
+Typical cause:
+
+- missing or empty API keys
+
+Check:
+
+- `.env`
+- startup logs
+- `GET /v1/models`
+
+## Route choice looks wrong
+
+Use the dry-run and trace surfaces first.
+
+```bash
+curl -fsS http://127.0.0.1:8090/api/route \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"auto","messages":[{"role":"user","content":"debug this route"}]}'
+
+curl -fsS 'http://127.0.0.1:8090/api/traces?limit=10'
+```
+
+Check:
+
+- selected provider
+- layer
+- rule
+- resolved profile
+- attempt order
+
+## Local worker stays unhealthy
+
+For `contract: local-worker`, FoundryGate probes `GET /models`.
+
+Common causes:
+
+- the worker is not listening
+- the worker is not actually OpenAI-compatible
+- the configured `base_url` is wrong
+- the worker is reachable but returns HTTP errors
+
+Validate directly:
+
+```bash
+curl -fsS http://127.0.0.1:11434/v1/models
+```
+
+Then re-check:
+
+```bash
+curl -fsS http://127.0.0.1:8090/health
+```
+
+## Many-agent OpenClaw traffic is not separated
+
+Check whether `x-openclaw-source` is present.
+
+That header is the current signal used for OpenClaw sub-agent differentiation in the stock config and built-in presets.
+
+## Database path is wrong or unwritable
+
+Use an absolute path outside the repo checkout:
+
+```bash
+mkdir -p "$HOME/.local/state/foundrygate"
+printf 'FOUNDRYGATE_DB_PATH=%s\n' "$HOME/.local/state/foundrygate/foundrygate.db"
+```
+
+## Update went wrong
+
+Current update path is manual or helper-script driven.
+
+Use:
+
+```bash
+foundrygate-status
+foundrygate-logs
+foundrygate-health
+```
+
+If you use `foundrygate-update`, remember that it is meant for deployment checkouts and removes local untracked changes.

--- a/docs/process/git-workflow.md
+++ b/docs/process/git-workflow.md
@@ -44,6 +44,20 @@ Use predictable names:
 5. Open a PR from the feature branch into `main`.
 6. Merge only when CI is green and review concerns are addressed.
 
+## Review cadence
+
+Every 4 or 5 merged PRs, run a broader maintenance pass in addition to normal feature reviews.
+
+That pass should include:
+
+- unit test review
+- integration test review
+- functional test review against current user workflows
+- documentation review across README, roadmap, process docs, troubleshooting docs, and integration guides
+- cleanup of stale assumptions, outdated examples, or renamed surfaces
+
+This keeps the project understandable from the outside and prevents documentation drift after several fast feature PRs.
+
 ## Optional review branch flow
 
 Use a `review/...` branch only when a second focused pass is useful.

--- a/skills/foundrygate/SKILL.md
+++ b/skills/foundrygate/SKILL.md
@@ -91,11 +91,13 @@ A web dashboard is available at http://127.0.0.1:8090/dashboard — open it in a
 
 ## How Routing Works
 
-FoundryGate uses 3 layers (evaluated in order, first match wins):
+FoundryGate uses 5 routing stages (evaluated in order, first decisive match wins):
 
-1. **Static rules**: Pattern matching on model name, system prompt keywords, headers (heartbeats, explicit model requests, subagent detection)
-2. **Heuristic scoring**: Keyword-weighted classification of user messages (NOT system prompt) into reasoning/code/simple/agent categories
-3. **LLM classifier** (optional): Cheapest model classifies the task when heuristics are uncertain
+1. **Policy rules**: Governance, local/cloud constraints, and capability-aware provider selection
+2. **Static rules**: Pattern matching on model name and headers (heartbeats, explicit model requests, subagent detection)
+3. **Heuristic scoring**: Keyword-weighted classification of user messages (NOT system prompt) into reasoning/code/simple/agent categories
+4. **Client profiles**: caller-specific defaults for OpenClaw, n8n, CLI wrappers, or local-only traffic
+5. **LLM classifier** (optional): Cheapest model classifies the task when heuristics are uncertain
 
 Key insight: Only user messages are scored, never the system prompt. OpenClaw's system prompt is large and keyword-rich — scoring it would route everything to the expensive reasoning tier.
 


### PR DESCRIPTION
## What changed
- refreshed the FoundryGate roadmap around the current baseline and the next big-picture sequence
- added architecture, integrations, onboarding, and troubleshooting docs for external readers
- updated README, AGENTS, CONTRIBUTING, process docs, releases docs, and the skill file to match the current runtime and review cadence
- documented the 4-5 PR full-review rule for tests and documentation maintenance

## Why
- the older near-term sequence was largely completed and the roadmap needed a new next sequence
- the repo needed a clearer docs set for people discovering FoundryGate from the outside
- process docs needed an explicit cadence for broader review and documentation refresh

## How verified
- git diff --check
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .