### PR TITLE
feat(wizard): add dry-run change summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added config-aware wizard update suggestions so existing installs can see `recommended_add`, `recommended_replace`, and `recommended_keep` groups before applying provider changes
 - Added wizard `recommended_mode_changes` suggestions so existing client profiles can be nudged toward the current purpose-aware routing defaults without silently rewriting them
 - Added an `apply suggestions` wizard flow so selected provider and client-mode recommendations can be merged into an existing config without manual copy/paste
+- Added a wizard dry-run change summary so operators can preview added providers, model replacements, fallback changes, and client-mode changes before writing config updates
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ To review and selectively adopt multiple candidates during first setup or a late
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles n8n --write config.yaml
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles n8n --dry-run-summary
 ```
 
 If you prefer a packaged or service-driven install, jump to [Deployment](#deployment) or the fuller [Operations guide](./docs/OPERATIONS.md).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,6 +108,9 @@ The config wizard can use this catalog metadata during first setup and later upd
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles n8n --write config.yaml
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles n8n --dry-run-summary
 ```
 
 That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`, `recommended_mode_changes`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -50,6 +50,9 @@ Useful flows:
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles opencode --write config.yaml
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles opencode --dry-run-summary
 ```
 
 When a current config is present, the suggestion output now also flags client-profile mode deltas such as `recommended_mode_changes`, so you can see when `n8n`, `openclaw`, or `opencode` probably want a different default mode for the selected purpose.

