### PR TITLE
feat(ops): add provider catalog drift alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 - `client_profiles` can now choose a default `routing_mode`, letting one client keep the global mode while another uses a different or custom mode by default
 - `GET /v1/models`, route previews, and runtime response headers now expose configured routing modes and resolved shortcut/mode metadata
+- `foundrygate-doctor`, onboarding reports, and a new provider-catalog API now surface curated model-drift and catalog-freshness alerts for configured providers
 
 ## v1.2.3 - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Runs locally on Linux, macOS, and Windows, with first-class workstation guidance
 - Strong operator visibility: `/health`, provider inventory, route previews, traces, stats, update checks, and dashboard views are built in, including per-client usage highlights.
 - Practical rollout controls: fallback chains, maintenance windows, rollout rings, provider scopes, and post-update verification gates are already there.
 - Copy/paste onboarding: OpenClaw, n8n, CLI, delegated-agent traffic, provider templates, and env starter files ship with the repo.
+- Curated provider-catalog checks catch stale model choices and drift before local configs quietly age out.
 
 ## Quickstart
 

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,16 @@ security:
   max_upload_bytes: 10485760
   max_header_value_chars: 160
 
+
+# ── Provider Catalog Checks ───────────────────────────────────────────────
+# Curated model guidance for known providers. This does not edit config.yaml
+# automatically; it only powers doctor/onboarding/API alerts.
+provider_catalog_check:
+  enabled: true
+  warn_on_untracked: true
+  warn_on_model_drift: true
+  max_catalog_age_days: 30
+
 # ── Provider Definitions ───────────────────────────────────────────────────
 #
 # Fields:

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,14 @@ Returns the loaded provider inventory plus the same capability-coverage summary 
 curl -fsS 'http://127.0.0.1:8090/api/providers?capability=image_generation'
 ```
 
+### `GET /api/provider-catalog`
+
+Returns the curated provider-catalog view with drift and freshness alerts for configured providers.
+
+```bash
+curl -fsS http://127.0.0.1:8090/api/provider-catalog
+```
+
 ### `GET /api/stats`
 
 Returns aggregate request counters, token usage, per-client breakdowns, aggregate client totals, client highlight summaries, cost data, and operator-action summaries.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,6 +61,23 @@ ClawRouter / BlockRun is different: its current public path is wallet-/x402-orie
 
 These settings drive the bounded JSON, upload, and routing-header behavior that ships in `v0.9.0+`.
 
+## Provider Catalog Checks
+
+`provider_catalog_check` controls a curated drift/freshness check for known providers.
+
+- `enabled`
+- `warn_on_untracked`
+- `warn_on_model_drift`
+- `max_catalog_age_days`
+
+This does not rewrite `config.yaml` automatically. It powers:
+
+- `foundrygate-doctor`
+- `foundrygate-onboarding-report`
+- `GET /api/provider-catalog`
+
+The intent is simple: if a configured provider drifts away from the curated model recommendation, or the catalog guidance has not been reviewed recently enough, operators get a visible warning before the setup silently rots.
+
 ## Provider Fields
 
 Each provider entry can include:

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -38,6 +38,12 @@ $EDITOR .env
 
 `foundrygate-onboarding-report` now includes concrete OpenClaw, n8n, and CLI quickstart hints plus a staged provider-rollout view. Use it after every provider or client change to keep the deployment understandable for the next operator as well.
 
+It now also includes provider-catalog alerts for:
+
+- configured models that drift away from the curated recommendation
+- providers that are not tracked yet
+- catalog entries that have gone stale and need review
+
 It also prints a client matrix:
 
 - which client profiles exist

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -1309,6 +1309,30 @@ def _normalize_security(data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _normalize_provider_catalog_check(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate provider-catalog drift/freshness checks."""
+    raw = data.get("provider_catalog_check") or {}
+    if raw in (None, ""):
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ConfigError("'provider_catalog_check' must be a mapping")
+
+    max_catalog_age_days = raw.get("max_catalog_age_days", 30)
+    if isinstance(max_catalog_age_days, bool) or not isinstance(max_catalog_age_days, int):
+        raise ConfigError("'provider_catalog_check.max_catalog_age_days' must be an integer")
+    if max_catalog_age_days < 0:
+        raise ConfigError("'provider_catalog_check.max_catalog_age_days' must be non-negative")
+
+    normalized = dict(data)
+    normalized["provider_catalog_check"] = {
+        "enabled": bool(raw.get("enabled", True)),
+        "warn_on_untracked": bool(raw.get("warn_on_untracked", True)),
+        "warn_on_model_drift": bool(raw.get("warn_on_model_drift", True)),
+        "max_catalog_age_days": max_catalog_age_days,
+    }
+    return normalized
+
+
 class Config:
     """Holds the parsed and expanded configuration."""
 
@@ -1446,6 +1470,18 @@ class Config:
             },
         )
 
+    @property
+    def provider_catalog_check(self) -> dict:
+        return self._data.get(
+            "provider_catalog_check",
+            {
+                "enabled": True,
+                "warn_on_untracked": True,
+                "warn_on_model_drift": True,
+                "max_catalog_age_days": 30,
+            },
+        )
+
     def provider(self, name: str) -> dict | None:
         return self.providers.get(name)
 
@@ -1478,16 +1514,18 @@ def load_config(path: str | Path | None = None) -> Config:
     with path.open() as f:
         raw = yaml.safe_load(f)
 
-    expanded = _normalize_security(
-        _normalize_auto_update(
-            _normalize_update_check(
-                _normalize_request_hooks(
-                    _validate_routing_mode_references(
-                        _normalize_model_shortcuts(
-                            _normalize_routing_modes(
-                                _normalize_client_profiles(
-                                    _normalize_routing_policies(
-                                        _normalize_providers(_walk_expand(raw))
+    expanded = _normalize_provider_catalog_check(
+        _normalize_security(
+            _normalize_auto_update(
+                _normalize_update_check(
+                    _normalize_request_hooks(
+                        _validate_routing_mode_references(
+                            _normalize_model_shortcuts(
+                                _normalize_routing_modes(
+                                    _normalize_client_profiles(
+                                        _normalize_routing_policies(
+                                            _normalize_providers(_walk_expand(raw))
+                                        )
                                     )
                                 )
                             )

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -27,6 +27,7 @@ from . import __version__
 from .config import Config, load_config
 from .hooks import AppliedHooks, HookExecutionError, RequestHookContext, apply_request_hooks
 from .metrics import MetricsStore, calc_cost
+from .provider_catalog import build_provider_catalog_report
 from .providers import ProviderBackend, ProviderError
 from .router import Router, RoutingDecision
 from .updates import (
@@ -1096,6 +1097,12 @@ async def provider_inventory(
         "providers": rows,
         "coverage": _build_capability_coverage(),
     }
+
+
+@app.get("/api/provider-catalog")
+async def provider_catalog():
+    """Return curated provider-catalog drift and freshness alerts."""
+    return build_provider_catalog_report(_config)
 
 
 @app.get("/v1/models")

--- a/foundrygate/onboarding.py
+++ b/foundrygate/onboarding.py
@@ -9,6 +9,7 @@ import yaml
 from dotenv import dotenv_values, load_dotenv
 
 from .config import load_config
+from .provider_catalog import build_provider_catalog_report
 
 
 def _env_path(env_file: str | Path | None = None) -> Path:
@@ -284,6 +285,7 @@ def build_onboarding_report(
         suggestions.append("Keep auto_update disabled until the provider and client set is stable.")
     provider_rollout = _build_provider_rollout(providers, list(config.fallback_chain))
     client_matrix = _build_client_matrix(client_profiles)
+    provider_catalog = build_provider_catalog_report(config)
     env_requirements = collect_provider_env_requirements(
         config_path=config_path,
         env_file=resolved_env,
@@ -623,6 +625,7 @@ def build_onboarding_report(
             "request_hook_count": len(request_hooks.get("hooks", [])),
         },
         "provider_rollout": provider_rollout,
+        "provider_catalog": provider_catalog,
         "operations": {
             "update_checks_enabled": bool(update_check.get("enabled")),
             "auto_update_enabled": bool(auto_update.get("enabled")),
@@ -639,6 +642,7 @@ def build_onboarding_validation(report: dict[str, Any]) -> dict[str, Any]:
     clients = report["clients"]
     routing = report["routing"]
     provider_rollout = report["provider_rollout"]
+    provider_catalog = report["provider_catalog"]
     env = report["env"]
 
     blockers: list[str] = []
@@ -664,6 +668,8 @@ def build_onboarding_validation(report: dict[str, Any]) -> dict[str, Any]:
             + ", ".join(item["name"] for item in providers["items"] if not item["ready"])
         )
     warnings.extend(provider_rollout["gaps"])
+    for alert in provider_catalog.get("alerts", []):
+        warnings.append(alert["message"])
 
     if not clients["profiles_enabled"]:
         warnings.append("Client profiles are disabled.")
@@ -693,6 +699,7 @@ def render_onboarding_report(report: dict[str, Any]) -> str:
     client_block = report["clients"]
     routing_block = report["routing"]
     rollout_block = report["provider_rollout"]
+    catalog_block = report["provider_catalog"]
     ops_block = report["operations"]
     integration_block = report["integrations"]
     preset_text = ", ".join(client_block["presets"]) if client_block["presets"] else "none"
@@ -761,6 +768,11 @@ def render_onboarding_report(report: dict[str, Any]) -> str:
             "- stage 2 secondary: " + (", ".join(rollout_block["stage_2_secondary"]) or "none"),
             "- stage 3 modality: " + (", ".join(rollout_block["stage_3_modality"]) or "none"),
             "",
+            "Provider catalog",
+            f"- tracked providers: {catalog_block['tracked_providers']} / "
+            f"{catalog_block['total_providers']}",
+            f"- alerts: {catalog_block['alert_count']}",
+            "",
             "Operations",
             f"- update checks: {ops_block['update_checks_enabled']}",
             f"- auto update: {ops_block['auto_update_enabled']}",
@@ -773,6 +785,10 @@ def render_onboarding_report(report: dict[str, Any]) -> str:
         for item in rollout_block["fallback_targets"]:
             readiness = "ready" if item["ready"] else "not ready"
             lines.append(f"  - {item['name']}: {readiness}")
+    if catalog_block["alerts"]:
+        lines.append("- catalog alerts:")
+        for alert in catalog_block["alerts"]:
+            lines.append(f"  - {alert['provider']}: {alert['message']}")
 
     lines.extend(["", "Integration quickstarts"])
     for client_name, data in integration_block.items():
@@ -796,6 +812,7 @@ def render_onboarding_report_markdown(report: dict[str, Any]) -> str:
     client_block = report["clients"]
     routing_block = report["routing"]
     rollout_block = report["provider_rollout"]
+    catalog_block = report["provider_catalog"]
     ops_block = report["operations"]
     integration_block = report["integrations"]
     env_block = report["env"]
@@ -868,6 +885,11 @@ def render_onboarding_report_markdown(report: dict[str, Any]) -> str:
             + (", ".join(f"`{item}`" for item in rollout_block["stage_2_secondary"]) or "none"),
             "- Stage 3 modality: "
             + (", ".join(f"`{item}`" for item in rollout_block["stage_3_modality"]) or "none"),
+            "",
+            "## Provider Catalog",
+            f"- Tracked providers: {catalog_block['tracked_providers']} / "
+            f"{catalog_block['total_providers']}",
+            f"- Alerts: {catalog_block['alert_count']}",
         ]
     )
 
@@ -876,6 +898,10 @@ def render_onboarding_report_markdown(report: dict[str, Any]) -> str:
         for item in rollout_block["fallback_targets"]:
             readiness = "ready" if item["ready"] else "not ready"
             lines.append(f"  - `{item['name']}`: {readiness}")
+    if catalog_block["alerts"]:
+        lines.append("- Catalog alerts:")
+        for alert in catalog_block["alerts"]:
+            lines.append(f"  - `{alert['provider']}`: {alert['message']}")
 
     lines.extend(
         [

--- a/foundrygate/provider_catalog.py
+++ b/foundrygate/provider_catalog.py
@@ -1,0 +1,177 @@
+"""Curated provider catalog and drift/freshness reporting."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from .config import Config
+
+_CATALOG: dict[str, dict[str, Any]] = {
+    "deepseek-chat": {
+        "recommended_model": "deepseek-chat",
+        "aliases": ["deepseek-chat"],
+        "track": "stable",
+        "notes": "Balanced DeepSeek chat default",
+        "last_reviewed": "2026-03-19",
+    },
+    "deepseek-reasoner": {
+        "recommended_model": "deepseek-reasoner",
+        "aliases": ["deepseek-reasoner"],
+        "track": "stable",
+        "notes": "Reasoning-heavy DeepSeek path",
+        "last_reviewed": "2026-03-19",
+    },
+    "gemini-flash-lite": {
+        "recommended_model": "gemini-2.5-flash-lite",
+        "aliases": ["gemini-2.5-flash-lite"],
+        "track": "stable",
+        "notes": "Cheap Gemini default",
+        "last_reviewed": "2026-03-19",
+    },
+    "gemini-flash": {
+        "recommended_model": "gemini-2.5-flash",
+        "aliases": ["gemini-2.5-flash"],
+        "track": "stable",
+        "notes": "Balanced Gemini default",
+        "last_reviewed": "2026-03-19",
+    },
+    "openrouter-fallback": {
+        "recommended_model": "openrouter/auto",
+        "aliases": ["openrouter/auto"],
+        "track": "stable",
+        "notes": "Marketplace fallback path",
+        "last_reviewed": "2026-03-19",
+    },
+    "kilocode": {
+        "recommended_model": "z-ai/glm-5:free",
+        "aliases": ["z-ai/glm-5:free"],
+        "track": "free",
+        "notes": "Current curated free-tier Kilo model",
+        "last_reviewed": "2026-03-19",
+    },
+    "blackbox-free": {
+        "recommended_model": "blackboxai/x-ai/grok-code-fast-1:free",
+        "aliases": ["blackboxai/x-ai/grok-code-fast-1:free"],
+        "track": "free",
+        "notes": "Current curated BLACKBOX free-tier model",
+        "last_reviewed": "2026-03-19",
+    },
+    "openai-gpt4o": {
+        "recommended_model": "gpt-4o",
+        "aliases": ["gpt-4o"],
+        "track": "stable",
+        "notes": "Balanced OpenAI multimodal path",
+        "last_reviewed": "2026-03-19",
+    },
+    "openai-images": {
+        "recommended_model": "gpt-image-1",
+        "aliases": ["gpt-image-1"],
+        "track": "stable",
+        "notes": "OpenAI image generation and editing",
+        "last_reviewed": "2026-03-19",
+    },
+    "anthropic-claude": {
+        "recommended_model": "claude-opus-4-6",
+        "aliases": ["claude-opus-4-6"],
+        "track": "stable",
+        "notes": "Quality-first Anthropic default",
+        "last_reviewed": "2026-03-19",
+    },
+}
+
+
+def build_provider_catalog_report(config: Config) -> dict[str, Any]:
+    """Compare configured providers against the curated provider catalog."""
+    check_cfg = config.provider_catalog_check
+    today = date.today()
+
+    tracked = 0
+    alerts: list[dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
+
+    for provider_name, provider in sorted(config.providers.items()):
+        model = str(provider.get("model", "") or "").strip()
+        catalog_entry = _CATALOG.get(provider_name)
+        item: dict[str, Any] = {
+            "provider": provider_name,
+            "configured_model": model,
+            "tracked": catalog_entry is not None,
+        }
+
+        if not catalog_entry:
+            item["status"] = "untracked"
+            items.append(item)
+            if check_cfg.get("enabled") and check_cfg.get("warn_on_untracked"):
+                alerts.append(
+                    {
+                        "provider": provider_name,
+                        "severity": "warning",
+                        "code": "untracked-provider",
+                        "message": (
+                            f"Provider '{provider_name}' is not in the curated provider "
+                            "catalog yet."
+                        ),
+                    }
+                )
+            continue
+
+        tracked += 1
+        recommended_model = str(catalog_entry["recommended_model"])
+        aliases = list(catalog_entry.get("aliases", []))
+        reviewed_on = date.fromisoformat(catalog_entry["last_reviewed"])
+        age_days = (today - reviewed_on).days
+
+        item.update(
+            {
+                "status": "tracked",
+                "recommended_model": recommended_model,
+                "track": catalog_entry.get("track", "stable"),
+                "notes": catalog_entry.get("notes", ""),
+                "last_reviewed": catalog_entry["last_reviewed"],
+                "catalog_age_days": age_days,
+                "model_matches_recommendation": model == recommended_model or model in aliases,
+            }
+        )
+        items.append(item)
+
+        if (
+            check_cfg.get("enabled")
+            and check_cfg.get("warn_on_model_drift")
+            and not item["model_matches_recommendation"]
+        ):
+            alerts.append(
+                {
+                    "provider": provider_name,
+                    "severity": "warning",
+                    "code": "model-drift",
+                    "message": (
+                        f"Provider '{provider_name}' uses model '{model}',"
+                        f" while the curated catalog recommends '{recommended_model}'."
+                    ),
+                    "recommended_model": recommended_model,
+                }
+            )
+
+        max_age_days = int(check_cfg.get("max_catalog_age_days", 30))
+        if check_cfg.get("enabled") and age_days > max_age_days:
+            alerts.append(
+                {
+                    "provider": provider_name,
+                    "severity": "notice",
+                    "code": "catalog-stale",
+                    "message": (
+                        f"Catalog guidance for provider '{provider_name}' is {age_days} days old."
+                    ),
+                    "last_reviewed": catalog_entry["last_reviewed"],
+                }
+            )
+
+    return {
+        "enabled": bool(check_cfg.get("enabled")),
+        "tracked_providers": tracked,
+        "total_providers": len(config.providers),
+        "alert_count": len(alerts),
+        "alerts": alerts,
+        "items": items,
+    }

--- a/scripts/foundrygate-doctor
+++ b/scripts/foundrygate-doctor
@@ -62,6 +62,8 @@ fi
 import os
 
 from foundrygate.onboarding import collect_provider_env_requirements
+from foundrygate.provider_catalog import build_provider_catalog_report
+from foundrygate.config import load_config
 
 requirements = collect_provider_env_requirements(
     config_path=os.environ.get("FOUNDRYGATE_CONFIG_FILE"),
@@ -72,6 +74,14 @@ for name in requirements["present"]:
     print(f"[ok] provider env present: {name}")
 for name in requirements["missing"]:
     print(f"[warn] provider env missing: {name}")
+
+config = load_config(os.environ.get("FOUNDRYGATE_CONFIG_FILE"))
+catalog = build_provider_catalog_report(config)
+if catalog["alert_count"] == 0:
+    print("[ok] provider catalog shows no model-drift or freshness alerts")
+else:
+    for alert in catalog["alerts"]:
+        print(f"[warn] provider catalog: {alert['message']}")
 PY
 
 if command -v curl >/dev/null 2>&1; then

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,6 +239,16 @@ def test_security_defaults_are_exposed():
     }
 
 
+def test_provider_catalog_check_defaults_are_exposed():
+    cfg = load_config(Path(__file__).parent.parent / "config.yaml")
+    assert cfg.provider_catalog_check == {
+        "enabled": True,
+        "warn_on_untracked": True,
+        "warn_on_model_drift": True,
+        "max_catalog_age_days": 30,
+    }
+
+
 def test_security_rejects_invalid_limit_values(tmp_path):
     path = tmp_path / "config.yaml"
     path.write_text(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -63,6 +63,7 @@ auto_update:
     assert report["clients"]["presets"] == ["openclaw"]
     assert report["integrations"]["openclaw"]["recommended"] is True
     assert report["integrations"]["n8n"]["recommended"] is False
+    assert report["provider_catalog"]["alert_count"] == 0
     assert (
         "Keep auto_update disabled until the provider and client set is stable."
         in report["suggestions"]
@@ -182,6 +183,51 @@ auto_update:
     assert "Client profiles are disabled." in validation["warnings"]
     assert "Request hooks are enabled but no hooks are configured." in validation["warnings"]
     assert "Status: blocked" in text
+
+
+def test_onboarding_report_includes_provider_catalog_alerts(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=sk-demo\n", encoding="utf-8")
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+fallback_chain:
+  - deepseek-chat
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "${DEEPSEEK_API_KEY}"
+    model: "deepseek-chat-v2"
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+  rules: []
+routing_policies:
+  enabled: false
+  rules: []
+request_hooks:
+  enabled: false
+  hooks: []
+update_check:
+  enabled: false
+auto_update:
+  enabled: false
+""".strip(),
+        encoding="utf-8",
+    )
+
+    report = build_onboarding_report(config_path=config_file, env_file=env_file)
+    validation = build_onboarding_validation(report)
+    text = render_onboarding_report(report)
+
+    assert report["provider_catalog"]["alert_count"] == 1
+    assert report["provider_catalog"]["alerts"][0]["code"] == "model-drift"
+    assert "Provider catalog" in text
+    assert any("curated catalog recommends" in warning for warning in validation["warnings"])
 
 
 def test_onboarding_validation_passes_for_ready_multi_provider_setup(tmp_path: Path):

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from foundrygate.config import load_config
+from foundrygate.provider_catalog import build_provider_catalog_report
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_provider_catalog_report_has_no_alert_for_aligned_model(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    report = build_provider_catalog_report(cfg)
+
+    assert report["tracked_providers"] == 1
+    assert report["alert_count"] == 0
+
+
+def test_provider_catalog_report_warns_on_model_drift(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat-v2"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    report = build_provider_catalog_report(cfg)
+
+    assert report["alert_count"] == 1
+    assert report["alerts"][0]["code"] == "model-drift"
+    assert report["alerts"][0]["recommended_model"] == "deepseek-chat"
+
+
+def test_provider_catalog_report_warns_on_untracked_provider(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  custom-provider:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "custom-model"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    report = build_provider_catalog_report(cfg)
+
+    assert report["tracked_providers"] == 0
+    assert report["alert_count"] == 1
+    assert report["alerts"][0]["code"] == "untracked-provider"

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -50,6 +50,7 @@ from foundrygate.main import (
     health,
     list_models,
     preview_image_route,
+    provider_catalog,
     provider_inventory,
 )
 from foundrygate.router import Router
@@ -408,6 +409,15 @@ async def test_list_models_includes_modes_and_shortcuts(preview_config):
     assert "premium" in model_ids
     assert "local" in model_ids
     assert "img" in model_ids
+
+
+@pytest.mark.asyncio
+async def test_provider_catalog_endpoint_reports_alerts(preview_config):
+    payload = await provider_catalog()
+
+    assert payload["total_providers"] >= 1
+    assert payload["alert_count"] >= 1
+    assert "alerts" in payload
 
 
 class TestRoutePreview:


### PR DESCRIPTION
## Summary
- add a curated provider catalog with freshness and model-drift checks
- surface catalog alerts in doctor, onboarding, and a new /api/provider-catalog endpoint
- add config controls for catalog freshness and drift warnings

## Notes
- replaces #94 after the original stacked PR was auto-closed during the #93 merge

## Testing
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_config.py tests/test_provider_catalog.py tests/test_route_introspection.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/config.py foundrygate/main.py foundrygate/onboarding.py foundrygate/provider_catalog.py tests/test_config.py tests/test_provider_catalog.py tests/test_route_introspection.py tests/test_onboarding.py README.md docs/API.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-doctor
- git diff --check