### PR TITLE
packaging: stabilize Homebrew Python runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+### Changed
+
+- Switched the Homebrew formula baseline from `python@3.13` to `python@3.12` to reduce macOS packaging friction around vendored native Python wheels
+- Clarified in the README and workstation docs that `brew install foundrygate` resolves cleanly after tapping `typelicious/foundrygate`, while the fully qualified install path remains the safest first-run example
+
 ## v1.2.0 - 2026-03-19
 
 ### Added

--- a/Formula/foundrygate.rb
+++ b/Formula/foundrygate.rb
@@ -6,10 +6,10 @@ class Foundrygate < Formula
   license "Apache-2.0"
   head "https://github.com/typelicious/FoundryGate.git", branch: "main"
 
-  depends_on "python@3.13"
+  depends_on "python@3.12"
 
   def install
-    python = Formula["python@3.13"].opt_bin/"python3.13"
+    python = Formula["python@3.12"].opt_bin/"python3.12"
 
     system python, "-m", "venv", libexec
     system libexec/"bin/pip", "install", "--upgrade", "pip", "setuptools", "wheel"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Minimal Homebrew flow on macOS:
 ```bash
 brew tap typelicious/foundrygate https://github.com/typelicious/FoundryGate
 brew install typelicious/foundrygate/foundrygate
+# or, after the tap is present:
+brew install foundrygate
 brew services start typelicious/foundrygate/foundrygate
 ```
 

--- a/docs/WORKSTATIONS.md
+++ b/docs/WORKSTATIONS.md
@@ -103,6 +103,8 @@ Typical flow:
 ```bash
 brew tap typelicious/foundrygate https://github.com/typelicious/FoundryGate
 brew install typelicious/foundrygate/foundrygate
+# or, after the tap is present and the name stays unique:
+brew install foundrygate
 $EDITOR "$(brew --prefix)/etc/foundrygate/config.yaml"
 $EDITOR "$(brew --prefix)/etc/foundrygate/foundrygate.env"
 brew services start typelicious/foundrygate/foundrygate
@@ -116,6 +118,8 @@ Useful paths for the formula-driven install:
 - logs: `$(brew --prefix)/var/log/foundrygate/`
 
 The formula is intentionally project-owned rather than targeted at `homebrew/core`. That keeps the Python-service packaging flexible and lets `brew services` manage the local `launchd` path cleanly.
+
+The fully qualified install path is the safest first-run example. Once the tap is added, `brew install foundrygate` also resolves cleanly as long as no conflicting formula name is introduced by another tap.
 
 ## Windows
 


### PR DESCRIPTION
## Summary
- move the Homebrew formula baseline from python@3.13 to python@3.12 for a more stable macOS packaging path
- document that brew install foundrygate resolves after tapping the repo, while the fully qualified install path remains the safest first-run example

## Testing
- ruby -c Formula/foundrygate.rb
- git diff --check
- verified locally that brew info/search resolve foundrygate after tap