### PR TITLE
docs(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to FoundryGate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
-## Unreleased
+## v0.9.0 - 2026-03-15
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,11 +22,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v0.8.0 -m "FoundryGate v0.8.0"
-git push origin v0.8.0
+git tag -a v0.9.0 -m "FoundryGate v0.9.0"
+git push origin v0.9.0
 ```
 
-Then open GitHub Releases and publish a release for `v0.8.0`.
+Then open GitHub Releases and publish a release for `v0.9.0`.
 
 ## Automation Baseline
 

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -756,7 +756,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="0.8.0",
+    version="0.9.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "0.8.0"
+version = "0.9.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What changed

- bumps FoundryGate from `0.8.0` to `0.9.0`
- moves the current `Unreleased` hardening notes into the `v0.9.0` changelog section
- updates release documentation examples to the new release version

## Why

The v0.9 hardening work is already on `main`. This PR is the minimal release-prep slice needed to tag and publish `v0.9.0` cleanly.

## How verified

- `PYTHONPYCACHEPREFIX="$PWD/.pycache" python3 -m compileall foundrygate tests`
- `PYTHONPATH=. ./.venv-check-313/bin/pytest -q`
- `./.venv-check-313/bin/ruff check .`
- `./.venv-check-313/bin/ruff format --check .`
- `./.venv-check-313/bin/python -m build --no-isolation`
- `./.venv-check-313/bin/python -m twine check dist/foundrygate-0.9.0.tar.gz dist/foundrygate-0.9.0-py3-none-any.whl`
- `PATH=/opt/homebrew/bin:$PATH /usr/bin/git diff --check`
