### PR TITLE
docs(release): prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to fusionAIze Gate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
+## v1.7.0 - 2026-03-22
+
+### Changed
+
+- Added internal Gate drilldowns for client quickstarts, provider discovery, and dashboard details so operators no longer need to leave the menu just to open one parameterized view
+- Expanded client scenarios into lane-based explanations with explicit quality, reasoning, workhorse, budget, and fallback roles so templates like `opencode / balanced` now explain why `kilocode`, `blackbox-free`, or `openrouter-fallback` are in or out
+- Added family-coverage hints for scenario output so operators can see when a provider family currently has only one quality or balanced slot and would need separate provider entries for richer `Opus / Sonnet / Haiku`-style splits
+- Refined the shell header color segmentation again to match the tighter blue / yellow / blue / green brand grouping across all three wordmark rows
+
 ## v1.6.3 - 2026-03-22
 
 ### Changed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.6.3 -m "fusionAIze Gate v1.6.3"
-git push origin v1.6.3
+git tag -a v1.7.0 -m "fusionAIze Gate v1.7.0"
+git push origin v1.7.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.6.3`.
+Then open GitHub Releases and publish a release for `v1.7.0`.
 
 ## Automation Baseline
 
@@ -75,6 +75,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.6.1` is the immediate packaging and polish follow-up: the Brew-installed dashboard helper is executable again, and the terminal wordmark now matches the intended shape more closely while surfacing the current version inline.
 - `v1.6.2` is the immediate guided-setup recovery follow-up: wizard writes now persist actual runtime config, doctor can flag accidental suggestion payloads in `config.yaml`, and the remaining packaged helper entrypoints keep their executable bits in Brew installs.
 - `v1.6.3` hardens that recovery line: nullish config sections no longer break guided writes, the missing Brew helper wrappers now match the shell UX more closely, and the refreshed three-color wordmark still surfaces the live version inline.
+- `v1.7.0` establishes the internal-drilldown baseline: parameterized client, provider, and dashboard views now open directly inside Gate, and scenario templates explain provider roles and family coverage more explicitly instead of only listing flat recommendation sets.
 
 ## Planned Publishing Path
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.6.3"
+__version__ = "1.7.0"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.6.3",
+    version="1.7.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.6.3"
+version = "1.7.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary\n- bump runtime and CLI versions to 1.7.0\n- roll the internal drilldown and richer scenario-lane UX block into the changelog and release guide\n- verify the full release-prep path before tagging\n\n## Testing\n- PYTHONPATH=. ./.venv-check-313/bin/pytest -q\n- ./.venv-check-313/bin/ruff check .\n- ./.venv-check-313/bin/ruff format --check .\n- ./.venv-check-313/bin/python -m build --no-isolation\n- ./.venv-check-313/bin/python -m twine check dist/faigate-1.7.0.tar.gz dist/faigate-1.7.0-py3-none-any.whl\n- zsh -lc 'PATH=/opt/homebrew/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources node packages/faigate-cli/bin/faigate.js --help'\n- ruby -c Formula/faigate.rb