### PR TITLE
feat(ui): add internal drilldowns and richer scenario lanes

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -628,7 +628,113 @@ def _render_alerts(report: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def render_dashboard_text(report: dict[str, Any], *, view: str = "overview") -> str:
+def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
+    target = provider_name.strip().lower()
+    unhealthy = {item["provider"]: item for item in report["cards"]["health"]["unhealthy"]}
+    row = next(
+        (item for item in report["providers"] if str(item.get("provider") or "").lower() == target),
+        None,
+    )
+    if not row:
+        return (
+            "fusionAIze Gate Dashboard\n\n"
+            f"Provider detail\n\nNo provider row found for '{provider_name}'.\n"
+        )
+
+    provider = str(row.get("provider") or provider_name)
+    status = "live-healthy"
+    if provider in unhealthy:
+        status = unhealthy[provider]["category"]
+
+    requests = _safe_int(row.get("requests"))
+    failures = _safe_int(row.get("failures"))
+    success_pct = 100.0 - (failures * 100.0 / max(1, requests))
+    lines = [
+        "fusionAIze Gate Dashboard",
+        "",
+        f"Provider detail: {provider}",
+        "",
+        f"Status            {status}",
+        f"Requests          {requests}",
+        f"Failures          {failures}",
+        f"Success           {_format_pct(success_pct)}",
+        f"Latency           {_format_latency_ms(_safe_float(row.get('avg_latency_ms')))}",
+        f"Cost              {_format_usd(_safe_float(row.get('cost_usd')))}",
+        f"Tokens            {_format_tokens(_safe_int(row.get('total_tokens')))}",
+        f"Prompt tokens     {_format_tokens(_safe_int(row.get('prompt_tokens')))}",
+        f"Completion tokens {_format_tokens(_safe_int(row.get('completion_tokens')))}",
+    ]
+    if provider in unhealthy:
+        lines.append(f"Live issue        {unhealthy[provider]['detail']}")
+    lines.extend(
+        [
+            "",
+            "Operator hints",
+            "- Compare this provider against Providers view when latency or failure rate starts drifting.",
+            "- If this is expensive and stable, move lighter traffic to cheaper workhorse lanes before adding budget.",
+            "- If this is both slow and expensive, keep it for the hard tasks and shift the rest to a balanced scenario.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _render_client_detail(report: dict[str, Any], client_name: str) -> str:
+    target = client_name.strip().lower()
+    row = next(
+        (
+            item
+            for item in report["clients"]
+            if str(item.get("client_tag") or item.get("client_profile") or "").lower() == target
+        ),
+        None,
+    )
+    if not row:
+        return (
+            "fusionAIze Gate Dashboard\n\n"
+            f"Client detail\n\nNo client row found for '{client_name}'.\n"
+        )
+
+    name = str(row.get("client_tag") or row.get("client_profile") or client_name)
+    expensive = (
+        _safe_float(row.get("cost_usd")) > 0.5 or _safe_float(row.get("avg_latency_ms")) > 4000
+    )
+    suggested_scenario = _recommended_scenario_for_client(
+        str(row.get("client_profile") or name),
+        expensive=expensive,
+    )
+    lines = [
+        "fusionAIze Gate Dashboard",
+        "",
+        f"Client detail: {name}",
+        "",
+        f"Profile           {row.get('client_profile') or 'generic'}",
+        f"Requests          {_safe_int(row.get('requests'))}",
+        f"Success           {_format_pct(_safe_float(row.get('success_pct') or 0))}",
+        f"Latency           {_format_latency_ms(_safe_float(row.get('avg_latency_ms')))}",
+        f"Cost              {_format_usd(_safe_float(row.get('cost_usd')))}",
+        f"Tokens            {_format_tokens(_safe_int(row.get('total_tokens')))}",
+        f"Providers         {row.get('providers') or 'n/a'}",
+    ]
+    if suggested_scenario:
+        lines.append(f"Suggested scenario {suggested_scenario}")
+    lines.extend(
+        [
+            "",
+            "Decision help",
+            "- Use the suggested scenario when this client needs a cleaner default without hand-editing the profile.",
+            "- If this client is expensive but not mission-critical, trial an eco or free path first.",
+            "- If this client is slow on hard tasks, keep premium paths for it and move lighter traffic elsewhere.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_dashboard_text(
+    report: dict[str, Any],
+    *,
+    view: str = "overview",
+    target: str | None = None,
+) -> str:
     """Render one human-readable dashboard view."""
     renderers = {
         "overview": _render_overview,
@@ -637,6 +743,10 @@ def render_dashboard_text(report: dict[str, Any], *, view: str = "overview") -> 
         "activity": _render_activity,
         "alerts": _render_alerts,
     }
+    if view == "provider-detail":
+        return _render_provider_detail(report, target or "")
+    if view == "client-detail":
+        return _render_client_detail(report, target or "")
     return renderers.get(view, _render_overview)(report)
 
 

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -136,6 +136,54 @@ _CLIENT_SCENARIOS: dict[str, dict[str, str]] = {
     },
 }
 
+_PROVIDER_ROLE_TAXONOMY: dict[str, dict[str, str]] = {
+    "anthropic-claude": {
+        "family": "Anthropic",
+        "slot": "quality",
+        "role": "architecture / deep review",
+    },
+    "openai-gpt4o": {
+        "family": "OpenAI",
+        "slot": "balanced",
+        "role": "general premium workhorse",
+    },
+    "deepseek-reasoner": {
+        "family": "DeepSeek",
+        "slot": "reasoning",
+        "role": "hard reasoning / debugging",
+    },
+    "deepseek-chat": {
+        "family": "DeepSeek",
+        "slot": "balanced",
+        "role": "day-to-day coding workhorse",
+    },
+    "gemini-flash": {
+        "family": "Gemini",
+        "slot": "balanced",
+        "role": "fast general coding",
+    },
+    "gemini-flash-lite": {
+        "family": "Gemini",
+        "slot": "cheap",
+        "role": "cheap burst traffic",
+    },
+    "kilocode": {
+        "family": "Kilo",
+        "slot": "free",
+        "role": "free coding coverage",
+    },
+    "blackbox-free": {
+        "family": "BLACKBOX",
+        "slot": "free",
+        "role": "free coding burst lane",
+    },
+    "openrouter-fallback": {
+        "family": "OpenRouter",
+        "slot": "fallback",
+        "role": "marketplace safety net",
+    },
+}
+
 
 _PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "deepseek-chat": {
@@ -1021,6 +1069,143 @@ def _scenario_provider_selection(*, purpose: str, client: str) -> list[str]:
     ]
 
 
+def _scenario_provider_selection_for_spec(spec: dict[str, Any]) -> list[str]:
+    purpose = str(spec["purpose"])
+    client = str(spec["client"])
+    routing_mode = str(spec.get("routing_mode") or "auto")
+
+    if client == "opencode":
+        by_mode = {
+            "eco": [
+                "gemini-flash-lite",
+                "kilocode",
+                "blackbox-free",
+                "deepseek-chat",
+                "deepseek-reasoner",
+                "openrouter-fallback",
+            ],
+            "auto": [
+                "deepseek-reasoner",
+                "deepseek-chat",
+                "anthropic-claude",
+                "openai-gpt4o",
+                "gemini-flash",
+                "kilocode",
+                "blackbox-free",
+                "openrouter-fallback",
+            ],
+            "premium": [
+                "anthropic-claude",
+                "openai-gpt4o",
+                "deepseek-reasoner",
+                "deepseek-chat",
+                "gemini-flash",
+                "openrouter-fallback",
+            ],
+            "free": [
+                "kilocode",
+                "blackbox-free",
+                "gemini-flash-lite",
+                "deepseek-chat",
+                "openrouter-fallback",
+            ],
+        }
+        preferred = by_mode.get(routing_mode, by_mode["auto"])
+        return [name for name in preferred if name in _PROVIDER_FACTORIES]
+
+    return _scenario_provider_selection(purpose=purpose, client=client)
+
+
+def _scenario_provider_lanes(provider_names: list[str]) -> list[tuple[str, list[str]]]:
+    lane_order = [
+        ("quality-first", ["anthropic-claude", "openai-gpt4o"]),
+        ("reasoning", ["deepseek-reasoner"]),
+        ("balanced workhorses", ["deepseek-chat", "gemini-flash"]),
+        ("budget / free", ["gemini-flash-lite", "kilocode", "blackbox-free"]),
+        ("fallback safety", ["openrouter-fallback"]),
+    ]
+    lanes: list[tuple[str, list[str]]] = []
+    for lane_name, lane_candidates in lane_order:
+        lane_members = [name for name in lane_candidates if name in provider_names]
+        if lane_members:
+            lanes.append((lane_name, lane_members))
+    return lanes
+
+
+def _scenario_provider_role(provider_name: str) -> str:
+    taxonomy = _PROVIDER_ROLE_TAXONOMY.get(provider_name) or {}
+    return str(taxonomy.get("role") or "")
+
+
+def _scenario_lane_descriptions(provider_names: list[str]) -> list[tuple[str, list[str]]]:
+    detailed_lanes: list[tuple[str, list[str]]] = []
+    for lane_name, lane_members in _scenario_provider_lanes(provider_names):
+        enriched = []
+        for provider_name in lane_members:
+            role = _scenario_provider_role(provider_name)
+            if role:
+                enriched.append(f"{provider_name} ({role})")
+            else:
+                enriched.append(provider_name)
+        detailed_lanes.append((lane_name, enriched))
+    return detailed_lanes
+
+
+def _scenario_family_coverage(provider_names: list[str]) -> list[str]:
+    provider_set = set(provider_names)
+    coverage: list[str] = []
+    if "anthropic-claude" in provider_set:
+        coverage.append("Anthropic: quality lane active; workhorse/fast lane not configured yet")
+    if "openai-gpt4o" in provider_set:
+        coverage.append(
+            "OpenAI: balanced lane active; faster or cheaper family split not configured yet"
+        )
+    if "deepseek-reasoner" in provider_set and "deepseek-chat" in provider_set:
+        coverage.append("DeepSeek: reasoning + workhorse lanes active")
+    if {"kilocode", "blackbox-free"} & provider_set:
+        coverage.append("Free lane: aggregator-backed budget coverage is active")
+    return coverage
+
+
+def _scenario_family_hint(provider_names: list[str]) -> str | None:
+    hints: list[str] = []
+    provider_set = set(provider_names)
+    if "anthropic-claude" in provider_set:
+        hints.append(
+            "Anthropic is currently represented by one quality lane. "
+            "Add separate Sonnet or Haiku-style providers if you want "
+            "dedicated workhorse or fast Anthropic slots."
+        )
+    if "openai-gpt4o" in provider_set:
+        hints.append(
+            "OpenAI is currently represented by one balanced multimodal "
+            "lane. Add more OpenAI family variants if you want sharper "
+            "quality vs speed splits there too."
+        )
+    if hints:
+        return " ".join(hints)
+    return None
+
+
+def _scenario_deemphasized_providers(provider_names: list[str]) -> list[str]:
+    scenario_set = set(provider_names)
+    return [
+        name
+        for name in (
+            "anthropic-claude",
+            "openai-gpt4o",
+            "deepseek-reasoner",
+            "deepseek-chat",
+            "gemini-flash",
+            "gemini-flash-lite",
+            "kilocode",
+            "blackbox-free",
+            "openrouter-fallback",
+        )
+        if name in _PROVIDER_FACTORIES and name not in scenario_set
+    ]
+
+
 def list_client_scenarios(
     *,
     env_file: str | Path | None = None,
@@ -1030,7 +1215,7 @@ def list_client_scenarios(
     detected = set(detect_wizard_providers(env_file=env_file))
     scenarios: list[dict[str, Any]] = []
     for scenario_id, spec in _CLIENT_SCENARIOS.items():
-        preferred = _scenario_provider_selection(purpose=spec["purpose"], client=spec["client"])
+        preferred = _scenario_provider_selection_for_spec(spec)
         ready = [name for name in preferred if name in detected]
         configured_hits = [name for name in preferred if name in configured]
         scenarios.append(
@@ -1047,6 +1232,11 @@ def list_client_scenarios(
                 "recommended_providers": preferred,
                 "ready_providers": ready,
                 "configured_providers": configured_hits,
+                "provider_lanes": _scenario_provider_lanes(preferred),
+                "lane_descriptions": _scenario_lane_descriptions(preferred),
+                "family_coverage": _scenario_family_coverage(preferred),
+                "deemphasized_providers": _scenario_deemphasized_providers(preferred),
+                "family_hint": _scenario_family_hint(preferred),
             }
         )
     return scenarios
@@ -1070,6 +1260,9 @@ def render_client_scenarios_text(
             lines.append("  " + f"best when: {item['best_for']}")
         if item["tradeoff"]:
             lines.append("  " + f"tradeoff: {item['tradeoff']}")
+        if item["lane_descriptions"]:
+            for lane_name, lane_members in item["lane_descriptions"]:
+                lines.append("  " + f"{lane_name}: " + ", ".join(lane_members))
         if item["ready_providers"]:
             lines.append("  " + "ready now: " + ", ".join(item["ready_providers"]))
         elif item["recommended_providers"]:
@@ -1079,10 +1272,27 @@ def render_client_scenarios_text(
                 + ", ".join(item["recommended_providers"][:4])
                 + (" ..." if len(item["recommended_providers"]) > 4 else "")
             )
+        if item["deemphasized_providers"]:
+            lines.append(
+                "  "
+                + "de-emphasized now: "
+                + ", ".join(item["deemphasized_providers"][:4])
+                + (" ..." if len(item["deemphasized_providers"]) > 4 else "")
+            )
+        if item.get("family_hint"):
+            lines.append("  " + f"family note: {item['family_hint']}")
+        if item["family_coverage"]:
+            for coverage_line in item["family_coverage"]:
+                lines.append("  " + f"family coverage: {coverage_line}")
     lines.append("")
     lines.append(
         "Tip: Apply one scenario when you want a client-specific default "
         "without hand-editing profile modes."
+    )
+    lines.append(
+        "Tip: Scenario lanes describe the current configured provider inventory. "
+        "If you want separate Opus / Sonnet / Haiku or similar family lanes, "
+        "add them as distinct providers first."
     )
     return "\n".join(lines) + "\n"
 
@@ -1096,14 +1306,15 @@ def apply_client_scenario(
     if scenario_id not in _CLIENT_SCENARIOS:
         raise ValueError(f"Unsupported client scenario '{scenario_id}'")
     spec = _CLIENT_SCENARIOS[scenario_id]
+    available = detect_wizard_providers(env_file=env_file)
+    selected = [
+        name for name in _scenario_provider_selection_for_spec(spec) if name in set(available)
+    ]
     suggestion = build_initial_config(
         env_file=env_file,
         purpose=spec["purpose"],
         client=spec["client"],
-        selected_providers=_scenario_provider_selection(
-            purpose=spec["purpose"],
-            client=spec["client"],
-        ),
+        selected_providers=selected,
     )
     merged = merge_initial_config(config_path=config_path, suggestion=suggestion)
     profiles = merged.setdefault("client_profiles", {}).setdefault("profiles", {})

--- a/scripts/faigate-client-integrations
+++ b/scripts/faigate-client-integrations
@@ -10,11 +10,12 @@ mode="text"
 client_name=""
 include_matrix="0"
 recommended_only="0"
+interactive_mode="0"
 
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/faigate-client-integrations [--json|--text] [--client NAME] [--matrix] [--recommended]
+  ./scripts/faigate-client-integrations [--json|--text] [--client NAME] [--matrix] [--recommended] [--interactive]
 
 Show client quickstarts and the current client-profile matrix from the active
 fusionAIze Gate config.
@@ -43,6 +44,10 @@ while [[ $# -gt 0 ]]; do
       recommended_only="1"
       shift
       ;;
+    --interactive)
+      interactive_mode="1"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -54,12 +59,51 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+client_entries=()
+if [[ "$interactive_mode" == "1" && -z "$client_name" && "$mode" == "text" ]]; then
+  client_entries_output="$(
+    FAIGATE_INTEGRATION_CONFIG="$config_file" \
+    FAIGATE_INTEGRATION_ENV="$env_file" \
+    "$python_bin" - <<'PY'
+from faigate.onboarding import build_onboarding_report
+import os
+
+report = build_onboarding_report(
+    config_path=os.environ["FAIGATE_INTEGRATION_CONFIG"],
+    env_file=os.environ["FAIGATE_INTEGRATION_ENV"],
+)
+
+priority = dict(
+    [
+        ("opencode", 0),
+        ("openclaw", 1),
+        ("n8n", 2),
+        ("cli", 3),
+    ]
+)
+
+def sort_key(item):
+    name, data = item
+    recommended = 0 if data.get("recommended") else 1
+    return (recommended, priority.get(name, 99), name)
+
+for name, data in sorted(report["integrations"].items(), key=sort_key):
+    readiness = "recommended" if data.get("recommended") else "available"
+    print(f"{name}\t{readiness}")
+PY
+  )"
+  while IFS= read -r entry; do
+    [ -n "$entry" ] && client_entries+=("$entry")
+  done <<< "$client_entries_output"
+fi
+
 FAIGATE_INTEGRATION_CONFIG="$config_file" \
 FAIGATE_INTEGRATION_ENV="$env_file" \
 FAIGATE_INTEGRATION_MODE="$mode" \
 FAIGATE_INTEGRATION_CLIENT="$client_name" \
 FAIGATE_INTEGRATION_MATRIX="$include_matrix" \
 FAIGATE_INTEGRATION_RECOMMENDED="$recommended_only" \
+FAIGATE_INTEGRATION_INTERACTIVE="$interactive_mode" \
 "$python_bin" - <<'PY'
 import json
 import os
@@ -145,7 +189,10 @@ else:
         print("Recommended clients now")
         if best_next:
             print(f"  Best next step: {best_next}")
-            print(f"  Drill in with --client {best_next} for copyable setup details.")
+            if os.environ.get("FAIGATE_INTEGRATION_INTERACTIVE") == "1":
+                print("  Use the drilldown selector below for one client at a time.")
+            else:
+                print(f"  Drill in with --client {best_next} for copyable setup details.")
         for name in recommended_names:
             data = all_integrations[name]
             print(f"- {name}")
@@ -159,5 +206,43 @@ else:
             print("")
             print("More available")
             print("  " + ", ".join(remaining_names))
-            print("  Use --client NAME for a detailed drilldown.")
+            if os.environ.get("FAIGATE_INTEGRATION_INTERACTIVE") == "1":
+                print("  Pick one below for a detailed drilldown inside Gate.")
+            else:
+                print("  Use --client NAME for a detailed drilldown.")
 PY
+
+if [[ "$interactive_mode" == "1" && -z "$client_name" && "$mode" == "text" && ${#client_entries[@]} -gt 0 ]]; then
+  echo ""
+  echo "  Open client drilldown"
+  entry_index=1
+  for entry in "${client_entries[@]}"; do
+    client_label="${entry%%$'\t'*}"
+    readiness_label="${entry#*$'\t'}"
+    printf "   %2d)  %-16s %s\n" "$entry_index" "$client_label" "$readiness_label"
+    entry_index=$((entry_index + 1))
+  done
+  echo ""
+  echo "   c)  Cancel"
+  echo "   q)  Quit"
+  echo ""
+  printf "  ▸ Selection: "
+  read -r selection
+  case "$selection" in
+    q|Q)
+      exit 0
+      ;;
+    c|C|"")
+      exit 0
+      ;;
+    *)
+      if [[ "$selection" =~ ^[0-9]+$ ]] && (( selection >= 1 && selection <= ${#client_entries[@]} )); then
+        chosen_entry="${client_entries[$((selection - 1))]}"
+        chosen_client="${chosen_entry%%$'\t'*}"
+        exec "$0" --client "$chosen_client"
+      fi
+      echo "Invalid selection." >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/scripts/faigate-client-scenarios
+++ b/scripts/faigate-client-scenarios
@@ -9,6 +9,7 @@ env_file="$(faigate_env_file)"
 python_bin="$(faigate_python_bin)"
 mode="interactive"
 scenario_id=""
+interactive_choice="0"
 
 usage() {
   cat <<'EOF'
@@ -17,6 +18,7 @@ Usage:
   ./scripts/faigate-client-scenarios --text
   ./scripts/faigate-client-scenarios --json
   ./scripts/faigate-client-scenarios --scenario ID --apply
+  ./scripts/faigate-client-scenarios --interactive
 
 Review or apply named client scenario templates such as:
   opencode-eco
@@ -42,6 +44,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --apply)
       mode="apply"
+      shift
+      ;;
+    --interactive)
+      mode="interactive"
+      interactive_choice="1"
       shift
       ;;
     --help|-h)
@@ -97,6 +104,21 @@ else:
 PY
 }
 
+list_scenario_ids() {
+  FAIGATE_SCENARIO_CONFIG="$config_file" \
+    FAIGATE_SCENARIO_ENV="$env_file" \
+    "$python_bin" - <<'PY'
+from faigate.wizard import list_client_scenarios
+import os
+
+for item in list_client_scenarios(
+    env_file=os.environ["FAIGATE_SCENARIO_ENV"],
+    config_path=os.environ["FAIGATE_SCENARIO_CONFIG"],
+):
+    print(f"{item['id']}\t{item['title']}\t{item['budget_posture']}")
+PY
+}
+
 apply_scenario() {
   local scenario="$1"
   local write_mode="$2"
@@ -144,15 +166,35 @@ while true; do
   faigate_ui_header "fusionAIze Gate Client Scenarios" "Named templates for client-specific defaults"
   render_scenarios text
   echo ""
-  printf "  %bChoose scenario%b  %s\n" "$FAIGATE_UI_BOLD" "$FAIGATE_UI_RESET" "(enter one scenario ID, Enter cancels)"
+  scenario_entries=()
+  while IFS= read -r entry; do
+    [ -n "$entry" ] && scenario_entries+=("$entry")
+  done <<< "$(list_scenario_ids)"
+
+  printf "  %bChoose scenario%b  %s\n" "$FAIGATE_UI_BOLD" "$FAIGATE_UI_RESET" "(pick a number or enter one scenario ID)"
+  entry_index=1
+  for entry in "${scenario_entries[@]}"; do
+    scenario_key="${entry%%$'\t'*}"
+    entry_rest="${entry#*$'\t'}"
+    scenario_title="${entry_rest%%$'\t'*}"
+    scenario_budget="${entry##*$'\t'}"
+    printf "   %2d)  %-20s %s [%s]\n" "$entry_index" "$scenario_key" "$scenario_title" "$scenario_budget"
+    entry_index=$((entry_index + 1))
+  done
   printf "  q) Quit\n"
   printf "  c) Cancel\n"
-  printf "  ▸ Scenario ID: "
-  read -r scenario_id
-  case "$scenario_id" in
+  printf "  ▸ Selection: "
+  read -r scenario_selection
+  case "$scenario_selection" in
     q|Q) exit 0 ;;
     c|C|"") return 0 2>/dev/null || exit 0 ;;
   esac
+  if [[ "$scenario_selection" =~ ^[0-9]+$ ]] && (( scenario_selection >= 1 && scenario_selection <= ${#scenario_entries[@]} )); then
+    chosen_entry="${scenario_entries[$((scenario_selection - 1))]}"
+    scenario_id="${chosen_entry%%$'\t'*}"
+  else
+    scenario_id="$scenario_selection"
+  fi
   echo ""
   apply_scenario "$scenario_id" "dry"
   echo ""

--- a/scripts/faigate-dashboard
+++ b/scripts/faigate-dashboard
@@ -2,11 +2,14 @@
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/faigate-service-lib.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/faigate-ui-lib.sh"
 
 python_bin="$(faigate_python_bin)"
 db_path="$(faigate_db_path)"
 view="overview"
 mode="text"
+target_name=""
+interactive_mode="0"
 
 usage() {
   cat <<'EOF'
@@ -16,6 +19,9 @@ Usage:
   ./scripts/faigate-dashboard --clients
   ./scripts/faigate-dashboard --activity
   ./scripts/faigate-dashboard --alerts
+  ./scripts/faigate-dashboard --provider NAME
+  ./scripts/faigate-dashboard --client NAME
+  ./scripts/faigate-dashboard --interactive
   ./scripts/faigate-dashboard --json
 
 Operator-facing performance dashboard for fusionAIze Gate.
@@ -26,6 +32,9 @@ Views:
   --clients    Client-level traffic, cost, and latency
   --activity   24h activity, recent daily trend, and operator actions
   --alerts     Alerts and decision support
+  --provider   One provider detail view
+  --client     One client detail view
+  --interactive Open an internal dashboard selector
   --json       Raw dashboard report as JSON
 EOF
 }
@@ -52,6 +61,20 @@ while [[ $# -gt 0 ]]; do
       view="alerts"
       shift
       ;;
+    --provider)
+      view="provider-detail"
+      target_name="${2:-}"
+      shift 2
+      ;;
+    --client)
+      view="client-detail"
+      target_name="${2:-}"
+      shift 2
+      ;;
+    --interactive)
+      interactive_mode="1"
+      shift
+      ;;
     --json)
       mode="json"
       shift
@@ -71,23 +94,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-health_payload=""
-stats_payload=""
-
-if payload="$(curl -fsS -m 2 "$(faigate_health_url)" 2>/dev/null)"; then
-  health_payload="$payload"
-fi
-
-if payload="$(curl -fsS -m 2 "$(faigate_stats_url)" 2>/dev/null)"; then
-  stats_payload="$payload"
-fi
-
-FAIGATE_DASHBOARD_DB="$db_path" \
-FAIGATE_DASHBOARD_VIEW="$view" \
-FAIGATE_DASHBOARD_MODE="$mode" \
-FAIGATE_DASHBOARD_HEALTH="$health_payload" \
-FAIGATE_DASHBOARD_STATS="$stats_payload" \
-"$python_bin" - <<'PY'
+build_report_json() {
+  local report_mode="${1:-json}"
+  FAIGATE_DASHBOARD_DB="$db_path" \
+  FAIGATE_DASHBOARD_VIEW="$view" \
+  FAIGATE_DASHBOARD_MODE="$report_mode" \
+  FAIGATE_DASHBOARD_TARGET="$target_name" \
+  FAIGATE_DASHBOARD_HEALTH="$health_payload" \
+  FAIGATE_DASHBOARD_STATS="$stats_payload" \
+  "$python_bin" - <<'PY'
 import json
 import os
 
@@ -108,5 +123,122 @@ report = build_dashboard_report(
 if os.environ["FAIGATE_DASHBOARD_MODE"] == "json":
     print(report_as_json(report))
 else:
-    print(render_dashboard_text(report, view=os.environ["FAIGATE_DASHBOARD_VIEW"]), end="")
+    print(
+        render_dashboard_text(
+            report,
+            view=os.environ["FAIGATE_DASHBOARD_VIEW"],
+            target=os.environ.get("FAIGATE_DASHBOARD_TARGET") or None,
+        ),
+        end="",
+    )
 PY
+}
+
+health_payload=""
+stats_payload=""
+
+if payload="$(curl -fsS -m 2 "$(faigate_health_url)" 2>/dev/null)"; then
+  health_payload="$payload"
+fi
+
+if payload="$(curl -fsS -m 2 "$(faigate_stats_url)" 2>/dev/null)"; then
+  stats_payload="$payload"
+fi
+
+if [[ "$interactive_mode" == "1" && "$mode" == "text" && -z "$target_name" ]]; then
+  while true; do
+    faigate_ui_header "fusionAIze Gate Dashboard" "Performance drilldowns for providers, clients, activity, and alerts"
+    build_report_json text
+    report_json="$(build_report_json json)"
+    echo ""
+    printf "    1)  Overview           Global confidence view\n"
+    printf "    2)  Providers          Summary table for provider traffic and spend\n"
+    printf "    3)  Clients            Summary table for client traffic and spend\n"
+    printf "    4)  Provider Detail    Pick one provider and open its detail view\n"
+    printf "    5)  Client Detail      Pick one client and open its detail view\n"
+    printf "    6)  Activity           24h activity and daily trend\n"
+    printf "    7)  Alerts             Alerts and decision support\n"
+    printf "    8)  Raw JSON           Full dashboard report\n"
+    printf "\n"
+    printf "    c)  Cancel\n"
+    printf "    q)  Quit\n\n"
+    printf "  ▸ Choice: "
+    read -r dashboard_choice
+    case "$dashboard_choice" in
+      1) exec "$0" --overview ;;
+      2) exec "$0" --providers ;;
+      3) exec "$0" --clients ;;
+      4)
+        selection="$(
+          FAIGATE_DASHBOARD_REPORT="$report_json" "$python_bin" - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["FAIGATE_DASHBOARD_REPORT"])
+for index, row in enumerate(report.get("providers") or [], start=1):
+    print(f"{index}\t{row.get('provider') or 'unknown'}")
+PY
+        )"
+        echo ""
+        echo "  Provider detail"
+        while IFS= read -r entry; do
+          [ -z "$entry" ] && continue
+          index="${entry%%$'\t'*}"
+          name="${entry#*$'\t'}"
+          printf "   %2d)  %s\n" "$index" "$name"
+        done <<< "$selection"
+        printf "\n    c)  Cancel\n"
+        printf "    q)  Quit\n\n"
+        printf "  ▸ Selection: "
+        read -r provider_choice
+        case "$provider_choice" in
+          q|Q) exit 0 ;;
+          c|C|"") continue ;;
+        esac
+        chosen_provider="$(printf '%s\n' "$selection" | awk -F '\t' -v target="$provider_choice" '$1 == target || $2 == target {print $2; exit}')"
+        [ -n "$chosen_provider" ] || { faigate_ui_warn "Invalid selection."; faigate_ui_pause; continue; }
+        exec "$0" --provider "$chosen_provider"
+        ;;
+      5)
+        selection="$(
+          FAIGATE_DASHBOARD_REPORT="$report_json" "$python_bin" - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["FAIGATE_DASHBOARD_REPORT"])
+for index, row in enumerate(report.get("clients") or [], start=1):
+    name = row.get("client_tag") or row.get("client_profile") or "generic"
+    print(f"{index}\t{name}")
+PY
+        )"
+        echo ""
+        echo "  Client detail"
+        while IFS= read -r entry; do
+          [ -z "$entry" ] && continue
+          index="${entry%%$'\t'*}"
+          name="${entry#*$'\t'}"
+          printf "   %2d)  %s\n" "$index" "$name"
+        done <<< "$selection"
+        printf "\n    c)  Cancel\n"
+        printf "    q)  Quit\n\n"
+        printf "  ▸ Selection: "
+        read -r client_choice
+        case "$client_choice" in
+          q|Q) exit 0 ;;
+          c|C|"") continue ;;
+        esac
+        chosen_client="$(printf '%s\n' "$selection" | awk -F '\t' -v target="$client_choice" '$1 == target || $2 == target {print $2; exit}')"
+        [ -n "$chosen_client" ] || { faigate_ui_warn "Invalid selection."; faigate_ui_pause; continue; }
+        exec "$0" --client "$chosen_client"
+        ;;
+      6) exec "$0" --activity ;;
+      7) exec "$0" --alerts ;;
+      8) exec "$0" --json ;;
+      c|C|"") exit 0 ;;
+      q|Q) exit 0 ;;
+      *) faigate_ui_warn "Invalid selection."; faigate_ui_pause ;;
+    esac
+  done
+fi
+
+build_report_json "$mode"

