### PR TITLE
docs(release): prepare v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 
 ## Unreleased
 
+## v1.5.1 - 2026-03-20
+
+### Changed
+
+- Reworked the interactive config wizard candidate screen so purpose/client selection now shows compact `Ready now`, `More options if you add keys`, and `Optional specialty add-ons` cards instead of a raw provider metadata dump
+- Improved the client quickstart surfaces so the menu and client helper now show a clearer `Best next step` hint and friendlier `Preset matches` wording instead of implying that `Presets 0` means something is broken
+- Clarified the API-key helper so provider base URL overrides are explicitly labeled as optional upstream overrides, reducing confusion between local Gate client URLs and upstream provider endpoints
+- Nudged the terminal logo spacing closer to the intended fusionAIze Gate wordmark in interactive screens
+
 ## v1.5.0 - 2026-03-20
 
 ### Changed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.5.0 -m "fusionAIze Gate v1.5.0"
-git push origin v1.5.0
+git tag -a v1.5.1 -m "fusionAIze Gate v1.5.1"
+git push origin v1.5.1
 ```
 
-Then open GitHub Releases and publish a release for `v1.5.0`.
+Then open GitHub Releases and publish a release for `v1.5.1`.
 
 ## Automation Baseline
 
@@ -70,6 +70,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.4.0` establishes the rebrand baseline: the product name is now `fusionAIze Gate`, the technical slug is `faigate`, and package, script, service, documentation, and repository references align with the new identity.
 - `v1.4.5` establishes the first Gate-native shell control-center baseline: operators now get one consistent menu for status, configure, clients, validation, control, and update flows, with client quickstarts, structured configure paths, and stronger service-control helpers.
 - `v1.5.0` deepens that shell UX into a stronger happy path: Quick Setup, summary cards, client recommendation cards, drilldowns, and explicit next-step receipts now make first setup and handoff flows feel much more guided.
+- `v1.5.1` polishes that guided shell UX: the wizard now surfaces compact ready-now candidate cards, the client area highlights the best next action more clearly, and base-url override prompts are explicitly framed as upstream provider overrides.
 
 ## Planned Publishing Path
 
@@ -87,6 +88,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.4.0`: ship the first fully rebranded release under `fusionAIze/faigate` so operators can adopt the new naming without mixed package, script, or documentation surfaces.
 - `v1.4.5`: ship the first cohesive shell UX line for standalone Gate operation, then follow with the actual Homebrew formula bump once the release tag exists.
 - `v1.5.0`: ship the first “guided wow path” for standalone Gate operation, then follow with the Homebrew formula bump once the release tag exists.
+- `v1.5.1`: tighten the first post-`v1.5.0` UX follow-up with clearer wizard cards, client-action hints, and less ambiguous provider override prompts.
 
 The npm package stays separate from the Python gateway core. It is meant for CLI-facing integrations, not for rewriting the service runtime.
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.5.0",
+    version="1.5.1",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.5.0"
+version = "1.5.1"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the version to v1.5.1 across Python and npm metadata
- roll the wizard/client polish into the changelog
- update the release guide baseline for the new patch release

## Verification
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_menu_helpers.py tests/test_onboarding.py
- ./.venv-check-313/bin/ruff check faigate/wizard.py tests/test_wizard.py tests/test_menu_helpers.py CHANGELOG.md RELEASES.md
- ./.venv-check-313/bin/python -m build --no-isolation
- git diff --check