### PR TITLE
feat(wizard): add update suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added a first `foundrygate-config-wizard` helper that suggests an initial `config.yaml` from the API keys already present in `.env`
 - Added first-class `routing_modes` and `model_shortcuts` config blocks so virtual model ids such as `auto`, `eco`, `premium`, `free`, or custom names can participate in routing
 - Added wizard candidate listing and conservative config merging so operators can select multiple provider candidates during first setup or later catalog-driven updates
+- Added config-aware wizard update suggestions so existing installs can see `recommended_add`, `recommended_replace`, and `recommended_keep` groups before applying provider changes
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To review and selectively adopt multiple candidates during first setup or a late
 
 ```bash
 ./scripts/foundrygate-config-wizard --purpose free --client n8n --list-candidates
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n
 ./scripts/foundrygate-config-wizard --purpose free --client n8n \
   --select kilocode,blackbox-free,gemini-flash-lite > config.yaml
 ./scripts/foundrygate-config-wizard --current-config config.yaml --merge-existing \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,13 +100,14 @@ The config wizard can use this catalog metadata during first setup and later upd
 
 ```bash
 ./scripts/foundrygate-config-wizard --purpose general --client generic --list-candidates
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose general --client generic
 ./scripts/foundrygate-config-wizard --purpose free --client n8n \
   --select kilocode,blackbox-free,gemini-flash-lite > config.yaml
 ./scripts/foundrygate-config-wizard --current-config config.yaml --merge-existing \
   --select openrouter-fallback --write config.yaml
 ```
 
-That gives operators one purpose-aware candidate list, the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.
+That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.
 
 ## Provider Fields
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -42,6 +42,7 @@ Useful flows:
 
 ```bash
 ./scripts/foundrygate-config-wizard --purpose coding --client opencode --list-candidates
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode
 ./scripts/foundrygate-config-wizard --purpose coding --client opencode \
   --select deepseek-chat,deepseek-reasoner,anthropic-claude > config.yaml
 ./scripts/foundrygate-config-wizard --current-config config.yaml --merge-existing \

--- a/foundrygate/wizard.py
+++ b/foundrygate/wizard.py
@@ -259,6 +259,24 @@ def _load_existing_provider_names(config_path: str | Path | None = None) -> set[
     return set(providers.keys())
 
 
+def _load_existing_provider_models(config_path: str | Path | None = None) -> dict[str, str]:
+    if config_path is None:
+        return {}
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    providers = raw.get("providers") or {}
+    if not isinstance(providers, dict):
+        return {}
+    result: dict[str, str] = {}
+    for name, provider in providers.items():
+        if isinstance(provider, dict):
+            result[str(name)] = str(provider.get("model", "") or "").strip()
+    return result
+
+
 def detect_wizard_providers(*, env_file: str | Path | None = None) -> list[str]:
     """Return provider names that can be configured from the current env file."""
     env_values = _load_env_values(env_file)
@@ -401,6 +419,50 @@ def list_provider_candidates(
             }
         )
     return rows
+
+
+def build_update_suggestions(
+    *,
+    env_file: str | Path | None = None,
+    purpose: str = "general",
+    client: str = "generic",
+    config_path: str | Path | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Return config-aware provider suggestions grouped by add/replace/keep."""
+    candidates = list_provider_candidates(
+        env_file=env_file,
+        purpose=purpose,
+        client=client,
+        config_path=config_path,
+    )
+    existing_models = _load_existing_provider_models(config_path)
+    recommended_add: list[dict[str, Any]] = []
+    recommended_replace: list[dict[str, Any]] = []
+    recommended_keep: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        provider = candidate["provider"]
+        entry = dict(candidate)
+        if not candidate["configured"]:
+            if candidate["selected_by_default"]:
+                entry["reason"] = "preferred by current purpose/client recommendation"
+                recommended_add.append(entry)
+            continue
+
+        configured_model = existing_models.get(provider, "")
+        if configured_model and configured_model != candidate["model"]:
+            entry["configured_model"] = configured_model
+            entry["reason"] = "configured model differs from the current curated default"
+            recommended_replace.append(entry)
+        else:
+            entry["reason"] = "already configured and aligned with the current recommendation"
+            recommended_keep.append(entry)
+
+    return {
+        "recommended_add": recommended_add,
+        "recommended_replace": recommended_replace,
+        "recommended_keep": recommended_keep,
+    }
 
 
 def _resolve_selected_providers(

--- a/scripts/foundrygate-config-wizard
+++ b/scripts/foundrygate-config-wizard
@@ -85,6 +85,7 @@ import yaml
 
 from foundrygate.wizard import (
     build_initial_config,
+    build_update_suggestions,
     list_provider_candidates,
     merge_initial_config,
     render_initial_config_yaml,
@@ -106,6 +107,22 @@ if list_candidates_only:
         "purpose": purpose,
         "client": client,
         "candidates": list_provider_candidates(
+            env_file=env_file,
+            purpose=purpose,
+            client=client,
+            config_path=current_config,
+        ),
+    }
+    rendered = (
+        json.dumps(payload, indent=2)
+        if render_format == "json"
+        else yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    )
+elif current_config is not None and not selected:
+    payload = {
+        "purpose": purpose,
+        "client": client,
+        "suggestions": build_update_suggestions(
             env_file=env_file,
             purpose=purpose,
             client=client,

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from foundrygate.wizard import (
     build_initial_config,
+    build_update_suggestions,
     detect_wizard_providers,
     list_provider_candidates,
     merge_initial_config,
@@ -196,3 +197,55 @@ fallback_chain: []
 
     assert "kilocode:" in rendered
     assert "warn_on_volatile_offers: true" in rendered
+
+
+def test_build_update_suggestions_returns_add_replace_keep_groups(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "DEEPSEEK_API_KEY=sk-demo",
+                "OPENROUTER_API_KEY=or-demo",
+                "KILOCODE_API_KEY=kilo-demo",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "${DEEPSEEK_API_KEY}"
+    model: "deepseek-chat"
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "${OPENROUTER_API_KEY}"
+    model: "openrouter/wrong"
+fallback_chain:
+  - deepseek-chat
+  - openrouter-fallback
+""",
+        encoding="utf-8",
+    )
+
+    suggestions = build_update_suggestions(
+        env_file=env_file,
+        purpose="free",
+        client="generic",
+        config_path=config_path,
+    )
+
+    add_names = {item["provider"] for item in suggestions["recommended_add"]}
+    replace_names = {item["provider"] for item in suggestions["recommended_replace"]}
+    keep_names = {item["provider"] for item in suggestions["recommended_keep"]}
+
+    assert "kilocode" in add_names
+    assert "openrouter-fallback" in replace_names
+    assert "deepseek-chat" in keep_names


### PR DESCRIPTION
## Summary
- add config-aware wizard suggestions grouped as recommended_add, recommended_replace, and recommended_keep
- let the wizard show update suggestions when a current config is provided without forcing an immediate merge
- document the review-then-select flow for later provider updates

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_config.py tests/test_provider_catalog.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/wizard.py tests/test_wizard.py README.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-config-wizard
- git diff --check