### PR TITLE
docs: record no-build dashboard direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ If every configured provider API key is empty, FoundryGate still starts, but it 
 - [Troubleshooting](./docs/TROUBLESHOOTING.md)
 - [Roadmap](./docs/FOUNDRYGATE-ROADMAP.md)
 
+## Dashboard Direction
+
+The built-in dashboard stays intentionally no-build for now.
+
+- no frontend framework
+- no component library
+- no separate asset pipeline
+- one self-contained operational UI served by the FastAPI app
+
+That keeps deployment simple for local hosts, Docker, and systemd installs while the dashboard remains an operator-facing read-heavy surface.
+
 ## How It Works
 
 ```text

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,15 @@ The main operational endpoints are:
 
 `/api/stats`, `/api/recent`, and `/api/traces` can now be filtered by provider, client profile, client tag, layer, and success state. The dashboard is a thin UI over those same filtered endpoints and persists its active filters in the URL so operators can share one filtered view.
 
+The dashboard remains intentionally no-build for now:
+
+- no frontend framework runtime
+- no component library dependency
+- no separate JS build pipeline
+- one self-contained operator UI shipped with the gateway
+
+That is deliberate. The current goal is operational clarity and portability, not a second product surface that adds frontend tooling, bundle management, and extra deployment steps.
+
 ## Design target
 
 The longer-term design target is to outperform simpler router designs by making routing multi-dimensional instead of mostly keyword- or model-name-driven.

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -206,7 +206,9 @@ Primary goals:
 - expand the release-check baseline into stronger update alerts so operators can see when a newer release is available
 - add an optional automatic update enabler for controlled deployments
 - improve route traces, metrics, and dashboard filters for providers, clients, and profiles
-- keep the dashboard simple, read-heavy, and operationally safe
+- keep the dashboard simple, read-heavy, operationally safe, and intentionally no-build
+
+Until the dashboard clearly needs to become a broader operator application, FoundryGate should avoid adding a frontend framework, a component-library dependency, or a separate web build pipeline.
 
 This release line is about day-2 operations rather than new routing concepts.
 
@@ -314,6 +316,10 @@ Examples:
 - route trace table with provider and client filters
 - provider health panel with capabilities and contract type
 - quick links to dry-run routing and recent failure context
+
+Constraint:
+
+- keep the dashboard self-contained and no-build until there is a concrete operator need that justifies a real frontend stack
 
 ### 4. Image generation and editing routing
 


### PR DESCRIPTION
## What changed
- document that the built-in dashboard stays intentionally no-build for now
- align README, architecture, and roadmap around a self-contained operator UI
- make the deployment tradeoff explicit for local, Docker, and systemd installs

## Why
The current dashboard is an operational surface, not a separate frontend product. Keeping it no-build avoids adding a framework, component library, and asset pipeline before there is a concrete operator need.

## How verified
- /usr/bin/git diff --check
