### PR TITLE
docs(release): prepare v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+## v1.4.0 - 2026-03-19
+
+### Changed
+
+- Renamed the product branding from `FoundryGate` to `fusionAIze Gate` across the repository, documentation, examples, and operator-facing surfaces
+- Renamed the technical runtime slug from `foundrygate` to `faigate`, including the Python package, npm CLI package, helper scripts, example file names, service templates, and Homebrew formula path
+- Moved the repository references from `typelicious/FoundryGate` to `fusionAIze/faigate` and aligned env prefixes, headers, and operational examples with the new `FAIGATE_` / `x-faigate-*` naming
+- Completed the first release-prep baseline for the rebrand so future releases, installs, and documentation no longer depend on the old names
+
 ## v1.3.0 - 2026-03-19
 
 ### Added

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.3.0 -m "fusionAIze Gate v1.3.0"
-git push origin v1.3.0
+git tag -a v1.4.0 -m "fusionAIze Gate v1.4.0"
+git push origin v1.4.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.3.0`.
+Then open GitHub Releases and publish a release for `v1.4.0`.
 
 ## Automation Baseline
 
@@ -67,6 +67,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.2` hardens the macOS packaging path further: the Homebrew formula now builds `pydantic-core` from source with explicit header padding, validates the wrapped binary in its formula test, and documents how virtualenvs can shadow the Brew-installed CLI.
 - `v1.2.3` finishes the immediate Brew runtime stabilization pass: the Brew-managed wrapper now invokes the correct Python module entrypoint and the formula also builds `watchfiles` from source to avoid the next macOS linkage fixup failure.
 - `v1.3.0` establishes the guided setup and catalog-assisted discovery baseline: routing modes and shortcuts are first-class, the config wizard can suggest, diff, apply, and back up multi-provider changes, provider-catalog drift alerts are richer, and discovery views stay explicitly performance-led and link-neutral.
+- `v1.4.0` establishes the rebrand baseline: the product name is now `fusionAIze Gate`, the technical slug is `faigate`, and package, script, service, documentation, and repository references align with the new identity.
 
 ## Planned Publishing Path
 
@@ -81,6 +82,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.2`: finish the first macOS packaging hardening pass by targeting the `pydantic-core` linkage warning directly and tightening the wrapper-level install checks.
 - `v1.2.3`: complete the immediate Brew-runtime stabilization work by fixing the packaged entrypoint path and broadening the native-wheel source-build policy on macOS.
 - `v1.3.0`: deepen guided onboarding and catalog-assisted operations with purpose-aware routing modes, config-wizard update flows, provider-catalog drift checks, and compact provider-discovery surfaces.
+- `v1.4.0`: ship the first fully rebranded release under `fusionAIze/faigate` so operators can adopt the new naming without mixed package, script, or documentation surfaces.
 
 The npm package stays separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/faigate/config.py
+++ b/faigate/config.py
@@ -1493,9 +1493,7 @@ def load_config(path: str | Path | None = None) -> Config:
     load_dotenv()
 
     if path is None:
-        env_path = os.environ.get("FAIGATE_CONFIG_FILE") or os.environ.get(
-            "FAIGATE_CONFIG_PATH"
-        )
+        env_path = os.environ.get("FAIGATE_CONFIG_FILE") or os.environ.get("FAIGATE_CONFIG_PATH")
         if env_path:
             path = env_path
 

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.3.0",
+    version="1.4.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.3.0"
+version = "1.4.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package and app versions to `1.4.0`
- roll up the first rebrand release notes for `fusionAIze Gate`
- refresh release guidance for the new `faigate` identity

## Verification
- `PYTHONPYCACHEPREFIX="$PWD/.pycache" python3 -m compileall faigate tests`
- `PYTHONPATH=. ./.venv-check-313/bin/pytest -q`
- `./.venv-check-313/bin/ruff check .`
- `./.venv-check-313/bin/ruff format --check .`
- `./.venv-check-313/bin/python -m build --no-isolation`
- `./.venv-check-313/bin/python -m twine check dist/faigate-1.4.0.tar.gz dist/faigate-1.4.0-py3-none-any.whl`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/node packages/faigate-cli/bin/faigate.js --help`
- `cd packages/faigate-cli && npm_config_cache=/tmp/faigate-npm-cache PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm pack --dry-run`
- `ruby -c Formula/faigate.rb`
- `git diff --check`