### PR TITLE
feat(cli): add provider discovery helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added a built-in `foundrygate-config-wizard --help` flow so first setup, catalog review, update suggestions, dry-run previews, and backup-aware writes are all discoverable directly from the CLI
 - Added optional provider-catalog discovery metadata and env-backed signup-link overrides so future CLI or control-center surfaces can show disclosed provider links without mixing affiliate state into normal config files
 - Added first CLI surfacing of disclosed provider discovery links in onboarding and doctor outputs, always alongside a payout-blind recommendation policy signal
+- Added `foundrygate-provider-discovery` for one compact text/JSON discovery view that later browser or control-center work can consume
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Then use the onboarding helpers to move from “the server starts” to “real 
 ./scripts/foundrygate-config-wizard --help
 ./scripts/foundrygate-config-wizard --purpose general --client generic > config.yaml
 ./scripts/foundrygate-onboarding-report
+./scripts/foundrygate-provider-discovery
 ./scripts/foundrygate-onboarding-validate
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,6 +103,13 @@ Returns the curated provider-catalog view with drift, freshness, volatility, aut
 curl -fsS http://127.0.0.1:8090/api/provider-catalog
 ```
 
+For local operator use, the same discovery block is also available via:
+
+```bash
+./scripts/foundrygate-provider-discovery
+./scripts/foundrygate-provider-discovery --json
+```
+
 ### `GET /api/stats`
 
 Returns aggregate request counters, token usage, per-client breakdowns, aggregate client totals, client highlight summaries, cost data, and operator-action summaries.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,6 +109,7 @@ The first CLI surfaces for this are the existing operator helpers:
 
 - `foundrygate-onboarding-report`
 - `foundrygate-doctor`
+- `foundrygate-provider-discovery`
 
 They show the resolved link together with the payout-blind policy state, so later browser or control-center work can build on the same rule set.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -80,6 +80,7 @@ Today that means:
 
 - `foundrygate-onboarding-report` can show the resolved provider discovery URL
 - `foundrygate-doctor` can print the same disclosed link for configured providers
+- `foundrygate-provider-discovery` can give one compact text or JSON view for later automation or browser work
 - both surfaces also print the payout-blind policy state alongside the links
 
 It also prints a client matrix:

--- a/foundrygate/provider_catalog.py
+++ b/foundrygate/provider_catalog.py
@@ -411,3 +411,35 @@ def build_provider_catalog_report(config: Config) -> dict[str, Any]:
         "alerts": alerts,
         "items": items,
     }
+
+
+def build_provider_discovery_view(config: Config) -> dict[str, Any]:
+    """Return a compact, disclosure-first provider discovery view."""
+    report = build_provider_catalog_report(config)
+    providers: list[dict[str, Any]] = []
+
+    for item in report.get("items", []):
+        discovery = item.get("discovery") or {}
+        resolved_url = str(discovery.get("resolved_url", "") or "").strip()
+        if not resolved_url:
+            continue
+        providers.append(
+            {
+                "provider": item["provider"],
+                "provider_type": item.get("provider_type", "direct"),
+                "offer_track": item.get("offer_track", "direct"),
+                "evidence_level": item.get("evidence_level", "official"),
+                "official_source_url": item.get("official_source_url", ""),
+                "signup_url": discovery.get("signup_url", ""),
+                "resolved_url": resolved_url,
+                "link_source": discovery.get("link_source", "official"),
+                "operator_env_var": discovery.get("operator_env_var", ""),
+                "disclosure": discovery.get("disclosure", ""),
+                "disclosure_required": bool(discovery.get("disclosure_required", False)),
+            }
+        )
+
+    return {
+        "recommendation_policy": report.get("recommendation_policy", {}),
+        "providers": providers,
+    }

--- a/scripts/foundrygate-provider-discovery
+++ b/scripts/foundrygate-provider-discovery
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+config_file="${FOUNDRYGATE_CONFIG_FILE:-$repo_root/config.yaml}"
+mode="${1:-text}"
+python_bin="${FOUNDRYGATE_PYTHON:-python3}"
+
+export FOUNDRYGATE_DISCOVERY_CONFIG="$config_file"
+export FOUNDRYGATE_DISCOVERY_MODE="$mode"
+
+"$python_bin" - <<'PY'
+import json
+import os
+
+from foundrygate.config import load_config
+from foundrygate.provider_catalog import build_provider_discovery_view
+
+view = build_provider_discovery_view(load_config(os.environ["FOUNDRYGATE_DISCOVERY_CONFIG"]))
+
+if os.environ["FOUNDRYGATE_DISCOVERY_MODE"] == "--json":
+    print(json.dumps(view, indent=2, sort_keys=True))
+else:
+    policy = view.get("recommendation_policy", {})
+    print("FoundryGate Provider Discovery")
+    print("")
+    print(
+        "Policy: payout affects ranking = "
+        f"{policy.get('affiliate_payout_affects_ranking', False)}"
+    )
+    if policy.get("disclosure"):
+        print(f"Disclosure: {policy['disclosure']}")
+    for item in view.get("providers", []):
+        label = "disclosed link" if item.get("disclosure_required") else "official link"
+        print("")
+        print(
+            f"- {item['provider']}: {item['provider_type']} / "
+            f"{item['offer_track']} / {item['evidence_level']}"
+        )
+        print(f"  {label}: {item['resolved_url']}")
+        if item.get("operator_env_var"):
+            print(f"  env override: {item['operator_env_var']}")
+PY

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -387,6 +387,64 @@ auto_update:
     assert report["clients"]["presets"] == ["openclaw"]
 
 
+def test_provider_discovery_helper_supports_json_output(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv(
+        "FOUNDRYGATE_PROVIDER_LINK_OPENROUTER_FALLBACK_URL",
+        "https://go.example.test/openrouter",
+    )
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+fallback_chain:
+  - openrouter-fallback
+providers:
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "secret"
+    model: "openrouter/auto"
+client_profiles:
+  enabled: false
+  profiles:
+    generic: {}
+  rules: []
+routing_policies:
+  enabled: false
+  rules: []
+request_hooks:
+  enabled: false
+  hooks: []
+update_check:
+  enabled: false
+auto_update:
+  enabled: false
+""".strip(),
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "scripts" / "foundrygate-provider-discovery"
+    env = os.environ.copy()
+    env["FOUNDRYGATE_CONFIG_FILE"] = str(config_file)
+    env["FOUNDRYGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(repo_root)
+
+    completed = subprocess.run(
+        ["bash", str(script), "--json"],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    view = json.loads(completed.stdout)
+    assert view["recommendation_policy"]["affiliate_payout_affects_ranking"] is False
+    assert view["providers"][0]["provider"] == "openrouter-fallback"
+    assert view["providers"][0]["resolved_url"] == "https://go.example.test/openrouter"
+
+
 def test_onboarding_report_marks_all_builtin_integrations_ready(tmp_path: Path):
     env_file = tmp_path / ".env"
     env_file.write_text("DEEPSEEK_API_KEY=sk-demo\n", encoding="utf-8")

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from foundrygate.config import load_config
-from foundrygate.provider_catalog import build_provider_catalog_report
+from foundrygate.provider_catalog import (
+    build_provider_catalog_report,
+    build_provider_discovery_view,
+)
 
 
 def _write_config(tmp_path: Path, body: str) -> Path:
@@ -188,3 +191,37 @@ metrics:
     assert discovery["resolved_url"] == "https://go.example.test/openrouter"
     assert discovery["link_source"] == "operator_override"
     assert discovery["disclosure_required"] is True
+
+
+def test_provider_discovery_view_filters_to_resolved_links(tmp_path: Path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "secret"
+    model: "openrouter/auto"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    view = build_provider_discovery_view(cfg)
+
+    assert view["recommendation_policy"]["affiliate_payout_affects_ranking"] is False
+    provider_names = [item["provider"] for item in view["providers"]]
+    assert provider_names == ["deepseek-chat", "openrouter-fallback"]
+    assert view["providers"][0]["resolved_url"].startswith("https://")


### PR DESCRIPTION
## Summary
- add a dedicated foundrygate-provider-discovery helper with text and JSON output
- build the helper on the same payout-blind provider catalog policy used by onboarding and doctor
- document the compact discovery view as the next CLI foundation for later browser/control-center work

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_onboarding.py tests/test_provider_catalog.py
- ./.venv-check-313/bin/ruff check foundrygate/provider_catalog.py tests/test_provider_catalog.py tests/test_onboarding.py README.md docs/API.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-provider-discovery
- git diff --check