### PR TITLE
packaging: harden Homebrew macOS install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+### Changed
+
+- Hardened the Homebrew formula so `pydantic-core` is built from source with extra Mach-O header padding on macOS instead of relying on the vendored wheel layout
+- Strengthened the formula test so it validates the wrapped `foundrygate --version` entrypoint instead of only importing the package inside `libexec`
+- Clarified in the README, workstation guide, and troubleshooting docs that active Python virtualenvs can shadow the Brew-installed `foundrygate` binary
+
 ## v1.2.1 - 2026-03-19
 
 ### Changed

--- a/Formula/foundrygate.rb
+++ b/Formula/foundrygate.rb
@@ -6,10 +6,17 @@ class Foundrygate < Formula
   license "Apache-2.0"
   head "https://github.com/typelicious/FoundryGate.git", branch: "main"
 
+  depends_on "rust" => :build
   depends_on "python@3.12"
 
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
+
+    # Build pydantic-core from source with extra Mach-O header space so
+    # Homebrew's linkage fixups do not trip over the vendored extension.
+    ENV["PIP_NO_BINARY"] = "pydantic-core"
+    ENV.append "RUSTFLAGS", " -C link-arg=-Wl,-headerpad_max_install_names"
+    ENV.append "LDFLAGS", " -Wl,-headerpad_max_install_names"
 
     system python, "-m", "venv", libexec
     system libexec/"bin/pip", "install", "--upgrade", "pip", "setuptools", "wheel"
@@ -81,6 +88,6 @@ class Foundrygate < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{libexec}/bin/python -c 'import foundrygate; print(foundrygate.__version__)'")
+    assert_match "foundrygate #{version}", shell_output("#{bin}/foundrygate --version")
   end
 end

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ brew install foundrygate
 brew services start typelicious/foundrygate/foundrygate
 ```
 
+If you already have an active Python virtualenv, check which binary you are calling before testing the Brew install:
+
+```bash
+which -a foundrygate
+/opt/homebrew/bin/foundrygate --version
+```
+
 ## How It Works
 
 ```text

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -182,6 +182,29 @@ foundrygate-health
 
 If you use `foundrygate-update`, remember that it is meant for deployment checkouts and removes local untracked changes.
 
+## Homebrew install warns about `pydantic_core` linkage or `foundrygate --version` looks wrong
+
+Separate the two failure modes first:
+
+- a Homebrew linkage warning during install is a packaging problem
+- an empty or unexpected `foundrygate --version` can simply mean an active virtualenv is shadowing the Brew binary
+
+Check which executable is first on `PATH`:
+
+```bash
+which -a foundrygate
+/opt/homebrew/bin/foundrygate --version
+```
+
+If the Brew binary works but plain `foundrygate` does not, leave the service running and fix your shell path or deactivate the virtualenv before testing the Homebrew install again.
+
+If Homebrew still warns about `pydantic_core`, update the tap and reinstall:
+
+```bash
+brew update
+brew reinstall typelicious/foundrygate/foundrygate
+```
+
 ## Update checks fail or show unavailable
 
 Check the cached runtime view first:

--- a/docs/WORKSTATIONS.md
+++ b/docs/WORKSTATIONS.md
@@ -121,6 +121,15 @@ The formula is intentionally project-owned rather than targeted at `homebrew/cor
 
 The fully qualified install path is the safest first-run example. Once the tap is added, `brew install foundrygate` also resolves cleanly as long as no conflicting formula name is introduced by another tap.
 
+If you are testing from a shell that already has an active Python virtualenv, confirm that the Brew-installed binary is the one being called:
+
+```bash
+which -a foundrygate
+/opt/homebrew/bin/foundrygate --version
+```
+
+The virtualenv binary can appear first on `PATH`, which makes it look like the Homebrew install is missing features when you are actually calling the wrong executable.
+
 ## Windows
 
 Recommended baseline:


### PR DESCRIPTION
## Summary
- build pydantic-core from source with explicit macOS header padding in the Homebrew formula
- strengthen the formula test so it exercises the wrapped foundrygate binary instead of only importing from libexec
- document how active virtualenvs can shadow the Brew-installed CLI in the README, workstation guide, and troubleshooting docs

## Testing
- ruby -c Formula/foundrygate.rb
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_main_cli.py
- ./.venv-check-313/bin/ruff check foundrygate/main.py tests/test_main_cli.py
- git diff --check