### PR TITLE
packaging: fix Homebrew runtime entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ### Changed
 
-- Hardened the Homebrew formula so `pydantic-core` is built from source with extra Mach-O header padding on macOS instead of relying on the vendored wheel layout
+- Hardened the Homebrew formula so native Python extensions such as `pydantic-core` and `watchfiles` are built from source with extra Mach-O header padding on macOS instead of relying on the vendored wheel layout
 - Strengthened the formula test so it validates the wrapped `foundrygate --version` entrypoint instead of only importing the package inside `libexec`
+- Fixed the Python service entrypoint so `python -m foundrygate.main` and the Brew-managed wrapper both execute the runtime correctly
 - Clarified in the README, workstation guide, and troubleshooting docs that active Python virtualenvs can shadow the Brew-installed `foundrygate` binary
 
 ## v1.2.1 - 2026-03-19

--- a/Formula/foundrygate.rb
+++ b/Formula/foundrygate.rb
@@ -12,9 +12,9 @@ class Foundrygate < Formula
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
 
-    # Build pydantic-core from source with extra Mach-O header space so
-    # Homebrew's linkage fixups do not trip over the vendored extension.
-    ENV["PIP_NO_BINARY"] = "pydantic-core"
+    # Build native Python extensions from source with extra Mach-O header
+    # space so Homebrew's linkage fixups do not trip over vendored wheels.
+    ENV["PIP_NO_BINARY"] = "pydantic-core,watchfiles"
     ENV.append "RUSTFLAGS", " -C link-arg=-Wl,-headerpad_max_install_names"
     ENV.append "LDFLAGS", " -Wl,-headerpad_max_install_names"
 
@@ -31,7 +31,7 @@ class Foundrygate < Formula
       export FOUNDRYGATE_CONFIG_FILE="${FOUNDRYGATE_CONFIG_FILE:-#{etc}/foundrygate/config.yaml}"
       export FOUNDRYGATE_DB_PATH="${FOUNDRYGATE_DB_PATH:-#{var}/lib/foundrygate/foundrygate.db}"
       cd "#{etc}/foundrygate"
-      exec "#{libexec}/bin/python" -m foundrygate.main "$@"
+      exec "#{libexec}/bin/python" -m foundrygate "$@"
     SH
 
     (bin/"foundrygate-stats").write <<~SH

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -1605,6 +1605,10 @@ def _inline_asset_hash(tag_name: str, html: str) -> str:
     return f"'sha256-{b64encode(digest).decode('ascii')}'"
 
 
+if __name__ == "__main__":
+    main()
+
+
 def _dashboard_csp() -> str:
     """Return the restrictive CSP for the built-in no-build dashboard."""
     style_hash = _inline_asset_hash("style", _DASHBOARD_HTML)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import runpy
+import sys
+
 import pytest
 
 import foundrygate.main as main_module
@@ -55,3 +58,13 @@ def test_main_supports_version_flag(monkeypatch, capsys):
 
     assert exc.value.code == 0
     assert "1.2.3" in capsys.readouterr().out
+
+
+def test_main_module_executes_main(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["foundrygate", "--version"])
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("foundrygate.main", run_name="__main__")
+
+    assert exc.value.code == 0
+    assert "foundrygate" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- build both pydantic-core and watchfiles from source in the Homebrew formula to avoid macOS linkage fixup issues on vendored wheels
- invoke the Brew-managed runtime via python -m foundrygate and add the missing __main__ guard in foundrygate.main
- add a regression test that exercises the module entrypoint path used by packaged installs

## Testing
- ruby -c Formula/foundrygate.rb
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_main_cli.py
- ./.venv-check-313/bin/ruff check foundrygate/main.py tests/test_main_cli.py
- git diff --check