--- a/scripts/faigate-menu
+++ b/scripts/faigate-menu
@@ -701,10 +701,10 @@ configure_direct_menu() {
 explore_menu() {
   while true; do
     faigate_ui_header "fusionAIze Gate Explore" "Providers, discovery links, and exposed models"
-    faigate_ui_tip "Start with Provider Probe when you want a readiness view. Use discovery for link/source browsing after that."
+    faigate_ui_tip "Start with Provider Probe when you want a readiness view. Use Provider Discovery drilldowns after that to inspect one source at a time."
     echo ""
     printf "    1)  Provider Probe       Probe configured sources against config, env, and /health\n"
-    printf "    2)  Provider Discovery   Browse provider links and offer tracks\n"
+    printf "    2)  Provider Discovery   Browse provider links, offer tracks, and one-provider detail views\n"
     printf "    3)  Provider Discovery   JSON export\n"
     printf "    4)  Models               List exposed model ids\n"
     printf "    5)  Health Check         Query /health\n"
@@ -715,7 +715,7 @@ explore_menu() {
     read -r choice
     case "$choice" in
       1) run_and_pause bash "${script_dir}/faigate-provider-probe" ;;
-      2) run_and_pause bash "${script_dir}/faigate-provider-discovery" --text ;;
+      2) run_and_pause bash "${script_dir}/faigate-provider-discovery" --interactive ;;
       3) run_and_pause bash "${script_dir}/faigate-provider-discovery" --json ;;
       4) run_and_pause show_models ;;
       5) run_and_pause bash "${script_dir}/faigate-health" ;;
