### PR TITLE
docs(release): prepare v0.5.0

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 - [ ] `main` is green
 - [ ] [CHANGELOG.md](../CHANGELOG.md) is updated
-- [ ] Version number and release tag are aligned (for example `v0.3.0`)
+- [ ] Version number and release tag are aligned (for example `v0.5.0`)
 - [ ] Version tag is created from `main`
 - [ ] Tag is pushed to GitHub
 - [ ] GitHub Release is created from the tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+## v0.5.0 - 2026-03-12
+
 ### Added
 
 - Added `contract: image-provider` plus OpenAI-compatible `POST /v1/images/generations` and `POST /v1/images/edits` paths for image-capable providers

--- a/README.md
+++ b/README.md
@@ -873,14 +873,14 @@ Short version:
 - `FoundryGate` is the product name
 - the completed foundation already covers capability-aware routing, local worker support, client profiles, request hooks, route introspection, route traces, local worker probing, and first multi-dimensional route-fit checks
 - `v0.4.x` now focuses on deeper route scoring and dashboard refinement rather than the initial hook/dashboard baseline
-- `v0.5.0` is the target line for Docker and PyPI publishing plus onboarding helpers
+- `v0.5.0` is the operator distribution baseline for Docker and PyPI publishing, onboarding helpers, and release update checks
 - the path to `v1.0.0` includes modality expansion, update operations, a separate npm or TypeScript CLI package, and a full security review
 
 ## Releases
 
 - [CHANGELOG.md](./CHANGELOG.md) tracks notable user-facing changes
 - [RELEASES.md](./RELEASES.md) describes the lightweight release process for tags and GitHub Releases
-- planned publishing path: GitHub Releases now, Docker and PyPI by `v0.5.0`, separate npm or TypeScript CLI package by `v1.0.0`
+- publishing path: GitHub Releases now, Docker and PyPI in `v0.5.0`, separate npm or TypeScript CLI package by `v1.0.0`
 - GitHub Releases: [https://github.com/typelicious/FoundryGate/releases](https://github.com/typelicious/FoundryGate/releases)
 
 ## Contributing

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,11 +21,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v0.4.0 -m "FoundryGate v0.4.0"
-git push origin v0.4.0
+git tag -a v0.5.0 -m "FoundryGate v0.5.0"
+git push origin v0.5.0
 ```
 
-Then open GitHub Releases and publish a release for `v0.4.0`.
+Then open GitHub Releases and publish a release for `v0.5.0`.
 
 ## Automation Baseline
 
@@ -53,6 +53,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 
 - `v0.3.0` is the first FoundryGate-branded release.
 - `v0.4.0` establishes the hardened routing baseline: request hooks, multi-dimensional scoring, route introspection, and the refined operator dashboard.
+- `v0.5.0` establishes the operator distribution baseline: image-provider contracts, Docker and GHCR packaging, PyPI workflow support, onboarding helpers, repo community standards, and cached release update checks.
 
 ## Planned Publishing Path
 

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -19,7 +19,7 @@ The foundation that used to be the near-term buildout is largely in place:
 
 This roadmap now shifts from "rename and foundation" to "deepen the gateway plane without bloating it".
 
-`v0.4.0` is the current routing-baseline release line: hooks, richer scoring, route introspection, and the refined dashboard are now in place.
+`v0.5.0` is the current operator-distribution release line: modality-aware image paths, publish workflows, onboarding helpers, community baselines, and release update checks are now in place on top of the `v0.4.x` routing foundation.
 
 ## Big Picture
 

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -487,7 +487,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="0.4.0",
+    version="0.5.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What changed
- bump the runtime and package version from `0.4.0` to `0.5.0`
- cut the `v0.5.0` changelog section from `Unreleased`
- align README, roadmap, release docs, and the release checklist with the `v0.5.0` release line

## Why
- prepares a clean, reviewable release candidate before tagging `v0.5.0`
- keeps the actual release cut separate from the feature work that landed in the `v0.5.0` scope

## How verified
- `PYTHONPYCACHEPREFIX="$PWD/.pycache" python3 -m compileall foundrygate tests`
- `PYTHONPATH=. ./.venv-check-313/bin/pytest -q`
- `./.venv-check-313/bin/ruff check .`
- `./.venv-check-313/bin/ruff format --check .`
- `bash -n scripts/*`
- `./.venv-check-313/bin/python -m build --no-isolation`
- `./.venv-check-313/bin/python -m twine check dist/foundrygate-0.5.0*`
- `/usr/bin/git diff --check`
