### PR TITLE
docs(release): prepare v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to fusionAIze Gate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
+## v1.8.0 - 2026-03-22
+
+### Changed
+
+- Started the adaptive-orchestration runtime line with canonical model-lane and provider-route metadata in config, wizard, runtime inventory, and provider-catalog surfaces
+- Added the first lane-aware router scoring slice so `quality`, `balanced`, `eco`, and `free` postures now influence candidate ranking through lane cluster, benchmark cluster, route type, and runtime pressure instead of only provider tier
+- Added Same-Lane-Route fallback preference before weaker cluster downgrades when a compatible alternate route exists for the same canonical model
+- Added an in-memory adaptation state for rate-limit, quota, timeout, and latency pressure so hot routes can be demoted conservatively at runtime
+- Persisted routing explainability fields such as `canonical_model`, `route_type`, `lane_cluster`, `selection_path`, and `decision_details` into metrics and route traces
+- Expanded candidate cards, client scenarios, and provider dashboard drilldowns so operators can now see route mirrors, degrade chains, canonical lanes, and runtime penalties directly in Gate
+
 ## v1.7.1 - 2026-03-22
 
 ### Changed
@@ -58,14 +69,6 @@ The format is intentionally lightweight and human-readable. Group entries by rel
 - Expanded client scenarios with clearer `budget`, `best when`, and `tradeoff` guidance so operators can pick templates by intent instead of only by routing-mode names
 - Expanded the new dashboard with budget, quota, and routing-pressure hints so it now helps answer whether traffic should shift, a cheaper scenario is worth trying, or a provider likely needs more budget
 
-## Unreleased
-
-### Changed
-
-- Started the `v1.8.0` lane-foundation line with canonical model-lane and provider-route metadata in the config, wizard, and provider-catalog surfaces, preparing Gate for route-aware aggregator handling and adaptive orchestration
-- Added the first lane-aware router scoring slice so `quality`, `balanced`, `eco`, and `free` postures now influence candidate ranking through canonical lane, cluster, and route-type metadata instead of only provider tier
-- Added the first same-lane-route fallback path so when a primary route becomes unhealthy Gate can preserve the canonical lane before dropping into a weaker cluster when a compatible alternate route exists
-- Carried lane metadata through runtime inventories and dashboard provider drilldowns so operator-facing views can now show canonical lane, route type, and cluster context alongside spend and health
 - Added a dedicated adaptive-orchestration roadmap that sketches the path from lane metadata to scoring, live adaptation, benchmark freshness, and budget-/quota-aware routing through the `v1.10.x` and `v1.11.x` lines
 
 ## v1.5.1 - 2026-03-20

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,11 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 ```bash
 git checkout main
 git pull --ff-only origin main
-git tag -a v1.7.1 -m "fusionAIze Gate v1.7.1"
-git push origin v1.7.1
+git tag -a v1.8.0 -m "fusionAIze Gate v1.8.0"
+git push origin v1.8.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.7.1`.
+Then open GitHub Releases and publish a release for `v1.8.0`.
 
 ## Automation Baseline
 
@@ -77,6 +77,7 @@ The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml
 - `v1.6.3` hardens that recovery line: nullish config sections no longer break guided writes, the missing Brew helper wrappers now match the shell UX more closely, and the refreshed three-color wordmark still surfaces the live version inline.
 - `v1.7.0` establishes the internal-drilldown baseline: parameterized client, provider, and dashboard views now open directly inside Gate, and scenario templates explain provider roles and family coverage more explicitly instead of only listing flat recommendation sets.
 - `v1.7.1` is the immediate polish follow-up: the wordmark now renders without accidental spacer gaps in interactive menus, and applying a client scenario cleanly returns control to the caller instead of repainting the same chooser screen.
+- `v1.8.0` establishes the adaptive-lane-routing foundation: canonical model lanes, direct-versus-aggregator route metadata, same-lane-route fallback preference, early runtime pressure adaptation, and richer route explainability now shape both routing decisions and operator visibility.
 
 ## Planned Publishing Path
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1076,7 +1076,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.7.1",
+    version="1.8.0",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/packages/faigate-cli/package.json
+++ b/packages/faigate-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faigate/cli",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Small npm CLI for checking and previewing a fusionAIze Gate gateway.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.7.1"
+version = "1.8.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package versions to 1.8.0 across Python, app metadata, and the npm CLI package
- promote the adaptive-lane-routing notes into the 1.8.0 changelog entry
- refresh release guidance and the current release baseline for v1.8.0

## Verification
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q
- ./.venv-check-313/bin/ruff check .
- ./.venv-check-313/bin/ruff format --check .
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/faigate-1.8.0.tar.gz dist/faigate-1.8.0-py3-none-any.whl
- zsh -lc "PATH=/opt/homebrew/bin:/Users/andrelange/bin:/Users/andrelange/.local/bin:/opt/homebrew/opt/openssl@3/bin:/opt/homebrew/opt/mysql/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/andrelange/.cargo/bin:/Users/andrelange/.codex/tmp/arg0/codex-arg0KNkFOC:/Applications/Codex.app/Contents/Resources node packages/faigate-cli/bin/faigate.js --help"
- ruby -c Formula/faigate.rb
- bash -n scripts/faigate-dashboard scripts/faigate-service-lib.sh
- git diff --check