### PR TITLE
docs(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+## v1.2.0 - 2026-03-19
+
 ### Added
 
 - Added a workstation operations guide for Linux, macOS, and Windows runtime layouts

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.1.0 -m "FoundryGate v1.1.0"
-git push origin v1.1.0
+git tag -a v1.2.0 -m "FoundryGate v1.2.0"
+git push origin v1.2.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.1.0`.
+Then open GitHub Releases and publish a release for `v1.2.0`.
 
 ## Automation Baseline
 
@@ -62,6 +62,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v0.9.0` is the pre-`v1.0` hardening baseline: conservative response headers, bounded request surfaces, stronger functional API coverage, and a full documentation pass over operator-facing behavior.
 - `v1.0.0` establishes the stable baseline: trust-boundary validation for upstream base URLs, sanitized provider-error responses, a documented security review, and the separate `@foundrygate/cli` npm package for CLI-facing workflows.
 - `v1.1.0` deepens post-1.0 adoption: wider AI-native starter coverage, tighter policy semantics, richer client highlights in stats/dashboard, and cleaner onboarding guidance for popular agent frameworks.
+- `v1.2.0` establishes the workstation and packaging baseline: Linux/macOS/Windows workstation guidance, macOS-aware runtime helpers, Windows startup examples, explicit config-path support for packaged installs, and a project-owned Homebrew formula path.
 
 ## Planned Publishing Path
 
@@ -71,6 +72,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v0.7.0`: helper-driven update controls become a first-class release line with scoped rollout gates and verification hooks.
 - `v0.8.0`: many-provider and many-client onboarding becomes copy/pasteable and validation-backed through reports, starters, and doctor checks.
 - `v1.0.0`: keep GitHub Releases, Docker, and PyPI, and add the separate npm CLI package under `packages/foundrygate-cli`.
+- `v1.2.0`: add the project-owned Homebrew packaging path for macOS workstations while keeping Docker, GitHub Releases, Python artifacts, and the separate npm CLI package.
 
 The npm package stays separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.
 

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -19,7 +19,9 @@ The foundation that used to be the near-term buildout is largely in place:
 
 This roadmap now shifts from "rename and foundation" to "deepen the gateway plane without bloating it".
 
-`v1.1.0` is now shipped. The next block should stay disciplined: improve workstation operations, keep adoption friction low across macOS and Windows, and extend runtime packaging guidance without turning FoundryGate into a sprawling platform.
+`v1.2.0` is now shipped. The workstation baseline is in place: Linux, macOS, and Windows runtime guidance is documented, macOS helpers now auto-detect `launchd`, and a project-owned Homebrew path exists for packaged macOS installs.
+
+The next block should stay disciplined: build on the workstation baseline, keep packaging practical, and avoid turning FoundryGate into a sprawling platform.
 
 ## `v1.2.0`: workstation operations baseline
 

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -828,7 +828,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="1.1.0",
+    version="1.2.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/foundrygate-cli/package.json
+++ b/packages/foundrygate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundrygate/cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Small npm CLI for checking and previewing a FoundryGate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "1.1.0"
+version = "1.2.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump FoundryGate and CLI package versions to 1.2.0
- move workstation and packaging notes into the v1.2.0 changelog section
- update release docs and roadmap status for the shipped v1.2.0 baseline

## Testing
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/foundrygate-1.2.0.tar.gz dist/foundrygate-1.2.0-py3-none-any.whl
- PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/node packages/foundrygate-cli/bin/foundrygate.js --help
- cd packages/foundrygate-cli && npm_config_cache=/tmp/foundrygate-npm-cache PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm pack --dry-run
- ruby -c Formula/foundrygate.rb
- git diff --check