### PR TITLE
docs: prepare v0.3.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to FoundryGate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
-## Unreleased (target: v0.3.0)
+## Unreleased
+
+No unreleased entries yet.
+
+## v0.3.0 - 2026-03-12
 
 ### Changed
 
@@ -19,12 +23,11 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added startup and `/health` probing for `contract: local-worker` providers via `GET /models`
 - Added built-in `client_profiles` presets for `openclaw`, `n8n`, and `cli`
 - Added a repository `AGENTS.md` and a documented Git workflow for `main`, `feature/*`, `review/*`, and `hotfix/*`
-- Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the next target release
+- Aligned release guidance around semantic-style `x.y.z` versioning with `v0.3.0` as the first FoundryGate-branded release
 
 ### Docs
 
 - Reworked the README into a more generic, portable open-source landing page
 - Added clearer API, configuration, deployment, and helper script documentation
-- Added release process documentation and a lightweight release checklist template
-
-No tagged release has been published from this repo yet. `v0.3.0` is the current target for the first FoundryGate-branded release.
+- Added release process documentation, roadmap updates, and a lightweight release checklist template
+- Added architecture, integrations, onboarding, and troubleshooting docs for external users

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -35,8 +35,8 @@ Then open GitHub Releases and publish a release for `v0.3.0`.
 
 ## Current Release Baseline
 
-- `v0.3.0` is the current target for the first FoundryGate-branded release.
-- This release line is the baseline for the full FoundryGate technical naming adoption.
+- `v0.3.0` is the first FoundryGate-branded release.
+- This release establishes the FoundryGate runtime naming, routing foundation, and public docs baseline.
 
 ## What Belongs In Release Notes
 


### PR DESCRIPTION
## What changed
- converted the unreleased changelog block into a real v0.3.0 entry dated 2026-03-12
- reset the Unreleased section for post-release work
- updated the release guide baseline from target wording to the actual first FoundryGate release

## Why
- v0.3.0 needs a stable changelog section before tagging and publishing the GitHub release
- the release docs should reflect that this is now the first FoundryGate-branded release

## How verified
- git diff --check
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .