### PR TITLE
docs(wizard): polish help and v1.3 roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added an `apply suggestions` wizard flow so selected provider and client-mode recommendations can be merged into an existing config without manual copy/paste
 - Added a wizard dry-run change summary so operators can preview added providers, model replacements, fallback changes, and client-mode changes before writing config updates
 - Added optional wizard write-backup snapshots so config updates can keep a local pre-change copy before overwriting `config.yaml`
+- Added a built-in `foundrygate-config-wizard --help` flow so first setup, catalog review, update suggestions, dry-run previews, and backup-aware writes are all discoverable directly from the CLI
 
 ### Changed
 
@@ -24,6 +25,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - `foundrygate-doctor`, onboarding reports, and the provider-catalog API now surface curated model-drift, source-confidence, volatility, and catalog-freshness alerts for configured providers
 - Provider catalog entries now distinguish direct providers from aggregators and wallet routers, track auth modes such as `api_key`, `byok`, and `wallet_x402`, and keep community watchlists explicitly secondary to official sources
 - `foundrygate-config-wizard` can now filter candidates by purpose and client, accept multi-select provider input, and merge selected providers back into an existing config instead of forcing a full rewrite
+- Tightened the roadmap and user-facing docs around `v1.3.0` so guided setup, catalog-assisted updates, and future recommendation-link work stay transparent and clearly separated from ranking logic
 
 ## v1.2.3 - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ curl -fsS http://127.0.0.1:8090/v1/models
 Then use the onboarding helpers to move from “the server starts” to “real clients are ready”:
 
 ```bash
+./scripts/foundrygate-config-wizard --help
 ./scripts/foundrygate-config-wizard --purpose general --client generic > config.yaml
 ./scripts/foundrygate-onboarding-report
 ./scripts/foundrygate-onboarding-validate

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -99,6 +99,7 @@ For fast-moving offers, the current preferred review inputs are:
 The config wizard can use this catalog metadata during first setup and later updates:
 
 ```bash
+./scripts/foundrygate-config-wizard --help
 ./scripts/foundrygate-config-wizard --purpose general --client generic --list-candidates
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose general --client generic
 ./scripts/foundrygate-config-wizard --purpose free --client n8n \
@@ -118,6 +119,12 @@ The config wizard can use this catalog metadata during first setup and later upd
 ```
 
 That gives operators one purpose-aware candidate list, config-aware update suggestions (`recommended_add`, `recommended_replace`, `recommended_keep`, `recommended_mode_changes`), the ability to pick multiple providers at once, and a safer merge path for incremental catalog-driven updates.
+
+If you want the shortest reminder of the whole flow, run:
+
+```bash
+./scripts/foundrygate-config-wizard --help
+```
 
 ## Provider Fields
 
@@ -207,6 +214,7 @@ Use the onboarding docs and starter examples when introducing a new client inste
 For a first local config, let FoundryGate suggest one from the API keys already present in your env file:
 
 ```bash
+./scripts/foundrygate-config-wizard --help
 ./scripts/foundrygate-config-wizard --purpose general > config.yaml
 ```
 

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -21,7 +21,32 @@ This roadmap now shifts from "rename and foundation" to "deepen the gateway plan
 
 `v1.2.0` is now shipped. The workstation baseline is in place: Linux, macOS, and Windows runtime guidance is documented, macOS helpers now auto-detect `launchd`, and a project-owned Homebrew path exists for packaged macOS installs.
 
+`v1.2.x` also closed the immediate Homebrew/macOS packaging loop. The next active release line should therefore shift to `v1.3.0`: guided setup, catalog-assisted updates, and safer operator ergonomics for many fast-moving providers.
+
 The next block should stay disciplined: build on the workstation baseline, keep packaging practical, and avoid turning FoundryGate into a sprawling platform.
+
+## `v1.3.0`: guided setup and catalog-assisted updates
+
+Primary goals:
+
+- make first setup and later provider updates realistic without turning `config.yaml` into hand-edited drift bait
+- keep routing modes, client defaults, and provider selection understandable across many clients
+- improve provider-catalog freshness and update suggestions without silently rewriting operator intent
+- start the provider-discovery and recommendation-link line only in a transparency-first, metadata-first shape
+
+Recommended minimal slices:
+
+1. wizard candidate selection, update suggestions, dry-run summaries, and backup-aware writes
+2. provider-catalog source metadata, offer-track volatility flags, and freshness alerts
+3. wizard and CLI usage polish so the guided flow is self-explanatory from `--help`
+4. optional provider recommendation-link metadata with explicit disclosure, but still no ranking changes based on affiliate payout
+
+Guardrails for any recommendation-link work in this line:
+
+- recommendation ranking must never use affiliate payout as an input and must stay performance-led, preferring fit, quality, health, capability, and cost behavior
+- affiliate or partner metadata should stay operator-owned and secret-backed, not embedded in user-editable client configs
+- docs and CLI output should disclose clearly when a shown signup link may include an affiliate attribution
+- the first slice should be metadata and display only; managed short links, browser control-center surfaces, and richer landing-page flows can come later
 
 ## `v1.2.0`: workstation operations baseline
 
@@ -494,6 +519,26 @@ Every 4 or 5 merged PRs, run a broader review pass:
 - refresh the roadmap and process docs if the direction changed
 
 This is necessary because FoundryGate is evolving quickly and the docs can drift even when individual PRs are clean.
+
+## Provider discovery and recommendation links
+
+FoundryGate should be able to help operators and end users discover suitable providers, but it should not turn recommendation output into a payout-optimized marketplace.
+
+That means the future recommendation-link line should stay deliberately staged:
+
+### First slices that make sense soon
+
+- add optional provider-catalog fields for signup URLs, affiliate parameter shapes, disclosure labels, and source ownership
+- surface those links in CLI or later browser-based control-center output only when they are available and disclosed
+- allow operator-managed secret or env-backed affiliate identifiers rather than baking them into normal client-visible config
+
+### Later slices that make sense after that
+
+- optional managed short-link or landing-page wrappers
+- richer provider discovery views in a small browser control center
+- trust/performance signals derived from historical provider behavior, so recommendations can explain quality and reliability more concretely
+
+The non-negotiable rule is simple: recommendation quality must stay fully independent from monetization metadata, and signup links may only follow from a recommendation rather than shaping it.
 
 ## Assumptions
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -41,6 +41,7 @@ $EDITOR .env
 Useful flows:
 
 ```bash
+./scripts/foundrygate-config-wizard --help
 ./scripts/foundrygate-config-wizard --purpose coding --client opencode --list-candidates
 ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose coding --client opencode
 ./scripts/foundrygate-config-wizard --purpose coding --client opencode \
@@ -58,6 +59,8 @@ Useful flows:
   --select kilocode,openrouter-fallback --select-profiles opencode \
   --write config.yaml --write-backup --backup-suffix .before-wizard
 ```
+
+If you only need a compact refresher for the flags and example flows, `./scripts/foundrygate-config-wizard --help` now prints the whole first-setup / update / dry-run / backup path directly in the CLI.
 
 When a current config is present, the suggestion output now also flags client-profile mode deltas such as `recommended_mode_changes`, so you can see when `n8n`, `openclaw`, or `opencode` probably want a different default mode for the selected purpose.
 

--- a/scripts/foundrygate-config-wizard
+++ b/scripts/foundrygate-config-wizard
@@ -18,8 +18,60 @@ dry_run_summary="false"
 write_backup="false"
 backup_suffix=".bak"
 
+print_help() {
+  cat <<'EOF'
+Usage:
+  ./scripts/foundrygate-config-wizard [options]
+
+Purpose-aware setup:
+  --purpose <general|coding|quality|free>
+  --client <generic|openclaw|n8n|cli|opencode|custom>
+  --env-file <path>
+  --json | --yaml
+
+Candidate review:
+  --list-candidates
+
+Existing config review:
+  --current-config <path>
+  --merge-existing
+  --dry-run-summary
+
+Selection and apply flow:
+  --select provider-a,provider-b
+  --select-profiles n8n,opencode
+  --apply recommended_add,recommended_replace,recommended_mode_changes
+
+Write controls:
+  --write <path>
+  --write-backup
+  --backup-suffix <suffix>
+
+Examples:
+  ./scripts/foundrygate-config-wizard --purpose general --client generic > config.yaml
+  ./scripts/foundrygate-config-wizard --purpose free --client n8n --list-candidates
+  ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n
+  ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+    --apply recommended_add,recommended_replace,recommended_mode_changes \
+    --select kilocode,openrouter-fallback --select-profiles n8n --dry-run-summary
+  ./scripts/foundrygate-config-wizard --current-config config.yaml --purpose free --client n8n \
+    --apply recommended_add,recommended_replace,recommended_mode_changes \
+    --select kilocode,openrouter-fallback --select-profiles n8n \
+    --write config.yaml --write-backup --backup-suffix .before-wizard
+
+Tip:
+  Run with --current-config and no --select first to inspect
+  recommended_add / recommended_replace / recommended_keep /
+  recommended_mode_changes before writing anything.
+EOF
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
+    --help|-h)
+      print_help
+      exit 0
+      ;;
     --env-file)
       env_file="$2"
       shift 2

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from foundrygate.wizard import (
@@ -263,6 +264,22 @@ client_profiles:
     assert "deepseek-chat" in keep_names
     assert "generic" in mode_profiles
     assert "n8n" in mode_profiles
+
+
+def test_config_wizard_help_lists_primary_flows():
+    result = subprocess.run(
+        ["bash", "scripts/foundrygate-config-wizard", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "--list-candidates" in result.stdout
+    assert "--dry-run-summary" in result.stdout
+    assert "--write-backup" in result.stdout
+    assert "recommended_mode_changes" in result.stdout
 
 
 def test_apply_update_suggestions_can_apply_provider_and_mode_changes(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a real --help flow to the config wizard with first-setup, update, dry-run, and backup examples
- add a wizard help regression test and refresh README/config/onboarding docs around the guided flow
- update the roadmap for v1.3.0 guided setup and future provider recommendation-link work with payout-blind guardrails

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_config.py tests/test_provider_catalog.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check tests/test_wizard.py README.md docs/CONFIGURATION.md docs/FOUNDRYGATE-ROADMAP.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-config-wizard
- git diff --check