### PR TITLE
feat(cli): add provider discovery filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Added optional provider-catalog discovery metadata and env-backed signup-link overrides so future CLI or control-center surfaces can show disclosed provider links without mixing link configuration into normal config files
 - Added first CLI surfacing of disclosed provider discovery links in onboarding and doctor outputs, always alongside a link-neutral recommendation policy signal
 - Added `foundrygate-provider-discovery` for one compact text/JSON discovery view that later browser or control-center work can consume
+- Added discovery-link filters for CLI and API views so operators can narrow provider links by `offer_track`, `link_source`, or `disclosed_only`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Then use the onboarding helpers to move from “the server starts” to “real 
 ./scripts/foundrygate-config-wizard --purpose general --client generic > config.yaml
 ./scripts/foundrygate-onboarding-report
 ./scripts/foundrygate-provider-discovery
+./scripts/foundrygate-provider-discovery --json --offer-track free
 ./scripts/foundrygate-onboarding-validate
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -110,6 +110,17 @@ For local operator use, the same discovery block is also available via:
 ./scripts/foundrygate-provider-discovery --json
 ```
 
+### `GET /api/provider-discovery`
+
+Returns the compact discovery-link view with the same link-neutral recommendation policy block, plus optional filters for `link_source`, `offer_track`, and `disclosed_only`.
+
+```bash
+curl -fsS 'http://127.0.0.1:8090/api/provider-discovery?offer_track=free'
+curl -fsS 'http://127.0.0.1:8090/api/provider-discovery?link_source=operator_override&disclosed_only=true'
+./scripts/foundrygate-provider-discovery --json --offer-track free
+./scripts/foundrygate-provider-discovery --link-source operator_override --disclosed-only
+```
+
 ### `GET /api/stats`
 
 Returns aggregate request counters, token usage, per-client breakdowns, aggregate client totals, client highlight summaries, cost data, and operator-action summaries.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,6 +113,14 @@ The first CLI surfaces for this are the existing operator helpers:
 
 They show the resolved link together with the link-neutral policy state, so later browser or control-center work can build on the same rule set.
 
+The compact discovery helper can also filter those links without changing the catalog itself:
+
+```bash
+./scripts/foundrygate-provider-discovery --offer-track free
+./scripts/foundrygate-provider-discovery --json --link-source operator_override --disclosed-only
+curl -fsS 'http://127.0.0.1:8090/api/provider-discovery?offer_track=byok'
+```
+
 For fast-moving offers, the current preferred review inputs are:
 
 - official provider docs first

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -81,6 +81,7 @@ Today that means:
 - `foundrygate-onboarding-report` can show the resolved provider discovery URL
 - `foundrygate-doctor` can print the same disclosed link for configured providers
 - `foundrygate-provider-discovery` can give one compact text or JSON view for later automation or browser work
+- that discovery helper can now also filter by `offer_track`, `link_source`, or `disclosed_only`
 - both surfaces also print the link-neutral policy state alongside the links
 
 It also prints a client matrix:

--- a/foundrygate/main.py
+++ b/foundrygate/main.py
@@ -27,7 +27,7 @@ from . import __version__
 from .config import Config, load_config
 from .hooks import AppliedHooks, HookExecutionError, RequestHookContext, apply_request_hooks
 from .metrics import MetricsStore, calc_cost
-from .provider_catalog import build_provider_catalog_report
+from .provider_catalog import build_provider_catalog_report, build_provider_discovery_view
 from .providers import ProviderBackend, ProviderError
 from .router import Router, RoutingDecision
 from .updates import (
@@ -1103,6 +1103,21 @@ async def provider_inventory(
 async def provider_catalog():
     """Return curated provider-catalog drift and freshness alerts."""
     return build_provider_catalog_report(_config)
+
+
+@app.get("/api/provider-discovery")
+async def provider_discovery(
+    link_source: str | None = None,
+    disclosed_only: bool = False,
+    offer_track: str | None = None,
+):
+    """Return compact provider-discovery links with optional filters."""
+    return build_provider_discovery_view(
+        _config,
+        link_source=link_source,
+        disclosed_only=disclosed_only,
+        offer_track=offer_track,
+    )
 
 
 @app.get("/v1/models")

--- a/foundrygate/provider_catalog.py
+++ b/foundrygate/provider_catalog.py
@@ -413,15 +413,29 @@ def build_provider_catalog_report(config: Config) -> dict[str, Any]:
     }
 
 
-def build_provider_discovery_view(config: Config) -> dict[str, Any]:
+def build_provider_discovery_view(
+    config: Config,
+    *,
+    link_source: str | None = None,
+    disclosed_only: bool = False,
+    offer_track: str | None = None,
+) -> dict[str, Any]:
     """Return a compact, disclosure-first provider discovery view."""
     report = build_provider_catalog_report(config)
     providers: list[dict[str, Any]] = []
+    normalized_link_source = str(link_source or "").strip().lower() or None
+    normalized_offer_track = str(offer_track or "").strip().lower() or None
 
     for item in report.get("items", []):
         discovery = item.get("discovery") or {}
         resolved_url = str(discovery.get("resolved_url", "") or "").strip()
         if not resolved_url:
+            continue
+        if normalized_link_source and discovery.get("link_source") != normalized_link_source:
+            continue
+        if disclosed_only and not discovery.get("disclosure_required", False):
+            continue
+        if normalized_offer_track and item.get("offer_track") != normalized_offer_track:
             continue
         providers.append(
             {
@@ -441,5 +455,10 @@ def build_provider_discovery_view(config: Config) -> dict[str, Any]:
 
     return {
         "recommendation_policy": report.get("recommendation_policy", {}),
+        "filters": {
+            "link_source": normalized_link_source,
+            "disclosed_only": disclosed_only,
+            "offer_track": normalized_offer_track,
+        },
         "providers": providers,
     }

--- a/scripts/foundrygate-provider-discovery
+++ b/scripts/foundrygate-provider-discovery
@@ -3,11 +3,46 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 config_file="${FOUNDRYGATE_CONFIG_FILE:-$repo_root/config.yaml}"
-mode="${1:-text}"
 python_bin="${FOUNDRYGATE_PYTHON:-python3}"
+mode="text"
+link_source=""
+offer_track=""
+disclosed_only="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      mode="json"
+      shift
+      ;;
+    --text)
+      mode="text"
+      shift
+      ;;
+    --link-source)
+      link_source="${2:-}"
+      shift 2
+      ;;
+    --offer-track)
+      offer_track="${2:-}"
+      shift 2
+      ;;
+    --disclosed-only)
+      disclosed_only="1"
+      shift
+      ;;
+    *)
+      echo "usage: foundrygate-provider-discovery [--json|--text] [--link-source official|operator_override] [--offer-track TRACK] [--disclosed-only]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 export FOUNDRYGATE_DISCOVERY_CONFIG="$config_file"
 export FOUNDRYGATE_DISCOVERY_MODE="$mode"
+export FOUNDRYGATE_DISCOVERY_LINK_SOURCE="$link_source"
+export FOUNDRYGATE_DISCOVERY_OFFER_TRACK="$offer_track"
+export FOUNDRYGATE_DISCOVERY_DISCLOSED_ONLY="$disclosed_only"
 
 "$python_bin" - <<'PY'
 import json
@@ -16,12 +51,18 @@ import os
 from foundrygate.config import load_config
 from foundrygate.provider_catalog import build_provider_discovery_view
 
-view = build_provider_discovery_view(load_config(os.environ["FOUNDRYGATE_DISCOVERY_CONFIG"]))
+view = build_provider_discovery_view(
+    load_config(os.environ["FOUNDRYGATE_DISCOVERY_CONFIG"]),
+    link_source=os.environ.get("FOUNDRYGATE_DISCOVERY_LINK_SOURCE") or None,
+    disclosed_only=os.environ.get("FOUNDRYGATE_DISCOVERY_DISCLOSED_ONLY") == "1",
+    offer_track=os.environ.get("FOUNDRYGATE_DISCOVERY_OFFER_TRACK") or None,
+)
 
-if os.environ["FOUNDRYGATE_DISCOVERY_MODE"] == "--json":
+if os.environ["FOUNDRYGATE_DISCOVERY_MODE"] == "json":
     print(json.dumps(view, indent=2, sort_keys=True))
 else:
     policy = view.get("recommendation_policy", {})
+    filters = view.get("filters", {})
     print("FoundryGate Provider Discovery")
     print("")
     print(
@@ -30,6 +71,13 @@ else:
     )
     if policy.get("disclosure"):
         print(f"Disclosure: {policy['disclosure']}")
+    if any(filters.values()):
+        print(
+            "Filters: "
+            f"link_source={filters.get('link_source') or 'any'}, "
+            f"offer_track={filters.get('offer_track') or 'any'}, "
+            f"disclosed_only={filters.get('disclosed_only', False)}"
+        )
     for item in view.get("providers", []):
         label = "disclosed link" if item.get("disclosure_required") else "official link"
         print("")

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -229,6 +229,45 @@ def test_stats_includes_client_highlights(api_client):
     assert body["client_highlights"]["slowest_client"]["client_tag"] == "batch-jobs"
 
 
+def test_provider_discovery_endpoint_supports_filters(api_client, monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "FOUNDRYGATE_PROVIDER_LINK_OPENROUTER_FALLBACK_URL",
+        "https://go.example.test/openrouter",
+    )
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "secret"
+    model: "openrouter/auto"
+fallback_chain:
+  - openrouter-fallback
+metrics:
+  enabled: false
+""",
+        )
+    )
+    monkeypatch.setattr(main_module, "_config", cfg, raising=False)
+
+    response = api_client.get(
+        "/api/provider-discovery",
+        params={"link_source": "operator_override", "disclosed_only": "true"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["filters"]["link_source"] == "operator_override"
+    assert body["filters"]["disclosed_only"] is True
+    assert [item["provider"] for item in body["providers"]] == ["openrouter-fallback"]
+
+
 def test_route_preview_rejects_large_json_payload(api_client):
     response = api_client.post(
         "/api/route",

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -445,6 +445,69 @@ auto_update:
     assert view["providers"][0]["resolved_url"] == "https://go.example.test/openrouter"
 
 
+def test_provider_discovery_helper_supports_filters(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv(
+        "FOUNDRYGATE_PROVIDER_LINK_OPENROUTER_FALLBACK_URL",
+        "https://go.example.test/openrouter",
+    )
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+fallback_chain:
+  - deepseek-chat
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "secret"
+    model: "openrouter/auto"
+client_profiles:
+  enabled: false
+  profiles:
+    generic: {}
+  rules: []
+routing_policies:
+  enabled: false
+  rules: []
+request_hooks:
+  enabled: false
+  hooks: []
+update_check:
+  enabled: false
+auto_update:
+  enabled: false
+""".strip(),
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "scripts" / "foundrygate-provider-discovery"
+    env = os.environ.copy()
+    env["FOUNDRYGATE_CONFIG_FILE"] = str(config_file)
+    env["FOUNDRYGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(repo_root)
+
+    completed = subprocess.run(
+        ["bash", str(script), "--json", "--link-source", "operator_override", "--disclosed-only"],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    view = json.loads(completed.stdout)
+    assert view["filters"]["link_source"] == "operator_override"
+    assert view["filters"]["disclosed_only"] is True
+    assert [item["provider"] for item in view["providers"]] == ["openrouter-fallback"]
+
+
 def test_onboarding_report_marks_all_builtin_integrations_ready(tmp_path: Path):
     env_file = tmp_path / ".env"
     env_file.write_text("DEEPSEEK_API_KEY=sk-demo\n", encoding="utf-8")

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -225,3 +225,50 @@ metrics:
     provider_names = [item["provider"] for item in view["providers"]]
     assert provider_names == ["deepseek-chat", "openrouter-fallback"]
     assert view["providers"][0]["resolved_url"].startswith("https://")
+
+
+def test_provider_discovery_view_supports_link_source_and_offer_track_filters(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv(
+        "FOUNDRYGATE_PROVIDER_LINK_OPENROUTER_FALLBACK_URL",
+        "https://go.example.test/openrouter",
+    )
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    base_url: "https://api.deepseek.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+  openrouter-fallback:
+    backend: openai-compat
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "secret"
+    model: "openrouter/auto"
+  kilocode:
+    backend: openai-compat
+    base_url: "https://api.kilo.ai/api/gateway/v1"
+    api_key: "secret"
+    model: "z-ai/glm-5:free"
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+
+    operator_view = build_provider_discovery_view(cfg, link_source="operator_override")
+    disclosed_view = build_provider_discovery_view(cfg, disclosed_only=True)
+    free_view = build_provider_discovery_view(cfg, offer_track="free")
+
+    assert operator_view["filters"]["link_source"] == "operator_override"
+    assert [item["provider"] for item in operator_view["providers"]] == ["openrouter-fallback"]
+    assert [item["provider"] for item in disclosed_view["providers"]] == ["openrouter-fallback"]
+    assert [item["provider"] for item in free_view["providers"]] == ["kilocode"]


### PR DESCRIPTION
## Summary
- add filtered provider discovery views for CLI and API
- support link source, offer track, and disclosed-only filtering
- document the new discovery filter flow and cover it with tests

## Verification
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_provider_catalog.py tests/test_onboarding.py tests/test_api_hardening.py
- ./.venv-check-313/bin/ruff check foundrygate/provider_catalog.py foundrygate/main.py tests/test_provider_catalog.py tests/test_onboarding.py tests/test_api_hardening.py README.md docs/API.md docs/CONFIGURATION.md docs/ONBOARDING.md CHANGELOG.md
- bash -n scripts/foundrygate-provider-discovery
- git diff --check