### PR TITLE
docs(release): prepare v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to fusionAIze Gate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
-## Unreleased
+## v1.6.0 - 2026-03-20
 
 ### Added
 
@@ -19,6 +19,8 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Renamed the old `FOUNDRYGATE STATS` CLI banner to `fusionAIze Gate Stats` so the terminal metrics surfaces stay on-brand
 - Expanded client scenarios with clearer `budget`, `best when`, and `tradeoff` guidance so operators can pick templates by intent instead of only by routing-mode names
 - Expanded the new dashboard with budget, quota, and routing-pressure hints so it now helps answer whether traffic should shift, a cheaper scenario is worth trying, or a provider likely needs more budget
+
+## Unreleased
 
 ## v1.5.1 - 2026-03-20
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.5.1 -m "fusionAIze Gate v1.5.1"
-git push origin v1.5.1
+git tag -a v1.6.0 -m "fusionAIze Gate v1.6.0"
+git push origin v1.6.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.5.1`.
+Then open GitHub Releases and publish a release for `v1.6.0`.
 
 ## Automation Baseline
 
@@ -71,6 +71,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.4.5` establishes the first Gate-native shell control-center baseline: operators now get one consistent menu for status, configure, clients, validation, control, and update flows, with client quickstarts, structured configure paths, and stronger service-control helpers.
 - `v1.5.0` deepens that shell UX into a stronger happy path: Quick Setup, summary cards, client recommendation cards, drilldowns, and explicit next-step receipts now make first setup and handoff flows feel much more guided.
 - `v1.5.1` polishes that guided shell UX: the wizard now surfaces compact ready-now candidate cards, the client area highlights the best next action more clearly, and base-url override prompts are explicitly framed as upstream provider overrides.
+- `v1.6.0` establishes the operator decision-support baseline: provider setup, provider probe, client scenario templates, and the new shell dashboard now work together as one onboarding-and-operations flow, with budget and routing hints layered into the live metrics view.
 
 ## Planned Publishing Path
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.5.1"
+__version__ = "1.6.0"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.5.1",
+    version="1.6.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.5.1"
+version = "1.6.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package and CLI versions to v1.6.0
- roll the provider onboarding and dashboard work into the release notes
- refresh release guidance for the v1.6.0 tag and publish flow

## Verification
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/faigate-1.6.0.tar.gz dist/faigate-1.6.0-py3-none-any.whl
- zsh -lc 'PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources node packages/faigate-cli/bin/faigate.js --help'
- ruby -c Formula/faigate.rb
- git diff --check

## Notes
- npm pack --dry-run is still blocked locally by root-owned files in ~/.npm from an older npm setup, so that check was not part of this run.