### PR TITLE
packaging: bump Homebrew formula to v1.2.1

### DIFF
--- a/Formula/foundrygate.rb
+++ b/Formula/foundrygate.rb
@@ -1,8 +1,8 @@
 class Foundrygate < Formula
   desc "Local OpenAI-compatible AI gateway for OpenClaw and other AI-native clients"
   homepage "https://github.com/typelicious/FoundryGate"
-  url "https://github.com/typelicious/FoundryGate/archive/refs/tags/v1.2.0.tar.gz"
-  sha256 "c1a4e8fec57a92da07cb528c5b7ee8cfb99841fc515a7ca52e41e4a75196eea7"
+  url "https://github.com/typelicious/FoundryGate/archive/refs/tags/v1.2.1.tar.gz"
+  sha256 "be1ac5103c00d2871e97923029066fc32533a28f327b53a5e8ed9cf8215c66df"
   license "Apache-2.0"
   head "https://github.com/typelicious/FoundryGate.git", branch: "main"
 


### PR DESCRIPTION
## Summary
- point the Homebrew formula stable url at the published v1.2.1 tarball
- refresh the formula sha256 to match the released source archive

## Testing
- ruby -c Formula/foundrygate.rb
- git diff --check
- curl -L https://github.com/typelicious/FoundryGate/archive/refs/tags/v1.2.1.tar.gz -o /tmp/foundrygate-v1.2.1.tar.gz
- shasum -a 256 /tmp/foundrygate-v1.2.1.tar.gz