### PR TITLE
docs(release): prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to FoundryGate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
-## Unreleased
+## v1.1.0 - 2026-03-16
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,11 +22,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.0.0 -m "FoundryGate v1.0.0"
-git push origin v1.0.0
+git tag -a v1.1.0 -m "FoundryGate v1.1.0"
+git push origin v1.1.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.0.0`.
+Then open GitHub Releases and publish a release for `v1.1.0`.
 
 ## Automation Baseline
 
@@ -60,6 +60,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v0.8.0` establishes the onboarding baseline: repeatable provider/client rollout helpers, starter templates, delegated-traffic examples, env validation, and shareable onboarding reports.
 - `v0.9.0` is the pre-`v1.0` hardening baseline: conservative response headers, bounded request surfaces, stronger functional API coverage, and a full documentation pass over operator-facing behavior.
 - `v1.0.0` establishes the stable baseline: trust-boundary validation for upstream base URLs, sanitized provider-error responses, a documented security review, and the separate `@foundrygate/cli` npm package for CLI-facing workflows.
+- `v1.1.0` deepens post-1.0 adoption: wider AI-native starter coverage, tighter policy semantics, richer client highlights in stats/dashboard, and cleaner onboarding guidance for popular agent frameworks.
 
 ## Planned Publishing Path
 

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -826,7 +826,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="1.0.0",
+    version="1.1.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/foundrygate-cli/package.json
+++ b/packages/foundrygate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundrygate/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Small npm CLI for checking and previewing a FoundryGate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "1.0.0"
+version = "1.1.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What changed\n- bumped the Python package, app, and npm CLI version to 1.1.0\n- moved the current Unreleased notes into the v1.1.0 changelog section\n- refreshed the release guide examples and current release guidance for the v1.1.0 line\n\n## Why\nThis turns the current mainline feature set into a clean v1.1.0 release candidate with aligned packaging metadata.\n\n## How verified\n- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests\n- PYTHONPATH=. ./.venv-check-313/bin/pytest -q\n- ./.venv-check-313/bin/ruff check .\n- ./.venv-check-313/bin/ruff format --check .\n- ./.venv-check-313/bin/python -m build --no-isolation\n- ./.venv-check-313/bin/python -m twine check dist/foundrygate-1.1.0.tar.gz dist/foundrygate-1.1.0-py3-none-any.whl\n- /opt/homebrew/bin/node packages/foundrygate-cli/bin/foundrygate.js --help\n- cd packages/foundrygate-cli && npm_config_cache=/tmp/foundrygate-npm-cache PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm pack --dry-run\n- /usr/bin/git diff --check