### PR TITLE
feat(wizard): add config backup snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added wizard `recommended_mode_changes` suggestions so existing client profiles can be nudged toward the current purpose-aware routing defaults without silently rewriting them
 - Added an `apply suggestions` wizard flow so selected provider and client-mode recommendations can be merged into an existing config without manual copy/paste
 - Added a wizard dry-run change summary so operators can preview added providers, model replacements, fallback changes, and client-mode changes before writing config updates
+- Added optional wizard write-backup snapshots so config updates can keep a local pre-change copy before overwriting `config.yaml`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To review and selectively adopt multiple candidates during first setup or a late
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles n8n --dry-run-summary
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles n8n \
+  --write config.yaml --write-backup --backup-suffix .before-wizard
 ```
 
 If you prefer a packaged or service-driven install, jump to [Deployment](#deployment) or the fuller [Operations guide](./docs/OPERATIONS.md).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -111,6 +111,10 @@ The config wizard can use this catalog metadata during first setup and later upd
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles n8n --dry-run-summary
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles n8n \
+  --write config.yaml --write-backup --backup-suffix .before-wizard
 ```
 
 That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`, `recommended_mode_changes`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -53,6 +53,10 @@ Useful flows:
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode \
   --apply recommended_add,recommended_replace,recommended_mode_changes \
   --select kilocode,openrouter-fallback --select-profiles opencode --dry-run-summary
+./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode \
+  --apply recommended_add,recommended_replace,recommended_mode_changes \
+  --select kilocode,openrouter-fallback --select-profiles opencode \
+  --write config.yaml --write-backup --backup-suffix .before-wizard
 ```
 
 When a current config is present, the suggestion output now also flags client-profile mode deltas such as `recommended_mode_changes`, so you can see when `n8n`, `openclaw`, or `opencode` probably want a different default mode for the selected purpose.

--- a/foundrygate/wizard.py
+++ b/foundrygate/wizard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -636,6 +637,32 @@ def build_config_change_summary(
         "replaced_models": replaced_models,
         "changed_profile_modes": changed_profile_modes,
         "fallback_additions": fallback_additions,
+    }
+
+
+def write_output_file(
+    *,
+    output_path: str | Path,
+    rendered: str,
+    write_backup: bool = False,
+    backup_suffix: str = ".bak",
+) -> dict[str, str | bool]:
+    """Write one rendered payload to disk, optionally snapshotting the previous file."""
+    path = Path(output_path)
+    backup_path = ""
+
+    if write_backup and path.exists():
+        if not backup_suffix:
+            raise ValueError("backup_suffix must not be empty when write_backup is enabled")
+        backup_path = str(path.parent / f"{path.name}{backup_suffix}")
+        shutil.copy2(path, backup_path)
+
+    payload = rendered if rendered.endswith("\n") else rendered + "\n"
+    path.write_text(payload, encoding="utf-8")
+    return {
+        "output_path": str(path),
+        "backup_created": bool(backup_path),
+        "backup_path": backup_path,
     }
 
 

--- a/scripts/foundrygate-config-wizard
+++ b/scripts/foundrygate-config-wizard
@@ -15,6 +15,8 @@ selected_csv=""
 apply_groups_csv=""
 profile_csv=""
 dry_run_summary="false"
+write_backup="false"
+backup_suffix=".bak"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -57,6 +59,14 @@ while [ $# -gt 0 ]; do
     --dry-run-summary)
       dry_run_summary="true"
       shift
+      ;;
+    --write-backup)
+      write_backup="true"
+      shift
+      ;;
+    --backup-suffix)
+      backup_suffix="$2"
+      shift 2
       ;;
     --current-config)
       current_config="$2"
@@ -101,6 +111,8 @@ export FOUNDRYGATE_WIZARD_SELECTED="$selected_csv"
 export FOUNDRYGATE_WIZARD_APPLY_GROUPS="$apply_groups_csv"
 export FOUNDRYGATE_WIZARD_SELECTED_PROFILES="$profile_csv"
 export FOUNDRYGATE_WIZARD_DRY_RUN_SUMMARY="$dry_run_summary"
+export FOUNDRYGATE_WIZARD_WRITE_BACKUP="$write_backup"
+export FOUNDRYGATE_WIZARD_BACKUP_SUFFIX="$backup_suffix"
 
 "$python_bin" - <<'PY'
 import json
@@ -116,6 +128,7 @@ from foundrygate.wizard import (
     build_update_suggestions,
     list_provider_candidates,
     merge_initial_config,
+    write_output_file,
 )
 
 env_file = os.environ["FOUNDRYGATE_WIZARD_ENV"]
@@ -133,6 +146,8 @@ apply_groups = [item.strip() for item in apply_groups_raw.split(",") if item.str
 selected_profiles_raw = os.environ["FOUNDRYGATE_WIZARD_SELECTED_PROFILES"]
 selected_profiles = [item.strip() for item in selected_profiles_raw.split(",") if item.strip()]
 dry_run_summary = os.environ["FOUNDRYGATE_WIZARD_DRY_RUN_SUMMARY"] == "true"
+write_backup = os.environ["FOUNDRYGATE_WIZARD_WRITE_BACKUP"] == "true"
+backup_suffix = os.environ["FOUNDRYGATE_WIZARD_BACKUP_SUFFIX"]
 
 if list_candidates_only:
     payload = {
@@ -210,7 +225,12 @@ else:
     )
 
 if write_path:
-    Path(write_path).write_text(rendered if rendered.endswith("\n") else rendered + "\n", encoding="utf-8")
+    write_output_file(
+        output_path=write_path,
+        rendered=rendered,
+        write_backup=write_backup,
+        backup_suffix=backup_suffix,
+    )
 else:
     print(rendered, end="" if rendered.endswith("\n") else "\n")
 PY

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -11,6 +11,7 @@ from foundrygate.wizard import (
     list_provider_candidates,
     merge_initial_config,
     render_initial_config_yaml,
+    write_output_file,
 )
 
 
@@ -384,3 +385,20 @@ fallback_chain:
         }
     ]
     assert summary["fallback_additions"] == ["kilocode"]
+
+
+def test_write_output_file_can_create_backup_snapshot(tmp_path: Path):
+    output_path = tmp_path / "config.yaml"
+    output_path.write_text("old: config\n", encoding="utf-8")
+
+    result = write_output_file(
+        output_path=output_path,
+        rendered="new: config\n",
+        write_backup=True,
+        backup_suffix=".before-wizard",
+    )
+
+    assert output_path.read_text(encoding="utf-8") == "new: config\n"
+    assert result["backup_created"] is True
+    assert result["backup_path"].endswith(".before-wizard")
+    assert Path(result["backup_path"]).read_text(encoding="utf-8") == "old: config\n"


### PR DESCRIPTION
## Summary
- add optional backup snapshots before the wizard overwrites an existing config file
- support configurable backup suffixes for local rollback hygiene
- document the safer write-backup flow alongside dry-run and apply suggestions

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_config.py tests/test_provider_catalog.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check foundrygate/wizard.py tests/test_wizard.py README.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-config-wizard
- git diff --check