@@ -730,14 +730,15 @@ dashboard_menu() {
   while true; do
     faigate_ui_header "fusionAIze Gate Dashboard" "Performance, spend, client load, and operator confidence"
     render_summary_cards
-    faigate_ui_tip "Overview is the fastest confidence check. Providers and Clients explain where traffic, failures, and spend really come from."
+    faigate_ui_tip "Overview is the fastest confidence check. Drilldowns help when you want to inspect one provider or one client without leaving Gate."
     echo ""
     printf "    1)  Overview           Global confidence view with traffic, spend, and top drivers\n"
     printf "    2)  Providers          Provider health, failures, latency, and spend\n"
     printf "    3)  Clients            Client-level traffic, cost, and latency\n"
     printf "    4)  Activity           24h activity, daily trend, and operator actions\n"
     printf "    5)  Alerts + Decisions Operator alerts and budget/routing hints\n"
-    printf "    6)  Raw JSON           Full dashboard report for scripts or UIs\n"
+    printf "    6)  Drilldowns         Pick one provider or client and open a focused detail view\n"
+    printf "    7)  Raw JSON           Full dashboard report for scripts or UIs\n"
     printf "\n"
     printf "    c)  Cancel\n"
     printf "    q)  Quit\n\n"
@@ -749,7 +750,8 @@ dashboard_menu() {
       3) run_and_pause bash "${script_dir}/faigate-dashboard" --clients ;;
       4) run_and_pause bash "${script_dir}/faigate-dashboard" --activity ;;
       5) run_and_pause bash "${script_dir}/faigate-dashboard" --alerts ;;
