### PR TITLE
docs(release): prepare v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to fusionAIze Gate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
+## v1.7.1 - 2026-03-22
+
+### Changed
+
+- Tightened the terminal header rendering again so interactive screens no longer insert apparent blank spacer lines between the three wordmark rows
+- Fixed the client-scenario apply flow so choosing `Write config` now returns cleanly to the calling menu after the confirmation step instead of dropping operators straight back into the same scenario list
+
 ## v1.7.0 - 2026-03-22
 
 ### Changed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.7.0 -m "fusionAIze Gate v1.7.0"
-git push origin v1.7.0
+git tag -a v1.7.1 -m "fusionAIze Gate v1.7.1"
+git push origin v1.7.1
 ```
 
-Then open GitHub Releases and publish a release for `v1.7.0`.
+Then open GitHub Releases and publish a release for `v1.7.1`.
 
 ## Automation Baseline
 
@@ -76,6 +76,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.6.2` is the immediate guided-setup recovery follow-up: wizard writes now persist actual runtime config, doctor can flag accidental suggestion payloads in `config.yaml`, and the remaining packaged helper entrypoints keep their executable bits in Brew installs.
 - `v1.6.3` hardens that recovery line: nullish config sections no longer break guided writes, the missing Brew helper wrappers now match the shell UX more closely, and the refreshed three-color wordmark still surfaces the live version inline.
 - `v1.7.0` establishes the internal-drilldown baseline: parameterized client, provider, and dashboard views now open directly inside Gate, and scenario templates explain provider roles and family coverage more explicitly instead of only listing flat recommendation sets.
+- `v1.7.1` is the immediate polish follow-up: the wordmark now renders without accidental spacer gaps in interactive menus, and applying a client scenario cleanly returns control to the caller instead of repainting the same chooser screen.
 
 ## Planned Publishing Path
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1030,7 +1030,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.7.0",
+    version="1.7.1",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.7.0"
+version = "1.7.1"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the Python and npm package versions to v1.7.1
- add the v1.7.1 changelog and release-baseline notes
- validate the release artifacts before tagging

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/faigate-1.7.1.tar.gz dist/faigate-1.7.1-py3-none-any.whl
- zsh -lc "PATH=/opt/homebrew/bin:/Users/andrelange/bin:/Users/andrelange/.local/bin:/opt/homebrew/opt/openssl@3/bin:/opt/homebrew/opt/mysql/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/Applications/Codex.app/Contents/Resources node packages/faigate-cli/bin/faigate.js --help"
- ruby -c Formula/faigate.rb
- git diff --check