### PR TITLE
docs(onboarding): add provider starter templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added staged provider-rollout reporting and fallback/image readiness warnings so many-provider onboarding is easier to phase safely
 - Added a client matrix to the onboarding report so profile match rules and routing intent are visible before traffic goes live
 - Added starter example files for OpenClaw, n8n, and CLI clients under `docs/examples/` so onboarding can begin from copy/pasteable templates
+- Added starter provider snippets for cloud, local-worker, and image-provider setups under `docs/examples/`
 
 ## v0.7.0 - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -842,6 +842,12 @@ Running `./scripts/foundrygate-install` also creates symlinks in `/usr/local/bin
 | `foundrygate-doctor` | Checks for config/env presence, writable DB path, at least one configured provider key, and optional local health endpoints |
 | `foundrygate-onboarding-report` | Summarizes provider readiness, staged rollout readiness, client-profile coverage, client match intent, routing layers, onboarding suggestions, and concrete OpenClaw/n8n/CLI quickstarts |
 | `foundrygate-onboarding-validate` | Exits non-zero when onboarding blockers exist and prints warnings for common multi-provider and multi-client misconfigurations |
+
+Provider starter snippets for the first rollout path live under [docs/examples](./docs/examples):
+
+- [provider-openai-compat.yaml](./docs/examples/provider-openai-compat.yaml)
+- [provider-local-worker.yaml](./docs/examples/provider-local-worker.yaml)
+- [provider-image-provider.yaml](./docs/examples/provider-image-provider.yaml)
 | `foundrygate-install` | Installs the unit file, creates `/var/lib/foundrygate`, creates helper symlinks, reloads `systemd`, and starts the service |
 | `foundrygate-start` | Runs `systemctl start foundrygate.service` |
 | `foundrygate-stop` | Runs `systemctl stop foundrygate.service` |

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -101,6 +101,12 @@ When onboarding a new provider:
 4. test routing with `POST /api/route`
 5. then route real traffic
 
+Starter snippets:
+
+- [examples/provider-openai-compat.yaml](./examples/provider-openai-compat.yaml)
+- [examples/provider-local-worker.yaml](./examples/provider-local-worker.yaml)
+- [examples/provider-image-provider.yaml](./examples/provider-image-provider.yaml)
+
 ## Client onboarding
 
 When onboarding a new client:

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -41,6 +41,12 @@ It also prints a client matrix:
 - set the required API key or local auth value in `.env`
 - keep the fallback chain simple
 
+Starter snippets:
+
+- [examples/provider-openai-compat.yaml](./examples/provider-openai-compat.yaml)
+- [examples/provider-local-worker.yaml](./examples/provider-local-worker.yaml)
+- [examples/provider-image-provider.yaml](./examples/provider-image-provider.yaml)
+
 ### 2. Verify provider health
 
 - check `GET /health`

--- a/docs/examples/provider-image-provider.yaml
+++ b/docs/examples/provider-image-provider.yaml
@@ -1,0 +1,18 @@
+providers:
+  image-provider:
+    contract: image-provider
+    backend: openai-compat
+    base_url: "http://127.0.0.1:9000/v1"
+    api_key: "${IMAGE_PROVIDER_API_KEY}"
+    model: "image-model"
+    tier: specialty
+    capabilities:
+      image_generation: true
+      image_editing: true
+    image:
+      policy_tags: ["editing", "balanced"]
+      max_outputs: 4
+      supported_sizes: ["1024x1024", "1536x1024"]
+
+fallback_chain:
+  - image-provider

--- a/docs/examples/provider-local-worker.yaml
+++ b/docs/examples/provider-local-worker.yaml
@@ -1,0 +1,14 @@
+providers:
+  local-worker:
+    contract: local-worker
+    backend: openai-compat
+    base_url: "http://127.0.0.1:11434/v1"
+    api_key: "local"
+    model: "llama3"
+    tier: local
+    capabilities:
+      local: true
+      cloud: false
+
+fallback_chain:
+  - local-worker

--- a/docs/examples/provider-openai-compat.yaml
+++ b/docs/examples/provider-openai-compat.yaml
@@ -1,0 +1,13 @@
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "${DEEPSEEK_API_KEY}"
+    model: "deepseek-chat"
+    tier: default
+    capabilities:
+      local: false
+      cloud: true
+
+fallback_chain:
+  - deepseek-chat


### PR DESCRIPTION
## What changed
- add starter provider snippets for cloud openai-compat, local-worker, and image-provider setups
- link the snippets from onboarding, integrations, and README helper documentation
- extend the docs examples area from client templates to provider templates

## Why
- make the first provider rollout path as copy/pasteable as the client onboarding path
- reduce friction for common gateway topologies during v0.8 onboarding work

## How verified
- ./.venv-check-313/bin/ruff check README.md docs/INTEGRATIONS.md docs/ONBOARDING.md CHANGELOG.md
- git diff --check
- python3 sanity check for new docs/examples provider files