-      6) run_and_pause bash "${script_dir}/faigate-dashboard" --json ;;
+      6) run_and_pause bash "${script_dir}/faigate-dashboard" --interactive ;;
+      7) run_and_pause bash "${script_dir}/faigate-dashboard" --json ;;
       c|C|"") return 0 ;;
       q|Q) exit 0 ;;
       *) faigate_ui_warn "Invalid choice."; faigate_ui_pause ;;
@@ -771,15 +773,16 @@ clients_menu() {
     printf "    1)  Recommended Cards  Compact client recommendations\n"
     printf "    2)  Scenario Templates Apply client-specific templates like opencode/eco\n"
     printf "    3)  Client Matrix      Show active client profiles and match intent\n"
-    printf "    4)  OpenClaw Details   Drill into OpenClaw setup hints\n"
-    printf "    5)  n8n Details        Drill into n8n setup hints\n"
-    printf "    6)  opencode Details   Drill into opencode setup hints\n"
-    printf "    7)  CLI Details        Drill into generic CLI setup hints\n"
-    printf "    8)  All Quickstarts    Show the full client quickstart list\n"
-    printf "    9)  OpenClaw Wizard    Run a client-scoped wizard for OpenClaw\n"
-    printf "   10)  n8n Wizard         Run a client-scoped wizard for n8n\n"
-    printf "   11)  opencode Wizard    Run a client-scoped wizard for opencode\n"
-    printf "   12)  CLI Wizard         Run a client-scoped wizard for cli callers\n"
+    printf "    4)  Client Drilldowns  Browse any client and open one detail view inside Gate\n"
+    printf "    5)  OpenClaw Details   Drill into OpenClaw setup hints\n"
+    printf "    6)  n8n Details        Drill into n8n setup hints\n"
+    printf "    7)  opencode Details   Drill into opencode setup hints\n"
+    printf "    8)  CLI Details        Drill into generic CLI setup hints\n"
+    printf "    9)  All Quickstarts    Show the full client quickstart list\n"
+    printf "   10)  OpenClaw Wizard    Run a client-scoped wizard for OpenClaw\n"
+    printf "   11)  n8n Wizard         Run a client-scoped wizard for n8n\n"
+    printf "   12)  opencode Wizard    Run a client-scoped wizard for opencode\n"
+    printf "   13)  CLI Wizard         Run a client-scoped wizard for cli callers\n"
     printf "\n"
     printf "    c)  Cancel\n"
     printf "    q)  Quit\n\n"
@@ -789,15 +792,16 @@ clients_menu() {
       1) run_and_pause bash "${script_dir}/faigate-client-integrations" --recommended ;;
       2) run_and_pause bash "${script_dir}/faigate-client-scenarios" ;;
       3) run_and_pause bash "${script_dir}/faigate-client-integrations" --matrix ;;
