### PR TITLE
docs(onboarding): add provider env starters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added a client matrix to the onboarding report so profile match rules and routing intent are visible before traffic goes live
 - Added starter example files for OpenClaw, n8n, and CLI clients under `docs/examples/` so onboarding can begin from copy/pasteable templates
 - Added starter provider snippets for cloud, local-worker, and image-provider setups under `docs/examples/`
+- Added matching provider `.env` starter files for cloud, local-worker, and image-provider onboarding flows
 
 ## v0.7.0 - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -846,8 +846,11 @@ Running `./scripts/foundrygate-install` also creates symlinks in `/usr/local/bin
 Provider starter snippets for the first rollout path live under [docs/examples](./docs/examples):
 
 - [provider-openai-compat.yaml](./docs/examples/provider-openai-compat.yaml)
+- [provider-openai-compat.env.example](./docs/examples/provider-openai-compat.env.example)
 - [provider-local-worker.yaml](./docs/examples/provider-local-worker.yaml)
+- [provider-local-worker.env.example](./docs/examples/provider-local-worker.env.example)
 - [provider-image-provider.yaml](./docs/examples/provider-image-provider.yaml)
+- [provider-image-provider.env.example](./docs/examples/provider-image-provider.env.example)
 | `foundrygate-install` | Installs the unit file, creates `/var/lib/foundrygate`, creates helper symlinks, reloads `systemd`, and starts the service |
 | `foundrygate-start` | Runs `systemctl start foundrygate.service` |
 | `foundrygate-stop` | Runs `systemctl stop foundrygate.service` |

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -104,8 +104,11 @@ When onboarding a new provider:
 Starter snippets:
 
 - [examples/provider-openai-compat.yaml](./examples/provider-openai-compat.yaml)
+- [examples/provider-openai-compat.env.example](./examples/provider-openai-compat.env.example)
 - [examples/provider-local-worker.yaml](./examples/provider-local-worker.yaml)
+- [examples/provider-local-worker.env.example](./examples/provider-local-worker.env.example)
 - [examples/provider-image-provider.yaml](./examples/provider-image-provider.yaml)
+- [examples/provider-image-provider.env.example](./examples/provider-image-provider.env.example)
 
 ## Client onboarding
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -44,8 +44,11 @@ It also prints a client matrix:
 Starter snippets:
 
 - [examples/provider-openai-compat.yaml](./examples/provider-openai-compat.yaml)
+- [examples/provider-openai-compat.env.example](./examples/provider-openai-compat.env.example)
 - [examples/provider-local-worker.yaml](./examples/provider-local-worker.yaml)
+- [examples/provider-local-worker.env.example](./examples/provider-local-worker.env.example)
 - [examples/provider-image-provider.yaml](./examples/provider-image-provider.yaml)
+- [examples/provider-image-provider.env.example](./examples/provider-image-provider.env.example)
 
 ### 2. Verify provider health
 

--- a/docs/examples/provider-image-provider.env.example
+++ b/docs/examples/provider-image-provider.env.example
@@ -1,0 +1,1 @@
+IMAGE_PROVIDER_API_KEY=replace-with-real-key

--- a/docs/examples/provider-local-worker.env.example
+++ b/docs/examples/provider-local-worker.env.example
@@ -1,0 +1,3 @@
+# Local workers often do not need a real remote key.
+# Keep the runtime value aligned with your provider stanza.
+LOCAL_WORKER_API_KEY=local

--- a/docs/examples/provider-openai-compat.env.example
+++ b/docs/examples/provider-openai-compat.env.example
@@ -1,0 +1,1 @@
+DEEPSEEK_API_KEY=replace-with-real-key


### PR DESCRIPTION
## What changed
- add provider .env starter files for cloud openai-compat, local-worker, and image-provider setups
- link the env starters from onboarding, integrations, and README helper docs
- keep the provider templates and env examples paired for copy/paste onboarding

## Why
- make provider onboarding complete without having to invent matching env keys by hand
- reduce friction between provider config snippets and real local setup

## How verified
- ./.venv-check-313/bin/ruff check README.md docs/INTEGRATIONS.md docs/ONBOARDING.md CHANGELOG.md
- git diff --check
- python3 sanity check for new docs/examples env files