### PR TITLE
docs(catalog): remove affiliate wording from provider links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added a wizard dry-run change summary so operators can preview added providers, model replacements, fallback changes, and client-mode changes before writing config updates
 - Added optional wizard write-backup snapshots so config updates can keep a local pre-change copy before overwriting `config.yaml`
 - Added a built-in `foundrygate-config-wizard --help` flow so first setup, catalog review, update suggestions, dry-run previews, and backup-aware writes are all discoverable directly from the CLI
-- Added optional provider-catalog discovery metadata and env-backed signup-link overrides so future CLI or control-center surfaces can show disclosed provider links without mixing affiliate state into normal config files
-- Added first CLI surfacing of disclosed provider discovery links in onboarding and doctor outputs, always alongside a payout-blind recommendation policy signal
+- Added optional provider-catalog discovery metadata and env-backed signup-link overrides so future CLI or control-center surfaces can show disclosed provider links without mixing link configuration into normal config files
+- Added first CLI surfacing of disclosed provider discovery links in onboarding and doctor outputs, always alongside a link-neutral recommendation policy signal
 - Added `foundrygate-provider-discovery` for one compact text/JSON discovery view that later browser or control-center work can consume
 
 ### Changed
@@ -29,7 +29,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Provider catalog entries now distinguish direct providers from aggregators and wallet routers, track auth modes such as `api_key`, `byok`, and `wallet_x402`, and keep community watchlists explicitly secondary to official sources
 - `foundrygate-config-wizard` can now filter candidates by purpose and client, accept multi-select provider input, and merge selected providers back into an existing config instead of forcing a full rewrite
 - Tightened the roadmap and user-facing docs around `v1.3.0` so guided setup, catalog-assisted updates, and future recommendation-link work stay transparent and clearly separated from ranking logic
-- Provider discovery metadata now carries an explicit payout-blind recommendation policy so affiliate or partner attribution can never be mistaken for a ranking signal
+- Provider discovery metadata now carries an explicit link-neutral recommendation policy so provider-link configuration can never be mistaken for a ranking signal
 
 ## v1.2.3 - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Runs locally on Linux, macOS, and Windows, with first-class workstation guidance
 - Practical rollout controls: fallback chains, maintenance windows, rollout rings, provider scopes, and post-update verification gates are already there.
 - Copy/paste onboarding: OpenClaw, n8n, CLI, delegated-agent traffic, provider templates, and env starter files ship with the repo.
 - Curated provider-catalog checks catch stale model choices, volatile free-tier picks, and source-confidence gaps before local configs quietly age out.
-- Provider discovery can stay transparent: catalog entries can expose official or operator-configured signup links, while recommendation ranking stays payout-blind and performance-led.
+- Provider discovery can stay transparent: catalog entries can expose official or operator-configured signup links, while recommendation ranking stays performance-led and link-neutral.
 - The onboarding report and doctor CLI can surface those links with disclosure, so operators can share a signup path without turning discovery into biased ranking.
 
 ## Quickstart

--- a/docs/API.md
+++ b/docs/API.md
@@ -97,7 +97,7 @@ curl -fsS 'http://127.0.0.1:8090/api/providers?capability=image_generation'
 
 ### `GET /api/provider-catalog`
 
-Returns the curated provider-catalog view with drift, freshness, volatility, auth-mode, source-confidence metadata, an explicit payout-blind recommendation policy block, and optional disclosed provider-discovery links for configured providers.
+Returns the curated provider-catalog view with drift, freshness, volatility, auth-mode, source-confidence metadata, an explicit link-neutral recommendation policy block, and optional disclosed provider-discovery links for configured providers.
 
 ```bash
 curl -fsS http://127.0.0.1:8090/api/provider-catalog

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,13 +97,13 @@ export FOUNDRYGATE_PROVIDER_LINK_OPENROUTER_FALLBACK_URL="https://go.example.com
 export FOUNDRYGATE_PROVIDER_LINK_KILOCODE_URL="https://go.example.com/kilo"
 ```
 
-These env vars are operator-controlled full URLs. They are intended for disclosed signup or partner links and keep attribution state out of normal client config. If unset, the catalog falls back to the provider's official signup or landing URL.
+These env vars are operator-controlled full URLs. They are intended for disclosed signup or discovery links and keep link configuration out of normal client config. If unset, the catalog falls back to the provider's official signup or landing URL.
 
 The guardrail is strict:
 
-- recommendation ranking does not use payout as an input
+- recommendation ranking does not use provider-link metadata as an input
 - operator-configured discovery links are only shown after a recommendation or candidate row already exists
-- CLI and API output should disclose that a shown link may include affiliate attribution
+- CLI and API output should disclose that a shown link is informational only
 
 The first CLI surfaces for this are the existing operator helpers:
 
@@ -111,7 +111,7 @@ The first CLI surfaces for this are the existing operator helpers:
 - `foundrygate-doctor`
 - `foundrygate-provider-discovery`
 
-They show the resolved link together with the payout-blind policy state, so later browser or control-center work can build on the same rule set.
+They show the resolved link together with the link-neutral policy state, so later browser or control-center work can build on the same rule set.
 
 For fast-moving offers, the current preferred review inputs are:
 

