### PR TITLE
feat(catalog): add source metadata and offer tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 - `client_profiles` can now choose a default `routing_mode`, letting one client keep the global mode while another uses a different or custom mode by default
 - `GET /v1/models`, route previews, and runtime response headers now expose configured routing modes and resolved shortcut/mode metadata
-- `foundrygate-doctor`, onboarding reports, and a new provider-catalog API now surface curated model-drift and catalog-freshness alerts for configured providers
+- `foundrygate-doctor`, onboarding reports, and the provider-catalog API now surface curated model-drift, source-confidence, volatility, and catalog-freshness alerts for configured providers
+- Provider catalog entries now distinguish direct providers from aggregators and wallet routers, track auth modes such as `api_key`, `byok`, and `wallet_x402`, and keep community watchlists explicitly secondary to official sources
 
 ## v1.2.3 - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Runs locally on Linux, macOS, and Windows, with first-class workstation guidance
 - Strong operator visibility: `/health`, provider inventory, route previews, traces, stats, update checks, and dashboard views are built in, including per-client usage highlights.
 - Practical rollout controls: fallback chains, maintenance windows, rollout rings, provider scopes, and post-update verification gates are already there.
 - Copy/paste onboarding: OpenClaw, n8n, CLI, delegated-agent traffic, provider templates, and env starter files ship with the repo.
-- Curated provider-catalog checks catch stale model choices and drift before local configs quietly age out.
+- Curated provider-catalog checks catch stale model choices, volatile free-tier picks, and source-confidence gaps before local configs quietly age out.
 
 ## Quickstart
 

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,8 @@ provider_catalog_check:
   enabled: true
   warn_on_untracked: true
   warn_on_model_drift: true
+  warn_on_unofficial_sources: true
+  warn_on_volatile_offers: true
   max_catalog_age_days: 30
 
 # ── Provider Definitions ───────────────────────────────────────────────────

--- a/docs/API.md
+++ b/docs/API.md
@@ -97,7 +97,7 @@ curl -fsS 'http://127.0.0.1:8090/api/providers?capability=image_generation'
 
 ### `GET /api/provider-catalog`
 
