### PR TITLE
packaging: bump Homebrew formula to v1.6.1

### DIFF
--- a/Formula/faigate.rb
+++ b/Formula/faigate.rb
@@ -1,8 +1,8 @@
 class Faigate < Formula
   desc "Local OpenAI-compatible AI gateway for OpenClaw and other AI-native clients"
   homepage "https://github.com/fusionAIze/faigate"
-  url "https://github.com/fusionAIze/faigate/archive/refs/tags/v1.6.0.tar.gz"
-  sha256 "d46b39e9631f351199e96af6efe2d9228a1a7429ab88dc682b83525cef13da0b"
+  url "https://github.com/fusionAIze/faigate/archive/refs/tags/v1.6.1.tar.gz"
+  sha256 "8f664df4020c2efe773af636fcf7518b739bafef437dea96e57e352aa5fc66b4"
   license "Apache-2.0"
   head "https://github.com/fusionAIze/faigate.git", branch: "main"
 


### PR DESCRIPTION
## Summary
- point the Homebrew formula at the released v1.6.1 tarball
- update the formula checksum to the published release archive

## Verification
- ruby -c Formula/faigate.rb
- git diff --check