-      4) run_and_pause bash "${script_dir}/faigate-client-integrations" --client openclaw ;;
-      5) run_and_pause bash "${script_dir}/faigate-client-integrations" --client n8n ;;
-      6) run_and_pause bash "${script_dir}/faigate-client-integrations" --client opencode ;;
-      7) run_and_pause bash "${script_dir}/faigate-client-integrations" --client cli ;;
-      8) run_and_pause bash "${script_dir}/faigate-client-integrations" ;;
-      9) run_client_wizard "openclaw" "general" ;;
-      10) run_client_wizard "n8n" "free" ;;
-      11) run_client_wizard "opencode" "coding" ;;
-      12) run_client_wizard "cli" "general" ;;
+      4) run_and_pause bash "${script_dir}/faigate-client-integrations" --interactive ;;
+      5) run_and_pause bash "${script_dir}/faigate-client-integrations" --client openclaw ;;
+      6) run_and_pause bash "${script_dir}/faigate-client-integrations" --client n8n ;;
+      7) run_and_pause bash "${script_dir}/faigate-client-integrations" --client opencode ;;
+      8) run_and_pause bash "${script_dir}/faigate-client-integrations" --client cli ;;
+      9) run_and_pause bash "${script_dir}/faigate-client-integrations" ;;
+      10) run_client_wizard "openclaw" "general" ;;
+      11) run_client_wizard "n8n" "free" ;;
+      12) run_client_wizard "opencode" "coding" ;;
+      13) run_client_wizard "cli" "general" ;;
       c|C|"") return 0 ;;
       q|Q) exit 0 ;;
       *) faigate_ui_warn "Invalid choice."; faigate_ui_pause ;;