-Returns the curated provider-catalog view with drift and freshness alerts for configured providers.
+Returns the curated provider-catalog view with drift, freshness, volatility, auth-mode, and source-confidence metadata for configured providers.
 
 ```bash
 curl -fsS http://127.0.0.1:8090/api/provider-catalog

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -68,6 +68,8 @@ These settings drive the bounded JSON, upload, and routing-header behavior that 
 - `enabled`
 - `warn_on_untracked`
 - `warn_on_model_drift`
+- `warn_on_unofficial_sources`
+- `warn_on_volatile_offers`
 - `max_catalog_age_days`
 
 This does not rewrite `config.yaml` automatically. It powers:
@@ -76,7 +78,23 @@ This does not rewrite `config.yaml` automatically. It powers:
 - `foundrygate-onboarding-report`
 - `GET /api/provider-catalog`
 
-The intent is simple: if a configured provider drifts away from the curated model recommendation, or the catalog guidance has not been reviewed recently enough, operators get a visible warning before the setup silently rots.
+The catalog now carries a little more structure than just one recommended model:
+
+- `provider_type` such as `direct`, `aggregator`, or `wallet-router`
+- `auth_modes` such as `api_key`, `byok`, or `wallet_x402`
+- `offer_track` such as `direct`, `free`, `byok`, or `marketplace`
+- `evidence_level` to distinguish fully official guidance from mixed/community-supported entries
+- `official_source_url` plus optional watchlist sources for faster re-review
+
+The intent is still simple: if a configured provider drifts away from the curated model recommendation, sits on a volatile free-tier track, or relies on less-than-fully-official guidance, operators get a visible warning before the setup silently rots.
+
+For fast-moving offers, the current preferred review inputs are:
+
+- official provider docs first
+- OpenRouter BYOK and provider-routing docs
+- Kilo gateway docs
+- BlockRun / ClawRouter docs for wallet-routed traffic
+- community watchlists such as `free-llm-api-resources` only as secondary signals
 
 ## Provider Fields
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -43,6 +43,8 @@ It now also includes provider-catalog alerts for:
 - configured models that drift away from the curated recommendation
 - providers that are not tracked yet
 - catalog entries that have gone stale and need review
+- volatile free-/BYOK-/marketplace-backed offer tracks
+- mixed/community-backed catalog entries that deserve faster review
 
 It also prints a client matrix:
 

--- a/foundrygate/config.py
+++ b/foundrygate/config.py
@@ -1328,6 +1328,8 @@ def _normalize_provider_catalog_check(data: dict[str, Any]) -> dict[str, Any]:
         "enabled": bool(raw.get("enabled", True)),
         "warn_on_untracked": bool(raw.get("warn_on_untracked", True)),
         "warn_on_model_drift": bool(raw.get("warn_on_model_drift", True)),
+        "warn_on_unofficial_sources": bool(raw.get("warn_on_unofficial_sources", True)),
+        "warn_on_volatile_offers": bool(raw.get("warn_on_volatile_offers", True)),
         "max_catalog_age_days": max_catalog_age_days,
     }
     return normalized

--- a/foundrygate/onboarding.py
+++ b/foundrygate/onboarding.py
@@ -785,6 +785,15 @@ def render_onboarding_report(report: dict[str, Any]) -> str:
         for item in rollout_block["fallback_targets"]:
             readiness = "ready" if item["ready"] else "not ready"
             lines.append(f"  - {item['name']}: {readiness}")
+    tracked_items = [item for item in catalog_block.get("items", []) if item.get("tracked")]
+    if tracked_items:
+        lines.append("- catalog inventory:")
+        for item in tracked_items:
+            lines.append(
+                "  - "
+                + f"{item['provider']}: {item['provider_type']} / {item['offer_track']} / "
+                + f"{item['evidence_level']} / {item['volatility']}"
+            )
     if catalog_block["alerts"]:
         lines.append("- catalog alerts:")
         for alert in catalog_block["alerts"]:
@@ -898,6 +907,15 @@ def render_onboarding_report_markdown(report: dict[str, Any]) -> str:
         for item in rollout_block["fallback_targets"]:
             readiness = "ready" if item["ready"] else "not ready"
             lines.append(f"  - `{item['name']}`: {readiness}")
+    tracked_items = [item for item in catalog_block.get("items", []) if item.get("tracked")]
+    if tracked_items:
+        lines.append("- Catalog inventory:")
+        for item in tracked_items:
+            lines.append(
+                "  - "
+                + f"`{item['provider']}`: {item['provider_type']} / {item['offer_track']} / "
+                + f"{item['evidence_level']} / {item['volatility']}"
+            )
     if catalog_block["alerts"]:
         lines.append("- Catalog alerts:")
         for alert in catalog_block["alerts"]:

--- a/foundrygate/provider_catalog.py
+++ b/foundrygate/provider_catalog.py
@@ -7,11 +7,23 @@ from typing import Any
 
 from .config import Config
 
+_COMMUNITY_WATCHLIST = {
+    "label": "free-llm-api-resources",
+    "url": "https://github.com/cheahjs/free-llm-api-resources",
+}
+
 _CATALOG: dict[str, dict[str, Any]] = {
     "deepseek-chat": {
         "recommended_model": "deepseek-chat",
         "aliases": ["deepseek-chat"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://api-docs.deepseek.com/",
+        "watch_sources": [],
         "notes": "Balanced DeepSeek chat default",
         "last_reviewed": "2026-03-19",
     },
@@ -19,6 +31,13 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "deepseek-reasoner",
         "aliases": ["deepseek-reasoner"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://api-docs.deepseek.com/",
+        "watch_sources": [],
         "notes": "Reasoning-heavy DeepSeek path",
         "last_reviewed": "2026-03-19",
     },
@@ -26,6 +45,13 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "gemini-2.5-flash-lite",
         "aliases": ["gemini-2.5-flash-lite"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://ai.google.dev/gemini-api/docs/models",
+        "watch_sources": [],
         "notes": "Cheap Gemini default",
         "last_reviewed": "2026-03-19",
     },
@@ -33,6 +59,13 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "gemini-2.5-flash",
         "aliases": ["gemini-2.5-flash"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://ai.google.dev/gemini-api/docs/models",
+        "watch_sources": [],
         "notes": "Balanced Gemini default",
         "last_reviewed": "2026-03-19",
     },
@@ -40,27 +73,58 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "openrouter/auto",
         "aliases": ["openrouter/auto"],
         "track": "stable",
-        "notes": "Marketplace fallback path",
+        "offer_track": "byok",
+        "provider_type": "aggregator",
+        "auth_modes": ["api_key", "byok"],
+        "volatility": "medium",
+        "evidence_level": "official",
+        "official_source_url": "https://openrouter.ai/docs/features/provider-routing",
+        "watch_sources": [],
+        "notes": "Marketplace fallback path with official provider routing and BYOK support",
         "last_reviewed": "2026-03-19",
     },
     "kilocode": {
         "recommended_model": "z-ai/glm-5:free",
         "aliases": ["z-ai/glm-5:free"],
         "track": "free",
-        "notes": "Current curated free-tier Kilo model",
+        "offer_track": "free",
+        "provider_type": "aggregator",
+        "auth_modes": ["api_key", "byok"],
+        "volatility": "high",
+        "evidence_level": "official",
+        "official_source_url": "https://kilo.ai/docs/gateway/models-and-providers",
+        "watch_sources": [_COMMUNITY_WATCHLIST],
+        "notes": "Current curated Kilo free-tier model; free and budget tracks can move quickly",
         "last_reviewed": "2026-03-19",
     },
     "blackbox-free": {
         "recommended_model": "blackboxai/x-ai/grok-code-fast-1:free",
         "aliases": ["blackboxai/x-ai/grok-code-fast-1:free"],
         "track": "free",
-        "notes": "Current curated BLACKBOX free-tier model",
+        "offer_track": "free",
+        "provider_type": "aggregator",
+        "auth_modes": ["api_key"],
+        "volatility": "high",
+        "evidence_level": "mixed",
+        "official_source_url": "https://docs.blackbox.ai/api-reference/authentication",
+        "watch_sources": [_COMMUNITY_WATCHLIST],
+        "notes": (
+            "Current curated BLACKBOX free-tier path; verify often because free "
+            "offerings can rotate"
+        ),
         "last_reviewed": "2026-03-19",
     },
     "openai-gpt4o": {
         "recommended_model": "gpt-4o",
         "aliases": ["gpt-4o"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://platform.openai.com/docs/models",
+        "watch_sources": [],
         "notes": "Balanced OpenAI multimodal path",
         "last_reviewed": "2026-03-19",
     },
@@ -68,6 +132,13 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "gpt-image-1",
         "aliases": ["gpt-image-1"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://platform.openai.com/docs/models",
+        "watch_sources": [],
         "notes": "OpenAI image generation and editing",
         "last_reviewed": "2026-03-19",
     },
@@ -75,10 +146,82 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "recommended_model": "claude-opus-4-6",
         "aliases": ["claude-opus-4-6"],
         "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
+        "watch_sources": [],
         "notes": "Quality-first Anthropic default",
         "last_reviewed": "2026-03-19",
     },
+    "clawrouter": {
+        "recommended_model": "auto",
+        "aliases": ["auto", "eco", "premium", "free"],
+        "track": "stable",
+        "offer_track": "marketplace",
+        "provider_type": "wallet-router",
+        "auth_modes": ["wallet_x402"],
+        "volatility": "medium",
+        "evidence_level": "official",
+        "official_source_url": "https://blockrun.ai/docs/products/routing/clawrouter",
+        "watch_sources": [],
+        "notes": "BlockRun ClawRouter uses wallet/x402 routing modes rather than a classic API key",
+        "last_reviewed": "2026-03-19",
+    },
 }
+
+
+def _alert(
+    *,
+    provider: str,
+    severity: str,
+    code: str,
+    message: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload = {
+        "provider": provider,
+        "severity": severity,
+        "code": code,
+        "message": message,
+    }
+    payload.update(extra)
+    return payload
+
+
+def _tracked_item(
+    provider_name: str,
+    provider: dict[str, Any],
+    catalog_entry: dict[str, Any],
+    *,
+    today: date,
+) -> dict[str, Any]:
+    model = str(provider.get("model", "") or "").strip()
+    recommended_model = str(catalog_entry["recommended_model"])
+    aliases = list(catalog_entry.get("aliases", []))
+    reviewed_on = date.fromisoformat(catalog_entry["last_reviewed"])
+    age_days = (today - reviewed_on).days
+    return {
+        "provider": provider_name,
+        "configured_model": model,
+        "tracked": True,
+        "status": "tracked",
+        "recommended_model": recommended_model,
+        "track": catalog_entry.get("track", "stable"),
+        "offer_track": catalog_entry.get("offer_track", "direct"),
+        "provider_type": catalog_entry.get("provider_type", "direct"),
+        "auth_modes": list(catalog_entry.get("auth_modes", ["api_key"])),
+        "volatility": catalog_entry.get("volatility", "low"),
+        "evidence_level": catalog_entry.get("evidence_level", "official"),
+        "official_source_url": catalog_entry.get("official_source_url", ""),
+        "watch_sources": list(catalog_entry.get("watch_sources", [])),
+        "notes": catalog_entry.get("notes", ""),
+        "last_reviewed": catalog_entry["last_reviewed"],
+        "catalog_age_days": age_days,
+        "model_matches_recommendation": model == recommended_model or model in aliases,
+    }
 
 
 def build_provider_catalog_report(config: Config) -> dict[str, Any]:
@@ -104,35 +247,20 @@ def build_provider_catalog_report(config: Config) -> dict[str, Any]:
             items.append(item)
             if check_cfg.get("enabled") and check_cfg.get("warn_on_untracked"):
                 alerts.append(
-                    {
-                        "provider": provider_name,
-                        "severity": "warning",
-                        "code": "untracked-provider",
-                        "message": (
+                    _alert(
+                        provider=provider_name,
+                        severity="warning",
+                        code="untracked-provider",
+                        message=(
                             f"Provider '{provider_name}' is not in the curated provider "
                             "catalog yet."
                         ),
-                    }
+                    )
                 )
             continue
 
         tracked += 1
-        recommended_model = str(catalog_entry["recommended_model"])
-        aliases = list(catalog_entry.get("aliases", []))
-        reviewed_on = date.fromisoformat(catalog_entry["last_reviewed"])
-        age_days = (today - reviewed_on).days
-
-        item.update(
-            {
-                "status": "tracked",
-                "recommended_model": recommended_model,
-                "track": catalog_entry.get("track", "stable"),
-                "notes": catalog_entry.get("notes", ""),
-                "last_reviewed": catalog_entry["last_reviewed"],
-                "catalog_age_days": age_days,
-                "model_matches_recommendation": model == recommended_model or model in aliases,
-            }
-        )
+        item = _tracked_item(provider_name, provider, catalog_entry, today=today)
         items.append(item)
 
         if (
@@ -141,30 +269,70 @@ def build_provider_catalog_report(config: Config) -> dict[str, Any]:
             and not item["model_matches_recommendation"]
         ):
             alerts.append(
-                {
-                    "provider": provider_name,
-                    "severity": "warning",
-                    "code": "model-drift",
-                    "message": (
-                        f"Provider '{provider_name}' uses model '{model}',"
-                        f" while the curated catalog recommends '{recommended_model}'."
+                _alert(
+                    provider=provider_name,
+                    severity="warning",
+                    code="model-drift",
+                    message=(
+                        f"Provider '{provider_name}' uses model '{model}', while the curated "
+                        f"catalog recommends '{item['recommended_model']}'."
                     ),
-                    "recommended_model": recommended_model,
-                }
+                    recommended_model=item["recommended_model"],
+                )
+            )
+
+        if (
+            check_cfg.get("enabled")
+            and check_cfg.get("warn_on_unofficial_sources")
+            and item["evidence_level"] != "official"
+        ):
+            alerts.append(
+                _alert(
+                    provider=provider_name,
+                    severity="notice",
+                    code="catalog-source-unofficial",
+                    message=(
+                        f"Catalog guidance for provider '{provider_name}' is backed by "
+                        f"{item['evidence_level']} evidence; review the configured "
+                        "model more often."
+                    ),
+                    official_source_url=item["official_source_url"],
+                )
+            )
+
+        if (
+            check_cfg.get("enabled")
+            and check_cfg.get("warn_on_volatile_offers")
+            and item["volatility"] in {"medium", "high"}
+            and item["offer_track"] in {"free", "credit", "byok", "marketplace"}
+        ):
+            alerts.append(
+                _alert(
+                    provider=provider_name,
+                    severity="notice",
+                    code="volatile-offer-configured",
+                    message=(
+                        f"Provider '{provider_name}' is on the '{item['offer_track']}' track "
+                        f"with {item['volatility']} volatility; limits, models, or "
+                        "pricing may change quickly."
+                    ),
+                    offer_track=item["offer_track"],
+                )
             )
 
         max_age_days = int(check_cfg.get("max_catalog_age_days", 30))
-        if check_cfg.get("enabled") and age_days > max_age_days:
+        if check_cfg.get("enabled") and item["catalog_age_days"] > max_age_days:
             alerts.append(
-                {
-                    "provider": provider_name,
-                    "severity": "notice",
-                    "code": "catalog-stale",
-                    "message": (
-                        f"Catalog guidance for provider '{provider_name}' is {age_days} days old."
+                _alert(
+                    provider=provider_name,
+                    severity="notice",
+                    code="catalog-stale",
+                    message=(
+                        f"Catalog guidance for provider '{provider_name}' is "
+                        f"{item['catalog_age_days']} days old."
                     ),
-                    "last_reviewed": catalog_entry["last_reviewed"],
-                }
+                    last_reviewed=item["last_reviewed"],
+                )
             )
 
     return {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -245,6 +245,8 @@ def test_provider_catalog_check_defaults_are_exposed():
         "enabled": True,
         "warn_on_untracked": True,
         "warn_on_model_drift": True,
+        "warn_on_unofficial_sources": True,
+        "warn_on_volatile_offers": True,
         "max_catalog_age_days": 30,
     }
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -37,6 +37,8 @@ metrics:
 
     assert report["tracked_providers"] == 1
     assert report["alert_count"] == 0
+    assert report["items"][0]["provider_type"] == "direct"
+    assert report["items"][0]["evidence_level"] == "official"
 
 
 def test_provider_catalog_report_warns_on_model_drift(tmp_path: Path):
@@ -93,3 +95,62 @@ metrics:
     assert report["tracked_providers"] == 0
     assert report["alert_count"] == 1
     assert report["alerts"][0]["code"] == "untracked-provider"
+
+
+def test_provider_catalog_report_warns_on_unofficial_and_volatile_tracks(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  blackbox-free:
+    backend: openai-compat
+    base_url: "https://api.blackbox.ai"
+    api_key: "secret"
+    model: "blackboxai/x-ai/grok-code-fast-1:free"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    report = build_provider_catalog_report(cfg)
+    codes = {alert["code"] for alert in report["alerts"]}
+
+    assert "catalog-source-unofficial" in codes
+    assert "volatile-offer-configured" in codes
+    assert report["items"][0]["offer_track"] == "free"
+    assert report["items"][0]["volatility"] == "high"
+
+
+def test_provider_catalog_report_exposes_wallet_router_metadata(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  clawrouter:
+    backend: openai-compat
+    base_url: "https://router.blockrun.ai/v1"
+    api_key: "wallet"
+    model: "auto"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    report = build_provider_catalog_report(cfg)
+
+    assert report["tracked_providers"] == 1
+    assert report["items"][0]["provider_type"] == "wallet-router"
+    assert report["items"][0]["auth_modes"] == ["wallet_x402"]
+    assert report["items"][0]["official_source_url"].startswith("https://blockrun.ai/")

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -418,6 +418,7 @@ async def test_provider_catalog_endpoint_reports_alerts(preview_config):
     assert payload["total_providers"] >= 1
     assert payload["alert_count"] >= 1
     assert "alerts" in payload
+    assert "items" in payload
 
 
 class TestRoutePreview:


### PR DESCRIPTION
## Summary
- expand provider catalog entries with provider type, auth modes, offer tracks, volatility, and source metadata
- distinguish official guidance from mixed/community-backed entries and surface new catalog alerts
- carry the richer catalog metadata into onboarding and documentation

## Notes
- treats community watchlists such as free-llm-api-resources as secondary signals, not the source of truth
- models OpenRouter and Kilo as aggregators and ClawRouter as a wallet/x402 router

## Testing
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall foundrygate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_config.py tests/test_provider_catalog.py tests/test_route_introspection.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/config.py foundrygate/main.py foundrygate/onboarding.py foundrygate/provider_catalog.py tests/test_config.py tests/test_provider_catalog.py tests/test_route_introspection.py tests/test_onboarding.py README.md docs/API.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-doctor
- git diff --check