### PR TITLE
feat(wizard): suggest client mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added first-class `routing_modes` and `model_shortcuts` config blocks so virtual model ids such as `auto`, `eco`, `premium`, `free`, or custom names can participate in routing
 - Added wizard candidate listing and conservative config merging so operators can select multiple provider candidates during first setup or later catalog-driven updates
 - Added config-aware wizard update suggestions so existing installs can see `recommended_add`, `recommended_replace`, and `recommended_keep` groups before applying provider changes
+- Added wizard `recommended_mode_changes` suggestions so existing client profiles can be nudged toward the current purpose-aware routing defaults without silently rewriting them
 
 ### Changed
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,7 +107,7 @@ The config wizard can use this catalog metadata during first setup and later upd
   --select openrouter-fallback --write config.yaml
 ```
 
-That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.
+That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`, `recommended_mode_changes`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.
 
 ## Provider Fields
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -49,6 +49,8 @@ Useful flows:
   --select openrouter-fallback,kilocode --write config.yaml
 ```
 
+When a current config is present, the suggestion output now also flags client-profile mode deltas such as `recommended_mode_changes`, so you can see when `n8n`, `openclaw`, or `opencode` probably want a different default mode for the selected purpose.
+
 `foundrygate-onboarding-report` now includes concrete OpenClaw, n8n, and CLI quickstart hints plus a staged provider-rollout view. Use it after every provider or client change to keep the deployment understandable for the next operator as well.
 
 It now also includes provider-catalog alerts for:

--- a/foundrygate/wizard.py
+++ b/foundrygate/wizard.py
@@ -277,6 +277,27 @@ def _load_existing_provider_models(config_path: str | Path | None = None) -> dic
     return result
 
 
+def _load_existing_profile_modes(config_path: str | Path | None = None) -> dict[str, str]:
+    if config_path is None:
+        return {}
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    client_profiles = raw.get("client_profiles") or {}
+    if not isinstance(client_profiles, dict):
+        return {}
+    profiles = client_profiles.get("profiles") or {}
+    if not isinstance(profiles, dict):
+        return {}
+    result: dict[str, str] = {}
+    for name, profile in profiles.items():
+        if isinstance(profile, dict) and profile.get("routing_mode"):
+            result[str(name)] = str(profile.get("routing_mode"))
+    return result
+
+
 def detect_wizard_providers(*, env_file: str | Path | None = None) -> list[str]:
     """Return provider names that can be configured from the current env file."""
     env_values = _load_env_values(env_file)
@@ -375,6 +396,22 @@ def _preferred_provider_set(available: list[str], *, purpose: str, client: str) 
     return selected
 
 
+def _suggested_profile_modes(*, purpose: str) -> dict[str, str]:
+    default_mode = {
+        "general": "auto",
+        "coding": "auto",
+        "quality": "premium",
+        "free": "free",
+    }[purpose]
+    return {
+        "generic": default_mode,
+        "openclaw": "auto",
+        "cli": "auto",
+        "opencode": "auto",
+        "n8n": "eco" if purpose != "quality" else "auto",
+    }
+
+
 def list_provider_candidates(
     *,
     env_file: str | Path | None = None,
@@ -436,9 +473,11 @@ def build_update_suggestions(
         config_path=config_path,
     )
     existing_models = _load_existing_provider_models(config_path)
+    existing_profile_modes = _load_existing_profile_modes(config_path)
     recommended_add: list[dict[str, Any]] = []
     recommended_replace: list[dict[str, Any]] = []
     recommended_keep: list[dict[str, Any]] = []
+    recommended_mode_changes: list[dict[str, Any]] = []
 
     for candidate in candidates:
         provider = candidate["provider"]
@@ -458,10 +497,23 @@ def build_update_suggestions(
             entry["reason"] = "already configured and aligned with the current recommendation"
             recommended_keep.append(entry)
 
+    for profile, suggested_mode in _suggested_profile_modes(purpose=purpose).items():
+        current_mode = existing_profile_modes.get(profile)
+        if current_mode and current_mode != suggested_mode:
+            recommended_mode_changes.append(
+                {
+                    "profile": profile,
+                    "configured_mode": current_mode,
+                    "suggested_mode": suggested_mode,
+                    "reason": "profile mode differs from the current purpose-aware wizard default",
+                }
+            )
+
     return {
         "recommended_add": recommended_add,
         "recommended_replace": recommended_replace,
         "recommended_keep": recommended_keep,
+        "recommended_mode_changes": recommended_mode_changes,
     }
 
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -231,6 +231,14 @@ providers:
 fallback_chain:
   - deepseek-chat
   - openrouter-fallback
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic:
+      routing_mode: premium
+    n8n:
+      routing_mode: premium
 """,
         encoding="utf-8",
     )
@@ -245,7 +253,10 @@ fallback_chain:
     add_names = {item["provider"] for item in suggestions["recommended_add"]}
     replace_names = {item["provider"] for item in suggestions["recommended_replace"]}
     keep_names = {item["provider"] for item in suggestions["recommended_keep"]}
+    mode_profiles = {item["profile"] for item in suggestions["recommended_mode_changes"]}
 
     assert "kilocode" in add_names
     assert "openrouter-fallback" in replace_names
     assert "deepseek-chat" in keep_names
+    assert "generic" in mode_profiles
+    assert "n8n" in mode_profiles


### PR DESCRIPTION
## Summary
- extend wizard update suggestions with recommended_mode_changes for existing client profiles
- compare configured client routing modes against purpose-aware defaults
- document the new client-mode suggestion flow in onboarding/config docs

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_config.py tests/test_provider_catalog.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/wizard.py tests/test_wizard.py docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-config-wizard
- git diff --check