--- a/scripts/faigate-provider-discovery
+++ b/scripts/faigate-provider-discovery
@@ -8,13 +8,15 @@ mode="text"
 link_source=""
 offer_track=""
 disclosed_only="0"
+provider_name=""
+interactive_mode="0"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --help|-h)
       cat <<'EOF'
 Usage:
-  ./scripts/faigate-provider-discovery [--json|--text] [--link-source official|operator_override] [--offer-track TRACK] [--disclosed-only]
+  ./scripts/faigate-provider-discovery [--json|--text] [--link-source official|operator_override] [--offer-track TRACK] [--disclosed-only] [--provider NAME] [--interactive]
 
 Render provider discovery links in text or JSON form with optional filters.
 EOF
@@ -40,8 +42,16 @@ EOF
       disclosed_only="1"
       shift
       ;;
+    --provider)
+      provider_name="${2:-}"
+      shift 2
+      ;;
+    --interactive)
+      interactive_mode="1"
+      shift
+      ;;
     *)
-      echo "usage: faigate-provider-discovery [--json|--text] [--link-source official|operator_override] [--offer-track TRACK] [--disclosed-only]" >&2
+      echo "usage: faigate-provider-discovery [--json|--text] [--link-source official|operator_override] [--offer-track TRACK] [--disclosed-only] [--provider NAME] [--interactive]" >&2
       exit 2
       ;;
   esac
@@ -52,6 +62,7 @@ export FAIGATE_DISCOVERY_MODE="$mode"
 export FAIGATE_DISCOVERY_LINK_SOURCE="$link_source"
 export FAIGATE_DISCOVERY_OFFER_TRACK="$offer_track"
 export FAIGATE_DISCOVERY_DISCLOSED_ONLY="$disclosed_only"
+export FAIGATE_DISCOVERY_PROVIDER="$provider_name"
 
 "$python_bin" - <<'PY'
 import json
@@ -66,6 +77,12 @@ view = build_provider_discovery_view(
     disclosed_only=os.environ.get("FAIGATE_DISCOVERY_DISCLOSED_ONLY") == "1",
     offer_track=os.environ.get("FAIGATE_DISCOVERY_OFFER_TRACK") or None,
 )