--- a/foundrygate/wizard.py
+++ b/foundrygate/wizard.py
@@ -298,6 +298,15 @@ def _load_existing_profile_modes(config_path: str | Path | None = None) -> dict[
     return result
 
 
+def _load_existing_config(config_path: str | Path) -> dict[str, Any]:
+    path = Path(config_path)
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("Existing config must be a YAML mapping")
+    return raw
+
+
 def detect_wizard_providers(*, env_file: str | Path | None = None) -> list[str]:
     """Return provider names that can be configured from the current env file."""
     env_values = _load_env_values(env_file)
@@ -577,6 +586,57 @@ def apply_update_suggestions(
             profiles[item["profile"]] = profile
 
     return merged
+
+
+def build_config_change_summary(
+    *,
+    config_path: str | Path,
+    updated_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Return one compact summary of config changes."""
+    existing = _load_existing_config(config_path)
+    existing_providers = existing.get("providers") or {}
+    updated_providers = updated_config.get("providers") or {}
+
+    added_providers = sorted(name for name in updated_providers if name not in existing_providers)
+    replaced_models: list[dict[str, str]] = []
+    for name, provider in updated_providers.items():
+        if name not in existing_providers:
+            continue
+        current = existing_providers.get(name) or {}
+        if not isinstance(provider, dict) or not isinstance(current, dict):
+            continue
+        from_model = str(current.get("model", "") or "").strip()
+        to_model = str(provider.get("model", "") or "").strip()
+        if from_model and to_model and from_model != to_model:
+            replaced_models.append(
+                {"provider": name, "from_model": from_model, "to_model": to_model}
+            )
+
+    existing_profiles = ((existing.get("client_profiles") or {}).get("profiles")) or {}
+    updated_profiles = ((updated_config.get("client_profiles") or {}).get("profiles")) or {}
+    changed_profile_modes: list[dict[str, str]] = []
+    for name, profile in updated_profiles.items():
+        current = existing_profiles.get(name) or {}
+        if not isinstance(profile, dict) or not isinstance(current, dict):
+            continue
+        from_mode = str(current.get("routing_mode", "") or "").strip()
+        to_mode = str(profile.get("routing_mode", "") or "").strip()
+        if from_mode and to_mode and from_mode != to_mode:
+            changed_profile_modes.append(
+                {"profile": name, "from_mode": from_mode, "to_mode": to_mode}
+            )
+
+    existing_fallback = list(existing.get("fallback_chain", []) or [])
+    updated_fallback = list(updated_config.get("fallback_chain", []) or [])
+    fallback_additions = [name for name in updated_fallback if name not in existing_fallback]
+
+    return {
+        "added_providers": added_providers,
+        "replaced_models": replaced_models,
+        "changed_profile_modes": changed_profile_modes,
+        "fallback_additions": fallback_additions,
+    }
 
 
 def _resolve_selected_providers(

--- a/scripts/foundrygate-config-wizard
+++ b/scripts/foundrygate-config-wizard
@@ -14,6 +14,7 @@ write_path=""
 selected_csv=""
 apply_groups_csv=""
 profile_csv=""
+dry_run_summary="false"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -52,6 +53,10 @@ while [ $# -gt 0 ]; do
         apply_groups_csv="$2"
       fi
       shift 2
+      ;;
+    --dry-run-summary)
+      dry_run_summary="true"
+      shift
       ;;
     --current-config)
       current_config="$2"
@@ -95,6 +100,7 @@ export FOUNDRYGATE_WIZARD_WRITE_PATH="$write_path"
 export FOUNDRYGATE_WIZARD_SELECTED="$selected_csv"
 export FOUNDRYGATE_WIZARD_APPLY_GROUPS="$apply_groups_csv"
 export FOUNDRYGATE_WIZARD_SELECTED_PROFILES="$profile_csv"
+export FOUNDRYGATE_WIZARD_DRY_RUN_SUMMARY="$dry_run_summary"
 
 "$python_bin" - <<'PY'
 import json
@@ -105,11 +111,11 @@ import yaml
 
 from foundrygate.wizard import (
     apply_update_suggestions,
+    build_config_change_summary,
     build_initial_config,
     build_update_suggestions,
     list_provider_candidates,
     merge_initial_config,
-    render_initial_config_yaml,
 )
 
 env_file = os.environ["FOUNDRYGATE_WIZARD_ENV"]
@@ -126,6 +132,7 @@ apply_groups_raw = os.environ["FOUNDRYGATE_WIZARD_APPLY_GROUPS"]
 apply_groups = [item.strip() for item in apply_groups_raw.split(",") if item.strip()]
 selected_profiles_raw = os.environ["FOUNDRYGATE_WIZARD_SELECTED_PROFILES"]
 selected_profiles = [item.strip() for item in selected_profiles_raw.split(",") if item.strip()]
+dry_run_summary = os.environ["FOUNDRYGATE_WIZARD_DRY_RUN_SUMMARY"] == "true"
 
 if list_candidates_only:
     payload = {
@@ -169,6 +176,11 @@ elif current_config is not None and apply_groups:
         selected_providers=selected or None,
         selected_profiles=selected_profiles or None,
     )
+    if dry_run_summary:
+        payload = build_config_change_summary(
+            config_path=current_config,
+            updated_config=payload,
+        )
     rendered = (
         json.dumps(payload, indent=2)
         if render_format == "json"
@@ -186,17 +198,15 @@ else:
         if merge_existing and current_config is not None
         else suggestion
     )
+    if dry_run_summary and current_config is not None:
+        payload = build_config_change_summary(
+            config_path=current_config,
+            updated_config=payload,
+        )
     rendered = (
         json.dumps(payload, indent=2)
         if render_format == "json"
-        else render_initial_config_yaml(
-            env_file=env_file,
-            purpose=purpose,
-            client=client,
-            selected_providers=selected or None,
-            config_path=current_config,
-            merge_existing=merge_existing,
-        )
+        else yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
     )
 
 if write_path:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from foundrygate.wizard import (
     apply_update_suggestions,
+    build_config_change_summary,
     build_initial_config,
     build_update_suggestions,
     detect_wizard_providers,
@@ -321,3 +322,65 @@ fallback_chain:
     assert merged["providers"]["openrouter-fallback"]["model"] == "openrouter/auto"
     assert merged["client_profiles"]["profiles"]["n8n"]["routing_mode"] == "eco"
     assert merged["client_profiles"]["profiles"]["generic"]["routing_mode"] == "premium"
+
+
+def test_build_config_change_summary_reports_added_replaced_and_mode_changes(tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "${DEEPSEEK_API_KEY}"
+    model: "deepseek-chat"
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    n8n:
+      routing_mode: premium
+fallback_chain:
+  - deepseek-chat
+""",
+        encoding="utf-8",
+    )
+
+    updated = {
+        "providers": {
+            "deepseek-chat": {
+                "model": "deepseek-chat-v2",
+            },
+            "kilocode": {
+                "model": "z-ai/glm-5:free",
+            },
+        },
+        "client_profiles": {
+            "profiles": {
+                "n8n": {"routing_mode": "eco"},
+            }
+        },
+        "fallback_chain": ["deepseek-chat", "kilocode"],
+    }
+
+    summary = build_config_change_summary(config_path=config_path, updated_config=updated)
+
+    assert summary["added_providers"] == ["kilocode"]
+    assert summary["replaced_models"] == [
+        {
+            "provider": "deepseek-chat",
+            "from_model": "deepseek-chat",
+            "to_model": "deepseek-chat-v2",
+        }
+    ]
+    assert summary["changed_profile_modes"] == [
+        {
+            "profile": "n8n",
+            "from_mode": "premium",
+            "to_mode": "eco",
+        }
+    ]
+    assert summary["fallback_additions"] == ["kilocode"]


### PR DESCRIPTION
## Summary
- add a dry-run change summary for wizard-driven config updates
- preview added providers, model replacements, fallback additions, and client-mode changes before writing
- document the new preview flow in README and onboarding/config docs

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_config.py tests/test_provider_catalog.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/wizard.py tests/test_wizard.py README.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-config-wizard
- git diff --check