### PR TITLE
feat(ops): add minimum release age guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added dashboard cards and tables for operator-side update checks and apply attempts
 - Added provider-health rollout guardrails so helper-driven auto-updates can block when gateway health is already degraded
 - Added `update_check.release_channel` and `auto_update.rollout_ring` so operators can distinguish stable vs preview checks and tighter rollout rings
+- Added `auto_update.min_release_age_hours` so helper-driven auto-updates can wait for a release to age before becoming eligible
 
 ## v0.6.0 - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Supported fields in `auto_update`:
 - `rollout_ring`
 - `require_healthy_providers`
 - `max_unhealthy_providers`
+- `min_release_age_hours`
 - `apply_command`
 
 Example:
@@ -559,6 +560,7 @@ auto_update:
   rollout_ring: "early"
   require_healthy_providers: true
   max_unhealthy_providers: 0
+  min_release_age_hours: 24
   apply_command: "foundrygate-update"
 ```
 
@@ -569,6 +571,7 @@ What the current runtime does with it:
 - lets `foundrygate-auto-update --apply` run only when the current release state is eligible
 - can block helper-driven rollout when provider health is already degraded
 - lets operators separate `stable` vs `preview` release checks and `stable` / `early` / `canary` rollout rings
+- can require that a release has aged for a minimum number of hours before helper-driven rollout
 
 What it still does not do:
 

--- a/config.yaml
+++ b/config.yaml
@@ -892,6 +892,7 @@ auto_update:
   rollout_ring: "early"
   require_healthy_providers: true
   max_unhealthy_providers: 0
+  min_release_age_hours: 0
   apply_command: "foundrygate-update"
 
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -65,6 +65,7 @@ If you want scheduled update application:
 - keep `auto_update.rollout_ring` on `stable` or `early` for normal environments; use `canary` only for faster adopters
 - keep `allow_major: false` unless you are ready to absorb breaking changes automatically
 - keep `require_healthy_providers: true` unless you are intentionally allowing rollouts while the gateway is degraded
+- set `min_release_age_hours` above `0` if you want scheduled rollouts to wait before applying newly published releases
 - prefer the reviewed examples in [examples/foundrygate-auto-update.service](./examples/foundrygate-auto-update.service) and [examples/foundrygate-auto-update.timer](./examples/foundrygate-auto-update.timer)
 - use the cron example in [examples/foundrygate-auto-update.cron](./examples/foundrygate-auto-update.cron) only when `systemd` timers are not practical
 

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -911,6 +911,12 @@ def _normalize_auto_update(data: dict[str, Any]) -> dict[str, Any]:
     if max_unhealthy_providers < 0:
         raise ConfigError("'auto_update.max_unhealthy_providers' must be non-negative")
 
+    min_release_age_hours = raw.get("min_release_age_hours", 0)
+    if isinstance(min_release_age_hours, bool) or not isinstance(min_release_age_hours, int):
+        raise ConfigError("'auto_update.min_release_age_hours' must be a non-negative integer")
+    if min_release_age_hours < 0:
+        raise ConfigError("'auto_update.min_release_age_hours' must be non-negative")
+
     apply_command = raw.get("apply_command", "foundrygate-update")
     if not isinstance(apply_command, str) or not apply_command.strip():
         raise ConfigError("'auto_update.apply_command' must be a non-empty string")
@@ -922,6 +928,7 @@ def _normalize_auto_update(data: dict[str, Any]) -> dict[str, Any]:
         "rollout_ring": rollout_ring,
         "require_healthy_providers": require_healthy_providers,
         "max_unhealthy_providers": max_unhealthy_providers,
+        "min_release_age_hours": min_release_age_hours,
         "apply_command": apply_command.strip(),
     }
     return normalized
@@ -1015,6 +1022,7 @@ class Config:
                 "rollout_ring": "early",
                 "require_healthy_providers": True,
                 "max_unhealthy_providers": 0,
+                "min_release_age_hours": 0,
                 "apply_command": "foundrygate-update",
             },
         )

--- a/foundrygate/updates.py
+++ b/foundrygate/updates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -102,6 +103,18 @@ def select_release_payload(payload: Any, *, release_channel: str) -> dict[str, A
     return {}
 
 
+def release_age_hours(published_at: str, *, now: datetime | None = None) -> float | None:
+    """Return the age of one release in hours from the GitHub published timestamp."""
+    if not published_at:
+        return None
+    try:
+        published = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    current = now or datetime.now(UTC)
+    return max(0.0, (current - published).total_seconds() / 3600)
+
+
 def apply_auto_update_guardrails(
     auto_update: dict[str, Any],
     *,
@@ -134,6 +147,34 @@ def apply_auto_update_guardrails(
     return result
 
 
+def apply_release_age_guardrail(
+    auto_update: dict[str, Any],
+    *,
+    published_at: str,
+) -> dict[str, Any]:
+    """Apply a minimum release-age guardrail to one auto-update eligibility result."""
+    result = dict(auto_update or {})
+    if not result.get("enabled") or not result.get("eligible"):
+        return result
+
+    min_release_age_hours = int(result.get("min_release_age_hours", 0))
+    if min_release_age_hours <= 0:
+        return result
+
+    age_hours = release_age_hours(published_at)
+    result["release_age_hours"] = age_hours
+    if age_hours is None:
+        result["eligible"] = False
+        result["blocked_reason"] = "Release age is unknown"
+        return result
+    if age_hours < min_release_age_hours:
+        result["eligible"] = False
+        result["blocked_reason"] = (
+            f"Release is too new ({age_hours:.1f}h < {min_release_age_hours}h)"
+        )
+    return result
+
+
 @dataclass
 class UpdateStatus:
     """Structured update-check result."""
@@ -144,6 +185,7 @@ class UpdateStatus:
     update_available: bool = False
     repository: str = ""
     release_url: str = ""
+    published_at: str = ""
     checked_at: float = 0.0
     status: str = "disabled"
     release_channel: str = "stable"
@@ -161,6 +203,7 @@ class UpdateStatus:
             "update_available": self.update_available,
             "repository": self.repository,
             "release_url": self.release_url,
+            "published_at": self.published_at,
             "checked_at": self.checked_at,
             "status": self.status,
             "release_channel": self.release_channel,
@@ -202,6 +245,7 @@ class UpdateChecker:
                 (auto_update or {}).get("require_healthy_providers", True)
             ),
             "max_unhealthy_providers": int((auto_update or {}).get("max_unhealthy_providers", 0)),
+            "min_release_age_hours": int((auto_update or {}).get("min_release_age_hours", 0)),
             "apply_command": str((auto_update or {}).get("apply_command", "foundrygate-update")),
         }
         self._cached = UpdateStatus(
@@ -261,6 +305,7 @@ class UpdateChecker:
                 self.auto_update.get("require_healthy_providers", True)
             ),
             "max_unhealthy_providers": int(self.auto_update.get("max_unhealthy_providers", 0)),
+            "min_release_age_hours": int(self.auto_update.get("min_release_age_hours", 0)),
             "eligible": eligible,
             "blocked_reason": blocked_reason,
             "apply_command": apply_command,
@@ -327,6 +372,7 @@ class UpdateChecker:
             payload = select_release_payload(response.json(), release_channel=self.release_channel)
             latest_version = str(payload.get("tag_name") or "").strip()
             release_url = str(payload.get("html_url") or "").strip()
+            published_at = str(payload.get("published_at") or "").strip()
             if not latest_version:
                 self._cached = UpdateStatus(
                     enabled=True,
@@ -360,6 +406,7 @@ class UpdateChecker:
                 update_available=update_available,
                 repository=self.repository,
                 release_url=release_url,
+                published_at=published_at,
                 checked_at=now,
                 status="ok",
                 release_channel=self.release_channel,
@@ -368,11 +415,14 @@ class UpdateChecker:
                 recommended_action=(
                     "Upgrade to the latest release" if update_available else "No action needed"
                 ),
-                auto_update=self._auto_update_status(
-                    status="ok",
-                    update_available=update_available,
-                    update_type=update_type,
-                    latest_version=latest_version,
+                auto_update=apply_release_age_guardrail(
+                    self._auto_update_status(
+                        status="ok",
+                        update_available=update_available,
+                        update_type=update_type,
+                        latest_version=latest_version,
+                    ),
+                    published_at=published_at,
                 ),
             )
             return self._cached

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,7 @@ def test_auto_update_defaults_are_exposed():
     assert cfg.auto_update["rollout_ring"] == "early"
     assert cfg.auto_update["require_healthy_providers"] is True
     assert cfg.auto_update["max_unhealthy_providers"] == 0
+    assert cfg.auto_update["min_release_age_hours"] == 0
     assert cfg.auto_update["apply_command"] == "foundrygate-update"
 
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from foundrygate.updates import (
@@ -9,8 +11,10 @@ from foundrygate.updates import (
     alert_level_for_update,
     allowed_update_types_for_ring,
     apply_auto_update_guardrails,
+    apply_release_age_guardrail,
     classify_update,
     is_update_available,
+    release_age_hours,
     select_release_payload,
 )
 
@@ -78,6 +82,26 @@ def test_select_release_payload_uses_first_preview_release():
     ]
     chosen = select_release_payload(payload, release_channel="preview")
     assert chosen["tag_name"] == "v0.8.0-rc1"
+
+
+def test_release_age_hours_reports_elapsed_time():
+    now = datetime(2026, 3, 12, 18, 0, tzinfo=UTC)
+    published = (now - timedelta(hours=6)).isoformat().replace("+00:00", "Z")
+    assert release_age_hours(published, now=now) == 6.0
+
+
+def test_release_age_guardrail_blocks_new_releases():
+    guarded = apply_release_age_guardrail(
+        {
+            "enabled": True,
+            "eligible": True,
+            "min_release_age_hours": 24,
+            "blocked_reason": "",
+        },
+        published_at=(datetime.now(UTC) - timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+    )
+    assert guarded["eligible"] is False
+    assert guarded["blocked_reason"].startswith("Release is too new")
 
 
 def test_auto_update_guardrails_block_when_too_many_providers_are_unhealthy():
@@ -294,6 +318,40 @@ async def test_preview_release_channel_reads_latest_preview_release():
 
     assert status.release_channel == "preview"
     assert status.latest_version == "v0.7.0-rc1"
+
+
+@pytest.mark.asyncio
+async def test_min_release_age_blocks_auto_update_until_release_has_aged():
+    checker = UpdateChecker(
+        current_version="0.6.0",
+        enabled=True,
+        repository="typelicious/FoundryGate",
+        auto_update={
+            "enabled": True,
+            "rollout_ring": "early",
+            "allow_major": False,
+            "min_release_age_hours": 24,
+        },
+    )
+    checker._client = _FakeClient(
+        _FakeResponse(
+            200,
+            {
+                "tag_name": "v0.6.1",
+                "html_url": "https://github.com/typelicious/FoundryGate/releases/tag/v0.6.1",
+                "published_at": (datetime.now(UTC) - timedelta(hours=1))
+                .isoformat()
+                .replace("+00:00", "Z"),
+            },
+        )
+    )
+
+    status = await checker.get_status(force=True)
+
+    assert status.update_type == "patch"
+    assert status.auto_update["eligible"] is False
+    assert status.auto_update["min_release_age_hours"] == 24
+    assert status.auto_update["blocked_reason"].startswith("Release is too new")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- adds auto_update.min_release_age_hours as a rollout guard for helper-driven updates
- exposes release published_at and computed release age for the update path
- updates README, publishing docs, changelog, and tests for the new age gate

## Why
- prevents scheduled updates from immediately applying brand-new releases
- gives operators a simple soak-time control without changing the core update helper flow

## How verified
- python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_updates.py tests/test_config.py
- ./.venv-check-313/bin/ruff check foundrygate/config.py foundrygate/updates.py tests/test_updates.py tests/test_config.py
- ./.venv-check-313/bin/ruff format --check foundrygate/config.py foundrygate/updates.py tests/test_updates.py tests/test_config.py
- /usr/bin/git diff --check