+
+provider_name = os.environ.get("FAIGATE_DISCOVERY_PROVIDER", "").strip().lower()
+if provider_name:
+    view["providers"] = [
+        item for item in view.get("providers", []) if item["provider"].lower() == provider_name
+    ]
 
 if os.environ["FAIGATE_DISCOVERY_MODE"] == "json":
     print(json.dumps(view, indent=2, sort_keys=True))
@@ -95,6 +112,107 @@ else:
             f"{item['offer_track']} / {item['evidence_level']}"
         )
         print(f"  {label}: {item['resolved_url']}")
+        if item.get("official_source_url"):
+            print(f"  official source: {item['official_source_url']}")
+        if item.get("signup_url") and item.get("signup_url") != item.get("resolved_url"):
+            print(f"  signup: {item['signup_url']}")
         if item.get("operator_env_var"):
             print(f"  env override: {item['operator_env_var']}")
 PY
+
+if [[ "$interactive_mode" == "1" && -z "$provider_name" && "$mode" == "text" ]]; then
+  echo ""
+  echo "  Discovery filters"
+  printf "    1)  All providers\n"
+  printf "    2)  Free / budget tracks\n"
+  printf "    3)  Disclosed-only links\n"
+  printf "    c)  Cancel\n"
+  printf "    q)  Quit\n"
+  printf "\n  ▸ Filter: "
+  read -r filter_choice
+  case "$filter_choice" in
+    q|Q) exit 0 ;;
+    c|C|"") exit 0 ;;
+    1) ;;
+    2) offer_track="free" ;;
+    3) disclosed_only="1" ;;
+    *) echo "Invalid selection." >&2; exit 2 ;;
+  esac
+
+  provider_entries="$(
+    FAIGATE_DISCOVERY_CONFIG="$config_file" \
+    FAIGATE_DISCOVERY_LINK_SOURCE="$link_source" \
+    FAIGATE_DISCOVERY_OFFER_TRACK="$offer_track" \
+    FAIGATE_DISCOVERY_DISCLOSED_ONLY="$disclosed_only" \
+    "$python_bin" - <<'PY'
+from faigate.config import load_config
+from faigate.provider_catalog import build_provider_discovery_view
+import os
+
+view = build_provider_discovery_view(
+    load_config(os.environ["FAIGATE_DISCOVERY_CONFIG"]),
+    link_source=os.environ.get("FAIGATE_DISCOVERY_LINK_SOURCE") or None,
+    disclosed_only=os.environ.get("FAIGATE_DISCOVERY_DISCLOSED_ONLY") == "1",
+    offer_track=os.environ.get("FAIGATE_DISCOVERY_OFFER_TRACK") or None,
+)
+
+for item in view.get("providers", []):
+    print(f"{item['provider']}\t{item['offer_track']}\t{item['provider_type']}")
+PY
+  )"
+
+  if [[ -n "$provider_entries" ]]; then
+    echo ""
+    echo "  Open provider detail"
+    entry_index=1
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      provider_id="${entry%%$'\t'*}"
+      rest="${entry#*$'\t'}"
+      provider_track="${rest%%$'\t'*}"
+      provider_type="${entry##*$'\t'}"
+      printf "   %2d)  %-22s %s / %s\n" "$entry_index" "$provider_id" "$provider_type" "$provider_track"
+      entry_index=$((entry_index + 1))
+    done <<< "$provider_entries"
+    printf "\n    c)  Cancel\n"
+    printf "    q)  Quit\n"
+    printf "\n  ▸ Selection: "
+    read -r provider_selection
+    case "$provider_selection" in
+      q|Q) exit 0 ;;
+      c|C|"") exit 0 ;;
+      *)
+        if [[ "$provider_selection" =~ ^[0-9]+$ ]]; then
+          chosen_entry="$(printf '%s\n' "$provider_entries" | sed -n "${provider_selection}p")"
+          [ -n "$chosen_entry" ] || { echo "Invalid selection." >&2; exit 2; }
+          chosen_provider="${chosen_entry%%$'\t'*}"
+          next_args=(--text --provider "$chosen_provider")
+          if [[ -n "$offer_track" ]]; then
+            next_args+=(--offer-track "$offer_track")
+          fi
+          if [[ "$disclosed_only" == "1" ]]; then
+            next_args+=(--disclosed-only)
+          fi
+          if [[ -n "$link_source" ]]; then
+            next_args+=(--link-source "$link_source")
+          fi
+          exec "$0" "${next_args[@]}"
+        fi
+        chosen_entry="$(printf '%s\n' "$provider_entries" | awk -F '\t' -v target="$provider_selection" '$1 == target {print; exit}')"
+        [ -n "$chosen_entry" ] || { echo "Invalid selection." >&2; exit 2; }
+        chosen_provider="${chosen_entry%%$'\t'*}"
+        next_args=(--text --provider "$chosen_provider")
+        if [[ -n "$offer_track" ]]; then
+          next_args+=(--offer-track "$offer_track")
+        fi
+        if [[ "$disclosed_only" == "1" ]]; then
+          next_args+=(--disclosed-only)
+        fi
+        if [[ -n "$link_source" ]]; then
+          next_args+=(--link-source "$link_source")
+        fi
+        exec "$0" "${next_args[@]}"
+        ;;
+    esac
+  fi
+fi

