### PR TITLE
docs(release): prepare v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
-## v1.2.2 - 2026-03-19
+## v1.2.3 - 2026-03-19
 
 ### Changed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.2.2 -m "FoundryGate v1.2.2"
-git push origin v1.2.2
+git tag -a v1.2.3 -m "FoundryGate v1.2.3"
+git push origin v1.2.3
 ```
 
-Then open GitHub Releases and publish a release for `v1.2.2`.
+Then open GitHub Releases and publish a release for `v1.2.3`.
 
 ## Automation Baseline
 
@@ -65,6 +65,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.0` establishes the workstation and packaging baseline: Linux/macOS/Windows workstation guidance, macOS-aware runtime helpers, Windows startup examples, explicit config-path support for packaged installs, and a project-owned Homebrew formula path.
 - `v1.2.1` is the first packaging follow-up on top of that baseline: the Homebrew formula now prefers `python@3.12` for a cleaner macOS install path and the docs now explicitly cover unqualified `brew install foundrygate` after tapping the project-owned tap.
 - `v1.2.2` hardens the macOS packaging path further: the Homebrew formula now builds `pydantic-core` from source with explicit header padding, validates the wrapped binary in its formula test, and documents how virtualenvs can shadow the Brew-installed CLI.
+- `v1.2.3` finishes the immediate Brew runtime stabilization pass: the Brew-managed wrapper now invokes the correct Python module entrypoint and the formula also builds `watchfiles` from source to avoid the next macOS linkage fixup failure.
 
 ## Planned Publishing Path
 
@@ -77,6 +78,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.0`: add the project-owned Homebrew packaging path for macOS workstations while keeping Docker, GitHub Releases, Python artifacts, and the separate npm CLI package.
 - `v1.2.1`: harden the Homebrew path with a more stable Python baseline and clearer tap/install guidance for macOS users.
 - `v1.2.2`: finish the first macOS packaging hardening pass by targeting the `pydantic-core` linkage warning directly and tightening the wrapper-level install checks.
+- `v1.2.3`: complete the immediate Brew-runtime stabilization work by fixing the packaged entrypoint path and broadening the native-wheel source-build policy on macOS.
 
 The npm package stays separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.
 

--- a/foundrygate/__init__.py
+++ b/foundrygate/__init__.py
@@ -1,3 +1,3 @@
 """FoundryGate package."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -828,7 +828,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="FoundryGate",
-    version="1.2.2",
+    version="1.2.3",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/foundrygate-cli/package.json
+++ b/packages/foundrygate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundrygate/cli",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Small npm CLI for checking and previewing a FoundryGate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foundrygate"
-version = "1.2.2"
+version = "1.2.3"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the Python package, service, and npm CLI versions to 1.2.3
- move the Homebrew runtime-fix notes into the v1.2.3 changelog entry
- refresh the release guide examples for the new patch tag

## Testing
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/foundrygate-1.2.3.tar.gz dist/foundrygate-1.2.3-py3-none-any.whl
- PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/node packages/foundrygate-cli/bin/foundrygate.js --help
- cd packages/foundrygate-cli && npm_config_cache=/tmp/foundrygate-npm-cache PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm pack --dry-run
- ruby -c Formula/foundrygate.rb
- git diff --check