### PR TITLE
docs(release): prepare v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+## v1.4.5 - 2026-03-19
+
 ### Added
 
 - Added a first `faigate-menu` control center with a shared terminal UI, the new fusionAIze Gate header, and consistent `q`/`c` navigation across status, configure, explore, validate, control, and update menus

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.4.0 -m "fusionAIze Gate v1.4.0"
-git push origin v1.4.0
+git tag -a v1.4.5 -m "fusionAIze Gate v1.4.5"
+git push origin v1.4.5
 ```
 
-Then open GitHub Releases and publish a release for `v1.4.0`.
+Then open GitHub Releases and publish a release for `v1.4.5`.
 
 ## Automation Baseline
 
@@ -68,6 +68,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.3` finishes the immediate Brew runtime stabilization pass: the Brew-managed wrapper now invokes the correct Python module entrypoint and the formula also builds `watchfiles` from source to avoid the next macOS linkage fixup failure.
 - `v1.3.0` establishes the guided setup and catalog-assisted discovery baseline: routing modes and shortcuts are first-class, the config wizard can suggest, diff, apply, and back up multi-provider changes, provider-catalog drift alerts are richer, and discovery views stay explicitly performance-led and link-neutral.
 - `v1.4.0` establishes the rebrand baseline: the product name is now `fusionAIze Gate`, the technical slug is `faigate`, and package, script, service, documentation, and repository references align with the new identity.
+- `v1.4.5` establishes the first Gate-native shell control-center baseline: operators now get one consistent menu for status, configure, clients, validation, control, and update flows, with client quickstarts, structured configure paths, and stronger service-control helpers.
 
 ## Planned Publishing Path
 
@@ -83,6 +84,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.2.3`: complete the immediate Brew-runtime stabilization work by fixing the packaged entrypoint path and broadening the native-wheel source-build policy on macOS.
 - `v1.3.0`: deepen guided onboarding and catalog-assisted operations with purpose-aware routing modes, config-wizard update flows, provider-catalog drift checks, and compact provider-discovery surfaces.
 - `v1.4.0`: ship the first fully rebranded release under `fusionAIze/faigate` so operators can adopt the new naming without mixed package, script, or documentation surfaces.
+- `v1.4.5`: ship the first cohesive shell UX line for standalone Gate operation, then follow with the actual Homebrew formula bump once the release tag exists.
 
 The npm package stays separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.5"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.4.0",
+    version="1.4.5",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.4.0",
+  "version": "1.4.5",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.4.0"
+version = "1.4.5"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the Python package, runtime, and npm CLI to 1.4.5
- roll the current Unreleased menu/control-center work into a v1.4.5 changelog section
- update RELEASES.md so the next tag/release flow points at v1.4.5 and describes the shell control-center baseline

## Testing
- PYTHONPYCACHEPREFIX="/Users/andrelange/.codex/worktrees/257a/ClawGate/.pycache" python3 -m compileall faigate tests
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/faigate-1.4.5.tar.gz dist/faigate-1.4.5-py3-none-any.whl
- PATH=/opt/homebrew/bin:/Users/andrelange/bin:/Users/andrelange/.local/bin:/opt/homebrew/opt/openssl@3/bin:/opt/homebrew/opt/mysql/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/Applications/Codex.app/Contents/Resources node packages/faigate-cli/bin/faigate.js --help
- PATH=/opt/homebrew/bin:/Users/andrelange/bin:/Users/andrelange/.local/bin:/opt/homebrew/opt/openssl@3/bin:/opt/homebrew/opt/mysql/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/Applications/Codex.app/Contents/Resources cd packages/faigate-cli && npm_config_cache=/tmp/faigate-npm-cache npm pack --dry-run
- ruby -c Formula/faigate.rb