--- a/scripts/faigate-ui-lib.sh
+++ b/scripts/faigate-ui-lib.sh
@@ -62,20 +62,26 @@ PY
 faigate_ui_logo() {
   local version_text="${1:-}"
   if faigate_ui_has_color; then
-    printf "  %b%s%b%b%s%b%b%s%b\n" \
+    printf "  %b%s%b%b%s%b%b%s%b%s%b%s\n" \
       "$FAIGATE_UI_BRAND_BLUE" "▐▘    ▘    " "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_YELLOW" "▄▖▄▖      " "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_GREEN" "▄▖  ▗      " "$FAIGATE_UI_RESET"
-    printf "  %b%s%b%b%s%b%b%s%b\n" \
+      "$FAIGATE_UI_BRAND_YELLOW" "▄▖▄▖" "$FAIGATE_UI_RESET" \
+      "$FAIGATE_UI_BRAND_BLUE" "    " "$FAIGATE_UI_RESET" \
+      "  " \
+      "$FAIGATE_UI_BRAND_GREEN" "▄▖  ▗   " "$FAIGATE_UI_RESET"
+    printf "  %b%s%b%b%s%b%b%s%b%s%b%s\n" \
       "$FAIGATE_UI_BRAND_BLUE" "▜▘▌▌▛▘▌▛▌▛▌" "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_YELLOW" "▌▌▐ ▀▌" "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_GREEN" "█▌  ▌ ▀▌▜▘█▌   " "$FAIGATE_UI_RESET"
-    printf "  %b%s%b%b%s%b%b%s%b" \
-      "$FAIGATE_UI_BRAND_BLUE" "▐ ▙▌▄▌▌" "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_YELLOW" "▙▌▌▌▛▌" "$FAIGATE_UI_RESET" \
-      "$FAIGATE_UI_BRAND_GREEN" "▟▖▙▖▙▖  ▙▌█▌▐▖▙▖  " "$FAIGATE_UI_RESET"
+      "$FAIGATE_UI_BRAND_YELLOW" "▌▌▐ " "$FAIGATE_UI_RESET" \
+      "$FAIGATE_UI_BRAND_BLUE" "▀▌█▌" "$FAIGATE_UI_RESET" \
+      "  " \
+      "$FAIGATE_UI_BRAND_GREEN" "▌ ▀▌▜▘█▌" "$FAIGATE_UI_RESET"
+    printf "  %b%s%b%b%s%b%b%s%b%s%b%s" \
+      "$FAIGATE_UI_BRAND_BLUE" "▐ ▙▌▄▌▌▙▌▌▌" "$FAIGATE_UI_RESET" \
+      "$FAIGATE_UI_BRAND_YELLOW" "▛▌▟▖" "$FAIGATE_UI_RESET" \
+      "$FAIGATE_UI_BRAND_BLUE" "▙▖▙▖" "$FAIGATE_UI_RESET" \
+      "  " \
+      "$FAIGATE_UI_BRAND_GREEN" "▙▌█▌▐▖▙▖" "$FAIGATE_UI_RESET"
     if [ -n "$version_text" ]; then
-      printf "  %b%s%b" "$FAIGATE_UI_DIM" "$version_text" "$FAIGATE_UI_RESET"
+      printf " %b%s%b" "$FAIGATE_UI_DIM" "$version_text" "$FAIGATE_UI_RESET"
     fi
     printf "\n"
   else

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -567,6 +567,58 @@ fallback_chain: [deepseek-chat]
     assert "header: X-faigate-Client: opencode" in result.stdout
 
 
+def test_faigate_client_integrations_interactive_drilldown(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+  log_level: "info"
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    api_key: "${DEEPSEEK_API_KEY}"
+    base_url: "https://api.deepseek.com/v1"
+    model: "deepseek-chat"
+    tier: default
+client_profiles:
+  enabled: true
+  default: generic
+  presets: [openclaw, n8n, cli]
+  profiles:
+    generic: {}
+    openclaw: {}
+    n8n: {}
+    cli: {}
+    opencode: {}
+fallback_chain: [deepseek-chat]
+""".strip(),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=test-key\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_ENV_FILE"] = str(env_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-client-integrations", "--interactive"],
+        cwd=REPO_ROOT,
+        env=env,
+        input="1\n",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Open client drilldown" in result.stdout
+    assert "1)  opencode" in result.stdout
+    assert "Client drilldown" in result.stdout
+
+
 def test_faigate_config_wizard_text_candidates_are_compact(tmp_path: Path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text(
@@ -1385,6 +1437,137 @@ def test_faigate_client_scenarios_text_lists_opencode_templates(tmp_path: Path):
     assert "Client scenarios" in result.stdout
     assert "opencode / quality" in result.stdout
     assert "ready now:" in result.stdout
+    assert "budget / free: kilocode (free coding coverage)" in result.stdout
+    assert "family note: Anthropic is currently represented by one quality lane." in result.stdout
+    assert "family coverage: Anthropic: quality lane active" in result.stdout
+
+
+def test_faigate_provider_discovery_interactive_opens_provider_detail(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    api_key: "${DEEPSEEK_API_KEY}"
+    base_url: "https://api.deepseek.com/v1"
+    model: "deepseek-chat"
+    tier: default
+  openrouter-fallback:
+    backend: openai-compat
+    api_key: "${OPENROUTER_API_KEY}"
+    base_url: "https://openrouter.ai/api/v1"
+    model: "openrouter/auto"
+    tier: fallback
+""".strip(),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-provider-discovery", "--interactive"],
+        cwd=REPO_ROOT,
+        env=env,
+        input="1\n1\n",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Discovery filters" in result.stdout
+    assert "Open provider detail" in result.stdout
+    assert "official source:" in result.stdout
+    assert "deepseek-chat" in result.stdout
+
+
+def test_faigate_dashboard_interactive_opens_provider_detail(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers: {}
+""".strip(),
+        encoding="utf-8",
+    )
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "summary": {"providers_total": 1, "providers_unhealthy": 0},
+                    "providers": {"deepseek-chat": {"healthy": True, "tier": "default"}},
+                }
+            ),
+            "/api/stats": json.dumps(
+                {
+                    "totals": {
+                        "total_requests": 42,
+                        "total_failures": 1,
+                        "avg_latency_ms": 850,
+                        "total_prompt_tokens": 12000,
+                        "total_compl_tokens": 4000,
+                        "total_cost_usd": 0.42,
+                    },
+                    "providers": [
+                        {
+                            "provider": "deepseek-chat",
+                            "requests": 42,
+                            "failures": 1,
+                            "avg_latency_ms": 850,
+                            "cost_usd": 0.42,
+                            "total_tokens": 16000,
+                            "prompt_tokens": 12000,
+                            "completion_tokens": 4000,
+                        }
+                    ],
+                    "clients": [
+                        {
+                            "client_tag": "opencode",
+                            "client_profile": "opencode",
+                            "requests": 42,
+                            "success_pct": 97.6,
+                            "avg_latency_ms": 850,
+                            "cost_usd": 0.42,
+                            "total_tokens": 16000,
+                            "providers": "deepseek-chat",
+                        }
+                    ],
+                    "routing": [],
+                    "client_totals": [],
+                    "hourly": [],
+                    "daily": [],
+                    "operator_actions": [],
+                }
+            ),
+        },
+    )
+    env = os.environ.copy()
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-dashboard", "--interactive"],
+        cwd=REPO_ROOT,
+        env=env,
+        input="4\n1\n",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Provider Detail" in result.stdout
+    assert "Provider detail: deepseek-chat" in result.stdout
+    assert "Status            live-healthy" in result.stdout
 
 
 def test_faigate_provider_setup_known_text_lists_curated_sources(tmp_path: Path):


### PR DESCRIPTION
## Summary\n- add internal Gate drilldowns for client quickstarts, provider discovery, and dashboard details\n- sharpen client scenarios with lane-based provider roles and family coverage notes\n- refine the header color segmentation and cover the new selectors with targeted tests\n\n## Testing\n- bash -n scripts/faigate-client-scenarios scripts/faigate-provider-discovery scripts/faigate-dashboard scripts/faigate-menu scripts/faigate-ui-lib.sh scripts/faigate-client-integrations\n- ./.venv-check-313/bin/ruff check faigate/wizard.py faigate/dashboard.py tests/test_menu_helpers.py\n- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py -k 'logo or client_integrations_interactive_drilldown or client_scenarios or provider_discovery_interactive or dashboard_interactive'