--- a/docs/FOUNDRYGATE-ROADMAP.md
+++ b/docs/FOUNDRYGATE-ROADMAP.md
@@ -39,13 +39,13 @@ Recommended minimal slices:
 1. wizard candidate selection, update suggestions, dry-run summaries, and backup-aware writes
 2. provider-catalog source metadata, offer-track volatility flags, and freshness alerts
 3. wizard and CLI usage polish so the guided flow is self-explanatory from `--help`
-4. optional provider recommendation-link metadata with explicit disclosure, but still no ranking changes based on affiliate payout
+4. optional provider recommendation-link metadata with explicit disclosure, but still no ranking changes based on provider-link metadata
 
 Guardrails for any recommendation-link work in this line:
 
-- recommendation ranking must never use affiliate payout as an input and must stay performance-led, preferring fit, quality, health, capability, and cost behavior
-- affiliate or partner metadata should stay operator-owned and secret-backed, not embedded in user-editable client configs
-- docs and CLI output should disclose clearly when a shown signup link may include an affiliate attribution
+- recommendation ranking must never use provider-link metadata as an input and must stay performance-led, preferring fit, quality, health, capability, and cost behavior
+- provider-link metadata should stay operator-owned and secret-backed, not embedded in user-editable client configs
+- docs and CLI output should disclose clearly when a shown signup link is informational only
 - the first slice should be metadata and display only; managed short links, browser control-center surfaces, and richer landing-page flows can come later
 
 ## `v1.2.0`: workstation operations baseline
@@ -522,15 +522,15 @@ This is necessary because FoundryGate is evolving quickly and the docs can drift
 
 ## Provider discovery and recommendation links
 
-FoundryGate should be able to help operators and end users discover suitable providers, but it should not turn recommendation output into a payout-optimized marketplace.
+FoundryGate should be able to help operators and end users discover suitable providers, but it should not turn recommendation output into a monetized marketplace.
 
 That means the future recommendation-link line should stay deliberately staged:
 
 ### First slices that make sense soon
 
-- add optional provider-catalog fields for signup URLs, affiliate parameter shapes, disclosure labels, and source ownership
+- add optional provider-catalog fields for signup URLs, disclosure labels, and source ownership
 - surface those links in CLI or later browser-based control-center output only when they are available and disclosed
-- allow operator-managed secret or env-backed affiliate identifiers rather than baking them into normal client-visible config
+- allow operator-managed secret or env-backed provider-link overrides rather than baking them into normal client-visible config
 
 ### Later slices that make sense after that
 
@@ -538,7 +538,7 @@ That means the future recommendation-link line should stay deliberately staged:
 - richer provider discovery views in a small browser control center
 - trust/performance signals derived from historical provider behavior, so recommendations can explain quality and reliability more concretely
 
-The non-negotiable rule is simple: recommendation quality must stay fully independent from monetization metadata, and signup links may only follow from a recommendation rather than shaping it.
+The non-negotiable rule is simple: recommendation quality must stay fully independent from provider-link metadata, and signup links may only follow from a recommendation rather than shaping it.
 
 ## Assumptions
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -74,14 +74,14 @@ It now also includes provider-catalog alerts for:
 - volatile free-/BYOK-/marketplace-backed offer tracks
 - mixed/community-backed catalog entries that deserve faster review
 
-The same catalog can now also carry optional provider-discovery links for CLI or later browser surfaces. Those links can be operator-configured through env vars, but they are deliberately downstream of the recommendation itself: ranking stays performance-led and payout-blind.
+The same catalog can now also carry optional provider-discovery links for CLI or later browser surfaces. Those links can be operator-configured through env vars, but they are deliberately downstream of the recommendation itself: ranking stays performance-led and link-neutral.
 
 Today that means:
 
 - `foundrygate-onboarding-report` can show the resolved provider discovery URL
 - `foundrygate-doctor` can print the same disclosed link for configured providers
 - `foundrygate-provider-discovery` can give one compact text or JSON view for later automation or browser work
-- both surfaces also print the payout-blind policy state alongside the links
+- both surfaces also print the link-neutral policy state alongside the links
 
 It also prints a client matrix:
 

--- a/foundrygate/onboarding.py
+++ b/foundrygate/onboarding.py
@@ -802,8 +802,8 @@ def render_onboarding_report(report: dict[str, Any]) -> str:
         lines.append("- provider discovery:")
         lines.append(
             "  - "
-            + "policy: payout affects ranking = "
-            + f"{policy.get('affiliate_payout_affects_ranking', False)}"
+            + "policy: provider links affect ranking = "
+            + f"{policy.get('provider_links_affect_ranking', False)}"
         )
         for item in discovery_items:
             discovery = item["discovery"]
@@ -938,8 +938,8 @@ def render_onboarding_report_markdown(report: dict[str, Any]) -> str:
         policy = catalog_block.get("recommendation_policy", {})
         lines.append("- Provider discovery:")
         lines.append(
-            "  - Policy: payout affects ranking = "
-            + f"`{policy.get('affiliate_payout_affects_ranking', False)}`"
+            "  - Policy: provider links affect ranking = "
+            + f"`{policy.get('provider_links_affect_ranking', False)}`"
         )
         for item in discovery_items:
             discovery = item["discovery"]

