### PR TITLE
docs(onboarding): add client starter templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added built-in OpenClaw, n8n, and CLI quickstart examples to the onboarding report and integration docs so client onboarding can stay copy/paste friendly
 - Added staged provider-rollout reporting and fallback/image readiness warnings so many-provider onboarding is easier to phase safely
 - Added a client matrix to the onboarding report so profile match rules and routing intent are visible before traffic goes live
+- Added starter example files for OpenClaw, n8n, and CLI clients under `docs/examples/` so onboarding can begin from copy/pasteable templates
 
 ## v0.7.0 - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If every configured provider API key is empty, FoundryGate still starts, but it 
 ## Docs
 
 - [Architecture](./docs/ARCHITECTURE.md)
+- [Examples](./docs/examples)
 - [Integrations](./docs/INTEGRATIONS.md)
 - [Onboarding](./docs/ONBOARDING.md)
 - [Publishing](./docs/PUBLISHING.md)

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -20,6 +20,7 @@ Current coverage:
 Use:
 
 - [openclaw-integration.jsonc](../openclaw-integration.jsonc)
+- [examples/openclaw-foundrygate.jsonc](./examples/openclaw-foundrygate.jsonc)
 - `client_profiles.presets: ["openclaw"]` for a standard starting point
 
 Minimal direction:
@@ -30,6 +31,8 @@ Minimal direction:
   "primary": "foundrygate/auto"
 }
 ```
+
+For a smaller starter snippet without the full alias block, use [examples/openclaw-foundrygate.jsonc](./examples/openclaw-foundrygate.jsonc).
 
 ## n8n
 
@@ -55,6 +58,8 @@ Base URL: http://127.0.0.1:8090/v1
 Model: auto
 Header: X-FoundryGate-Client: n8n
 ```
+
+For an importable HTTP Request node example, use [examples/n8n-foundrygate-http-request.json](./examples/n8n-foundrygate-http-request.json).
 
 ## CLI clients
 
@@ -83,6 +88,8 @@ Minimal direction:
 export OPENAI_BASE_URL=http://127.0.0.1:8090/v1
 export OPENAI_API_KEY=local
 ```
+
+For a reusable shell starter, use [examples/cli-foundrygate-env.sh](./examples/cli-foundrygate-env.sh).
 
 ## Provider onboarding
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -110,6 +110,8 @@ OpenClaw:
 }
 ```
 
+Starter file: [examples/openclaw-foundrygate.jsonc](./examples/openclaw-foundrygate.jsonc)
+
 n8n:
 
 ```text
@@ -124,6 +126,11 @@ CLI:
 export OPENAI_BASE_URL=http://127.0.0.1:8090/v1
 export OPENAI_API_KEY=local
 ```
+
+Starter files:
+
+- [examples/n8n-foundrygate-http-request.json](./examples/n8n-foundrygate-http-request.json)
+- [examples/cli-foundrygate-env.sh](./examples/cli-foundrygate-env.sh)
 
 ### 4. Add request hooks only if needed
 

--- a/docs/examples/cli-foundrygate-env.sh
+++ b/docs/examples/cli-foundrygate-env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Example environment for OpenAI-compatible CLI tools using FoundryGate.
+
+export OPENAI_BASE_URL="http://127.0.0.1:8090/v1"
+export OPENAI_API_KEY="local"
+export FOUNDRYGATE_CLIENT_HEADER="X-FoundryGate-Client: codex"
+
+# Example one-off request:
+# curl -fsS "$OPENAI_BASE_URL/chat/completions" \
+#   -H "Content-Type: application/json" \
+#   -H "$FOUNDRYGATE_CLIENT_HEADER" \
+#   -d '{
+#     "model": "auto",
+#     "messages": [{"role": "user", "content": "Describe the current gateway health."}]
+#   }'

--- a/docs/examples/n8n-foundrygate-http-request.json
+++ b/docs/examples/n8n-foundrygate-http-request.json
@@ -1,0 +1,20 @@
+{
+  "method": "POST",
+  "url": "http://127.0.0.1:8090/v1/chat/completions",
+  "sendHeaders": true,
+  "headerParameters": {
+    "parameters": [
+      {
+        "name": "Content-Type",
+        "value": "application/json"
+      },
+      {
+        "name": "X-FoundryGate-Client",
+        "value": "n8n"
+      }
+    ]
+  },
+  "sendBody": true,
+  "specifyBody": "json",
+  "jsonBody": "{\n  \"model\": \"auto\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Summarize the latest workflow failures in one paragraph.\"\n    }\n  ],\n  \"max_tokens\": 256\n}"
+}

--- a/docs/examples/openclaw-foundrygate.jsonc
+++ b/docs/examples/openclaw-foundrygate.jsonc
@@ -1,0 +1,34 @@
+// Example OpenClaw provider block for FoundryGate.
+// Merge this into ~/.openclaw/openclaw.json.
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "foundrygate": {
+        "baseUrl": "http://127.0.0.1:8090/v1",
+        "apiKey": "local",
+        "auth": "api-key",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "auto",
+            "name": "FoundryGate Auto-Router",
+            "contextWindow": 128000,
+            "maxTokens": 8000
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "foundrygate/auto",
+        "fallbacks": []
+      },
+      "subagents": {
+        "model": "foundrygate/auto"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- add starter example files for OpenClaw, n8n, and CLI clients under docs/examples/
- link the example files from onboarding and integration docs
- expose the examples in the main docs index

## Why
- move from report-only onboarding guidance to copy/pasteable starter templates
- make many-client onboarding faster for first-time operators

## How verified
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests
- ./.venv-check-313/bin/ruff check README.md docs/INTEGRATIONS.md docs/ONBOARDING.md CHANGELOG.md
- bash -n docs/examples/cli-foundrygate-env.sh
- git diff --check