### PR TITLE
docs(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to FoundryGate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
-## Unreleased
+## v0.8.0 - 2026-03-15
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,11 +21,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v0.7.0 -m "FoundryGate v0.7.0"
-git push origin v0.7.0
+git tag -a v0.8.0 -m "FoundryGate v0.8.0"
+git push origin v0.8.0
 ```
 
-Then open GitHub Releases and publish a release for `v0.7.0`.
+Then open GitHub Releases and publish a release for `v0.8.0`.
 
 ## Automation Baseline
 
@@ -56,6 +56,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v0.5.0` establishes the operator distribution baseline: image-provider contracts, Docker and GHCR packaging, PyPI workflow support, onboarding helpers, repo community standards, and cached release update checks.
 - `v0.6.0` establishes the modality-expansion baseline: image route previews, provider capability coverage, shared image request validation, and image policy presets.
 - `v0.7.0` establishes the operations-polish baseline: update alerts, operator events, rollout guardrails, scoped update checks, maintenance windows, and post-update verification hints.
+- `v0.8.0` establishes the onboarding baseline: repeatable provider/client rollout helpers, starter templates, delegated-traffic examples, env validation, and shareable onboarding reports.
 
 ## Planned Publishing Path
 
@@ -63,6 +64,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v0.5.0`: Docker and PyPI publishing baseline is introduced through the release workflow and repo docs.
 - `v0.6.0`: modality-aware image routing becomes an explicit release line with provider inventory and image-policy guidance.
 - `v0.7.0`: helper-driven update controls become a first-class release line with scoped rollout gates and verification hooks.
+- `v0.8.0`: many-provider and many-client onboarding becomes copy/pasteable and validation-backed through reports, starters, and doctor checks.
 - `v1.0.0`: keep GitHub Releases, Docker, and PyPI, and add a separate npm or TypeScript CLI package if the CLI surface is ready.
 
 The npm or TypeScript package should stay separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -685,7 +685,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="0.7.0",
+    version="0.8.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What changed
- bump runtime and package version from 0.7.0 to 0.8.0
- cut the onboarding work from Unreleased into the v0.8.0 changelog section
- update release guidance to include the v0.8.0 onboarding baseline

## Why
- finalize the many-provider and many-client onboarding line as a releasable milestone
- prepare the repo for the v0.8.0 tag and GitHub release

## How verified
- PYTHONPYCACHEPREFIX="$PWD/.pycache" python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/foundrygate-0.8.0.tar.gz dist/foundrygate-0.8.0-py3-none-any.whl
- git diff --check