--- a/foundrygate/provider_catalog.py
+++ b/foundrygate/provider_catalog.py
@@ -15,8 +15,8 @@ _COMMUNITY_WATCHLIST = {
 }
 
 _DISCOVERY_DISCLOSURE = (
-    "Provider recommendations stay performance-led. Signup or discovery links may include "
-    "operator-configured affiliate attribution, but payout never affects ranking."
+    "Provider recommendations stay performance-led. Shown signup or discovery links are "
+    "informational only and do not affect ranking."
 )
 
 _CATALOG: dict[str, dict[str, Any]] = {
@@ -398,7 +398,7 @@ def build_provider_catalog_report(config: Config) -> dict[str, Any]:
         "total_providers": len(config.providers),
         "alert_count": len(alerts),
         "recommendation_policy": {
-            "affiliate_payout_affects_ranking": False,
+            "provider_links_affect_ranking": False,
             "ranking_basis": [
                 "fit",
                 "quality",

--- a/scripts/foundrygate-doctor
+++ b/scripts/foundrygate-doctor
@@ -85,8 +85,8 @@ else:
 
 policy = catalog.get("recommendation_policy", {})
 print(
-    "[ok] provider discovery policy: payout affects ranking = "
-    f"{policy.get('affiliate_payout_affects_ranking', False)}"
+    "[ok] provider discovery policy: provider links affect ranking = "
+    f"{policy.get('provider_links_affect_ranking', False)}"
 )
 for item in catalog.get("items", []):
     discovery = item.get("discovery") or {}

--- a/scripts/foundrygate-provider-discovery
+++ b/scripts/foundrygate-provider-discovery
@@ -25,8 +25,8 @@ else:
     print("FoundryGate Provider Discovery")
     print("")
     print(
-        "Policy: payout affects ranking = "
-        f"{policy.get('affiliate_payout_affects_ranking', False)}"
+        "Policy: provider links affect ranking = "
+        f"{policy.get('provider_links_affect_ranking', False)}"
     )
     if policy.get("disclosure"):
         print(f"Disclosure: {policy['disclosure']}")

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -275,10 +275,10 @@ auto_update:
 
     policy = report["provider_catalog"]["recommendation_policy"]
 
-    assert policy["affiliate_payout_affects_ranking"] is False
+    assert policy["provider_links_affect_ranking"] is False
     assert "provider discovery:" in text
     assert "openrouter-fallback: disclosed link -> https://go.example.test/openrouter" in text
-    assert "Policy: payout affects ranking = `False`" in markdown
+    assert "Policy: provider links affect ranking = `False`" in markdown
     assert (
         "`openrouter-fallback`: disclosed link -> `https://go.example.test/openrouter`" in markdown
     )
@@ -440,7 +440,7 @@ auto_update:
     )
 
     view = json.loads(completed.stdout)
-    assert view["recommendation_policy"]["affiliate_payout_affects_ranking"] is False
+    assert view["recommendation_policy"]["provider_links_affect_ranking"] is False
     assert view["providers"][0]["provider"] == "openrouter-fallback"
     assert view["providers"][0]["resolved_url"] == "https://go.example.test/openrouter"
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -186,7 +186,7 @@ metrics:
 
     report = build_provider_catalog_report(cfg)
 
-    assert report["recommendation_policy"]["affiliate_payout_affects_ranking"] is False
+    assert report["recommendation_policy"]["provider_links_affect_ranking"] is False
     discovery = report["items"][0]["discovery"]
     assert discovery["resolved_url"] == "https://go.example.test/openrouter"
     assert discovery["link_source"] == "operator_override"
@@ -221,7 +221,7 @@ metrics:
 
     view = build_provider_discovery_view(cfg)
 
-    assert view["recommendation_policy"]["affiliate_payout_affects_ranking"] is False
+    assert view["recommendation_policy"]["provider_links_affect_ranking"] is False
     provider_names = [item["provider"] for item in view["providers"]]
     assert provider_names == ["deepseek-chat", "openrouter-fallback"]
     assert view["providers"][0]["resolved_url"].startswith("https://")


### PR DESCRIPTION
## Summary
- remove affiliate/referral wording from provider discovery policy, exports, and docs
- keep provider discovery links as neutral signup/discovery links that never affect recommendation ranking
- update roadmap, changelog, onboarding, doctor, and discovery helper output to reflect the new strategy

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_onboarding.py tests/test_provider_catalog.py
- ./.venv-check-313/bin/ruff check foundrygate/provider_catalog.py foundrygate/onboarding.py tests/test_provider_catalog.py tests/test_onboarding.py README.md docs/API.md docs/CONFIGURATION.md docs/ONBOARDING.md docs/FOUNDRYGATE-ROADMAP.md CHANGELOG.md
- bash -n scripts/foundrygate-doctor && bash -n scripts/foundrygate-provider-discovery
- git diff --check