### PR TITLE
feat(runtime): add strategy-aware provider probes

### DIFF
--- a/faigate/config.py
+++ b/faigate/config.py
@@ -97,7 +97,7 @@ _SUPPORTED_PROVIDER_TRANSPORT_KEYS = {
     "notes",
 }
 _SUPPORTED_PROVIDER_TRANSPORT_AUTH_MODES = {"bearer", "query", "none"}
-_SUPPORTED_PROVIDER_TRANSPORT_PROBE_STRATEGIES = {"models", "none"}
+_SUPPORTED_PROVIDER_TRANSPORT_PROBE_STRATEGIES = {"models", "chat", "models_or_chat", "none"}
 _SUPPORTED_PROVIDER_TRANSPORT_COMPATIBILITY = {"native", "aggregator", "compat-layer"}
 _SUPPORTED_PROVIDER_TRANSPORT_CONFIDENCE = {"high", "medium", "low"}
 
@@ -548,6 +548,7 @@ def _normalize_provider_transport(name: str, cfg: dict[str, Any]) -> dict[str, A
     normalized["auth_mode"] = auth_mode
 
     probe_strategy = str(transport.get("probe_strategy", "models") or "models").strip().lower()
+    probe_strategy = probe_strategy.replace("-", "_")
     if probe_strategy not in _SUPPORTED_PROVIDER_TRANSPORT_PROBE_STRATEGIES:
         supported = ", ".join(sorted(_SUPPORTED_PROVIDER_TRANSPORT_PROBE_STRATEGIES))
         raise ConfigError(

--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -76,7 +76,7 @@ def _health_issue_category(last_error: str) -> str:
 
 def _readiness_category(status: str) -> str:
     normalized = str(status or "").strip().lower()
-    if normalized in {"ready"}:
+    if normalized in {"ready", "ready-verified"}:
         return "ready"
     if normalized in {"ready-compat"}:
         return "compat"
@@ -844,6 +844,8 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
     ]
     if request_readiness.get("reason"):
         lines.append(f"Readiness detail  {request_readiness.get('reason')}")
+    if request_readiness.get("verified_via"):
+        lines.append(f"Verified via      {request_readiness.get('verified_via')}")
     if transport:
         lines.extend(
             [

--- a/faigate/lane_registry.py
+++ b/faigate/lane_registry.py
@@ -396,12 +396,13 @@ _PROVIDER_TRANSPORT_BINDINGS: dict[str, dict[str, Any]] = {
         "compatibility": "aggregator",
         "probe_confidence": "high",
         "auth_mode": "bearer",
-        "probe_strategy": "models",
+        "probe_strategy": "models_or_chat",
         "models_path": "/models",
         "chat_path": "/chat/completions",
         "notes": [
             "requires HTTP-Referer and X-Title headers for best marketplace attribution",
             "route remains OpenAI-compatible but upstream model selection is marketplace-managed",
+            "request-readiness can fall back from /models to a shallow chat probe when needed",
         ],
     },
     "kilocode": {
@@ -409,11 +410,13 @@ _PROVIDER_TRANSPORT_BINDINGS: dict[str, dict[str, Any]] = {
         "compatibility": "aggregator",
         "probe_confidence": "medium",
         "auth_mode": "bearer",
-        "probe_strategy": "models",
-        "models_path": "/models",
+        "probe_strategy": "chat",
+        "models_path": "",
         "chat_path": "/chat/completions",
+        "supports_models_probe": False,
         "notes": [
-            "aggregator route uses OpenAI-compatible chat paths with medium evidence",
+            "aggregator route is validated through a shallow chat probe "
+            "instead of relying on /models",
             "free-tier model availability and path behavior should be revalidated regularly",
         ],
     },
@@ -422,11 +425,13 @@ _PROVIDER_TRANSPORT_BINDINGS: dict[str, dict[str, Any]] = {
         "compatibility": "aggregator",
         "probe_confidence": "medium",
         "auth_mode": "bearer",
-        "probe_strategy": "models",
-        "models_path": "/models",
+        "probe_strategy": "chat",
+        "models_path": "",
         "chat_path": "/chat/completions",
+        "supports_models_probe": False,
         "notes": [
-            "aggregator route uses OpenAI-compatible chat paths with mixed evidence",
+            "aggregator route is validated through a shallow chat probe "
+            "instead of relying on /models",
             "free-tier route volatility is high; auth and model availability can shift quickly",
         ],
     },

--- a/faigate/providers.py
+++ b/faigate/providers.py
@@ -89,6 +89,8 @@ class ProviderBackend:
             **dict(cfg.get("transport", {})),
         }
         self.health = ProviderHealth(name=name)
+        self._last_probe_strategy = ""
+        self._last_probe_verified = False
 
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(120.0, connect=10.0),
@@ -146,6 +148,45 @@ class ProviderBackend:
             return "transport-error", "the route is reachable by config but not transport-ready"
         return "degraded", detail[:160]
 
+    def _mark_probe_success(self, strategy: str, latency_ms: float) -> None:
+        self._last_probe_strategy = strategy
+        self._last_probe_verified = True
+        self.health.record_success(latency_ms)
+
+    def _mark_probe_failure(self, detail: str) -> None:
+        self._last_probe_verified = False
+        self.health.record_failure(detail)
+
+    async def _probe_via_models(self, *, timeout_seconds: float) -> bool:
+        url = self._transport_url(self._transport_path("models_path", "/models"))
+        headers = self._authorization_headers()
+        t0 = time.time()
+        resp = await self._client.get(url, headers=headers, timeout=timeout_seconds)
+        latency = (time.time() - t0) * 1000
+        if resp.status_code >= 400:
+            error_text = resp.text[:500]
+            raise ProviderError(self.name, resp.status_code, error_text)
+        self._mark_probe_success("models", latency)
+        return True
+
+    async def _probe_via_chat(self, *, timeout_seconds: float) -> bool:
+        url = self._transport_url(self._transport_path("chat_path", "/chat/completions"))
+        headers = self._authorization_headers(content_type="application/json")
+        body = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+            "stream": False,
+        }
+        t0 = time.time()
+        resp = await self._client.post(url, json=body, headers=headers, timeout=timeout_seconds)
+        latency = (time.time() - t0) * 1000
+        if resp.status_code >= 400:
+            error_text = resp.text[:500]
+            raise ProviderError(self.name, resp.status_code, error_text)
+        self._mark_probe_success("chat", latency)
+        return True
+
     def request_readiness(self) -> dict[str, Any]:
         """Return operator-facing request-readiness for one configured route."""
         requires_api_key = bool(self.transport.get("requires_api_key", True))
@@ -154,6 +195,7 @@ class ProviderBackend:
         profile = str(self.transport.get("profile", "") or "")
         probe_confidence = str(self.transport.get("probe_confidence", "medium") or "medium")
         notes = list(self.transport.get("notes", []) or [])
+        verified_via = self._last_probe_strategy or ""
 
         if requires_api_key and not self.api_key:
             return {
@@ -165,6 +207,7 @@ class ProviderBackend:
                 "profile": profile,
                 "probe_confidence": probe_confidence,
                 "notes": notes,
+                "verified_via": verified_via,
             }
         if requires_api_key and _UNRESOLVED_ENV_RE.search(self.api_key or ""):
             return {
@@ -176,6 +219,7 @@ class ProviderBackend:
                 "profile": profile,
                 "probe_confidence": probe_confidence,
                 "notes": notes,
+                "verified_via": verified_via,
             }
         if self.health.last_error:
             status, reason = self._classify_request_readiness_issue(self.health.last_error)
@@ -189,6 +233,19 @@ class ProviderBackend:
                 "profile": profile,
                 "probe_confidence": probe_confidence,
                 "notes": notes,
+                "verified_via": verified_via,
+            }
+        if self._last_probe_verified:
+            return {
+                "ready": True,
+                "status": "ready-verified",
+                "reason": f"route passed a live {verified_via or probe_strategy} probe recently",
+                "probe_strategy": probe_strategy,
+                "compatibility": compatibility,
+                "profile": profile,
+                "probe_confidence": "high",
+                "notes": notes,
+                "verified_via": verified_via or probe_strategy,
             }
         if compatibility != "native" and probe_confidence != "high":
             return {
@@ -203,6 +260,7 @@ class ProviderBackend:
                 "profile": profile,
                 "probe_confidence": probe_confidence,
                 "notes": notes,
+                "verified_via": verified_via,
             }
         return {
             "ready": True,
@@ -213,6 +271,7 @@ class ProviderBackend:
             "profile": profile,
             "probe_confidence": probe_confidence,
             "notes": notes,
+            "verified_via": verified_via,
         }
 
     async def probe_health(self, timeout_seconds: float = 10.0) -> bool:
@@ -221,30 +280,36 @@ class ProviderBackend:
         For OpenAI-compatible providers this uses GET /models. For Google GenAI,
         which does not expose a compatible models listing here, probing is skipped.
         """
-        if self.backend_type == "google-genai" or not self.transport.get(
-            "supports_models_probe", True
-        ):
+        if self.backend_type == "google-genai":
             return self.health.healthy
 
-        url = self._transport_url(self._transport_path("models_path", "/models"))
-        headers = self._authorization_headers()
+        strategy = str(self.transport.get("probe_strategy", "models") or "models").strip().lower()
+        strategy = strategy.replace("-", "_")
+        if strategy == "none":
+            return self.health.healthy
 
-        t0 = time.time()
         try:
-            resp = await self._client.get(url, headers=headers, timeout=timeout_seconds)
-            latency = (time.time() - t0) * 1000
-            if resp.status_code >= 400:
-                error_text = resp.text[:500]
-                self.health.record_failure(f"Probe HTTP {resp.status_code}: {error_text}")
-                return False
-
-            self.health.record_success(latency)
-            return True
+            if strategy == "chat":
+                return await self._probe_via_chat(timeout_seconds=timeout_seconds)
+            if strategy == "models_or_chat":
+                try:
+                    return await self._probe_via_models(timeout_seconds=timeout_seconds)
+                except ProviderError as exc:
+                    status, _reason = self._classify_request_readiness_issue(exc.detail)
+                    if status not in {"endpoint-mismatch", "model-unavailable", "degraded"}:
+                        raise
+                    return await self._probe_via_chat(timeout_seconds=timeout_seconds)
+            if not self.transport.get("supports_models_probe", True):
+                return self.health.healthy
+            return await self._probe_via_models(timeout_seconds=timeout_seconds)
+        except ProviderError as e:
+            self._mark_probe_failure(f"Probe HTTP {e.status}: {e.detail}")
+            return False
         except httpx.TimeoutException as e:
-            self.health.record_failure(f"Probe timeout: {e}")
+            self._mark_probe_failure(f"Probe timeout: {e}")
             return False
         except httpx.ConnectError as e:
-            self.health.record_failure(f"Probe connection error: {e}")
+            self._mark_probe_failure(f"Probe connection error: {e}")
             return False
 
     async def generate_image(

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import re
 import shutil
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +19,7 @@ from .lane_registry import (
     get_provider_transport_binding,
 )
 from .provider_catalog import get_provider_catalog
+from .providers import ProviderBackend
 
 ProviderFactory = dict[str, Any]
 
@@ -466,6 +470,51 @@ def _extract_env_reference(value: str) -> str:
     if stripped.startswith("${") and stripped.endswith("}"):
         return stripped[2:-1].split(":-", 1)[0].split(":", 1)[0]
     return ""
+
+
+_ENV_REF_RE = re.compile(r"\$\{([^}]+)}")
+
+
+def _expand_env_with_values(value: Any, env_values: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        def _replace(match: re.Match[str]) -> str:
+            token = match.group(1)
+            if ":-" in token:
+                name, default = token.split(":-", 1)
+                return env_values.get(name, default)
+            return env_values.get(token, match.group(0))
+
+        return _ENV_REF_RE.sub(_replace, value)
+    if isinstance(value, dict):
+        return {key: _expand_env_with_values(val, env_values) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_with_values(item, env_values) for item in value]
+    return value
+
+
+async def _probe_providers_live(
+    configured: dict[str, dict[str, Any]],
+    *,
+    env_values: dict[str, str],
+    timeout_seconds: float,
+) -> dict[str, dict[str, Any]]:
+    results: dict[str, dict[str, Any]] = {}
+    for name, provider in configured.items():
+        runtime_cfg = _expand_env_with_values(deepcopy(provider), env_values)
+        if not isinstance(runtime_cfg, dict):
+            continue
+        backend = ProviderBackend(name, runtime_cfg)
+        try:
+            ok = await backend.probe_health(timeout_seconds=timeout_seconds)
+            results[name] = {
+                "healthy": ok,
+                "avg_latency_ms": backend.health.avg_latency_ms,
+                "last_error": backend.health.last_error,
+                "request_readiness": backend.request_readiness(),
+            }
+        finally:
+            await backend.close()
+    return results
 
 
 def _load_existing_provider_models(config_path: str | Path | None = None) -> dict[str, str]:
@@ -1035,10 +1084,23 @@ def build_provider_probe_report(
     config_path: str | Path | None = None,
     env_file: str | Path | None = None,
     health_payload: dict[str, Any] | None = None,
+    live_probe: bool = False,
+    timeout_seconds: float = 2.0,
 ) -> dict[str, Any]:
     configured = _load_existing_provider_configs(config_path)
     env_values = _load_env_values(env_file)
     provider_health = ((health_payload or {}).get("providers")) or {}
+    if live_probe and configured:
+        provider_health = {
+            **provider_health,
+            **asyncio.run(
+                _probe_providers_live(
+                    configured,
+                    env_values=env_values,
+                    timeout_seconds=timeout_seconds,
+                )
+            ),
+        }
     rows: list[dict[str, Any]] = []
     ready_count = 0
 
@@ -1059,12 +1121,18 @@ def build_provider_probe_report(
         if missing_key:
             status = "missing-key"
             status_reason = f"needs {env_name}"
-        elif health_payload is None:
-            status = "configured"
-            status_reason = "health endpoint unavailable; config and env look present"
         elif request_readiness and not bool(request_readiness.get("ready")):
             status = str(request_readiness.get("status") or "unhealthy")
             status_reason = str(request_readiness.get("reason") or "route is not request-ready")
+        elif request_readiness and bool(request_readiness.get("ready")):
+            status = str(request_readiness.get("status") or "ready")
+            status_reason = str(
+                request_readiness.get("reason") or "route looks request-ready from runtime probes"
+            )
+            ready_count += 1
+        elif health_payload is None:
+            status = "configured"
+            status_reason = "health endpoint unavailable; config and env look present"
         elif healthy:
             status = "ready"
             status_reason = "responding through /health"
@@ -1115,6 +1183,13 @@ def build_provider_probe_report(
                     or transport_defaults.get("probe_confidence")
                     or ""
                 ),
+                "probe_strategy": str(
+                    request_readiness.get("probe_strategy")
+                    or (provider.get("transport") or {}).get("probe_strategy")
+                    or transport_defaults.get("probe_strategy")
+                    or ""
+                ),
+                "verified_via": str(request_readiness.get("verified_via") or ""),
             }
         )
 
@@ -1124,6 +1199,7 @@ def build_provider_probe_report(
             "configured": len(rows),
             "ready": ready_count,
             "health_live": health_payload is not None,
+            "live_probe": live_probe,
         },
     }
 
@@ -1138,6 +1214,8 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
         "Live health: "
         + ("available" if summary.get("health_live") else "not available; config/env only")
     )
+    if summary.get("live_probe"):
+        lines.append("Live probe: enabled (using transport-specific shallow request probes)")
     lines.append("")
     for row in report.get("providers", []):
         lines.append(f"- {row['provider']}  ({row['status']})")
@@ -1154,7 +1232,14 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                     if row.get("transport_confidence")
                     else ""
                 )
+                + (
+                    f" | strategy: {row.get('probe_strategy')}"
+                    if row.get("probe_strategy")
+                    else ""
+                )
             )
+        if row.get("verified_via"):
+            lines.append("  " + f"verified via: {row['verified_via']}")
         if row.get("avg_latency_ms"):
             lines.append("  " + f"latency: {row['avg_latency_ms']:.1f} ms")
         lines.append("  " + f"why: {row['reason']}")

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -149,6 +149,7 @@ if health_raw:
         profile = str(request_readiness.get("profile") or "")
         compatibility = str(request_readiness.get("compatibility") or "")
         confidence = str(request_readiness.get("probe_confidence") or "")
+        verified_via = str(request_readiness.get("verified_via") or "")
         profile_bits = []
         if profile:
             profile_bits.append(profile)
@@ -156,6 +157,8 @@ if health_raw:
             profile_bits.append(compatibility)
         if confidence:
             profile_bits.append(f"confidence={confidence}")
+        if verified_via:
+            profile_bits.append(f"verified={verified_via}")
         profile_suffix = f" [{' | '.join(profile_bits)}]" if profile_bits else ""
         if request_readiness.get("ready"):
             ready += 1

--- a/scripts/faigate-provider-probe
+++ b/scripts/faigate-provider-probe
@@ -7,14 +7,17 @@ config_file="$(faigate_config_file)"
 env_file="$(faigate_env_file)"
 python_bin="$(faigate_python_bin)"
 mode="text"
+live_probe="0"
+timeout_seconds="2.0"
 
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/faigate-provider-probe [--json|--text]
+  ./scripts/faigate-provider-probe [--json|--text] [--live] [--timeout SECONDS]
 
 Probe configured provider sources against the current config, env file, and
-local /health payload when available.
+local /health payload when available. Use --live to run shallow transport-aware
+request probes directly against the configured providers.
 EOF
 }
 
@@ -27,6 +30,18 @@ while [[ $# -gt 0 ]]; do
     --text)
       mode="text"
       shift
+      ;;
+    --live)
+      live_probe="1"
+      shift
+      ;;
+    --timeout)
+      timeout_seconds="${2:-}"
+      if [[ -z "$timeout_seconds" ]]; then
+        usage >&2
+        exit 2
+      fi
+      shift 2
       ;;
     --help|-h)
       usage
@@ -48,6 +63,8 @@ FAIGATE_PROVIDER_PROBE_CONFIG="$config_file" \
 FAIGATE_PROVIDER_PROBE_ENV="$env_file" \
 FAIGATE_PROVIDER_PROBE_MODE="$mode" \
 FAIGATE_PROVIDER_PROBE_HEALTH="$health_payload" \
+FAIGATE_PROVIDER_PROBE_LIVE="$live_probe" \
+FAIGATE_PROVIDER_PROBE_TIMEOUT="$timeout_seconds" \
 "$python_bin" - <<'PY'
 import json
 import os
@@ -60,6 +77,8 @@ report = build_provider_probe_report(
     config_path=os.environ["FAIGATE_PROVIDER_PROBE_CONFIG"],
     env_file=os.environ["FAIGATE_PROVIDER_PROBE_ENV"],
     health_payload=health_payload,
+    live_probe=os.environ.get("FAIGATE_PROVIDER_PROBE_LIVE") == "1",
+    timeout_seconds=float(os.environ.get("FAIGATE_PROVIDER_PROBE_TIMEOUT") or "2.0"),
 )
 
 if os.environ["FAIGATE_PROVIDER_PROBE_MODE"] == "json":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,6 +244,7 @@ providers:
     api_key: "secret"
     model: "chat-model"
     transport:
+      probe_strategy: models-or-chat
       chat_path: /responses/chat
 fallback_chain: []
 metrics:
@@ -257,6 +258,7 @@ metrics:
     assert cfg.providers["cloud-default"]["transport"]["auth_mode"] == "bearer"
     assert cfg.providers["cloud-default"]["transport"]["profile"] == "openai-compatible"
     assert cfg.providers["cloud-default"]["transport"]["compatibility"] == "native"
+    assert cfg.providers["cloud-default"]["transport"]["probe_strategy"] == "models_or_chat"
     assert cfg.providers["cloud-default"]["transport"]["models_path"] == "/models"
     assert cfg.providers["cloud-default"]["transport"]["chat_path"] == "/responses/chat"
 

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1286,8 +1286,9 @@ def test_faigate_dashboard_overview_summarizes_live_stats(tmp_path: Path):
                             "tier": "default",
                             "request_readiness": {
                                 "ready": True,
-                                "status": "ready",
-                                "reason": _READY_REASON,
+                                "status": "ready-verified",
+                                "reason": "route passed a live models probe recently",
+                                "verified_via": "models",
                             },
                         },
                         "gemini-flash": {
@@ -1431,8 +1432,9 @@ def test_faigate_dashboard_overview_summarizes_live_stats(tmp_path: Path):
                             },
                             "request_readiness": {
                                 "ready": True,
-                                "status": "ready",
-                                "reason": _READY_REASON,
+                                "status": "ready-verified",
+                                "reason": "route passed a live models probe recently",
+                                "verified_via": "models",
                             },
                             "transport": {
                                 "profile": "openai-compatible",
@@ -1517,8 +1519,9 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
                             "tier": "default",
                             "request_readiness": {
                                 "ready": True,
-                                "status": "ready",
-                                "reason": _READY_REASON,
+                                "status": "ready-verified",
+                                "reason": "route passed a live models probe recently",
+                                "verified_via": "models",
                             },
                         },
                     },
@@ -1584,8 +1587,9 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
                             },
                             "request_readiness": {
                                 "ready": True,
-                                "status": "ready",
-                                "reason": _READY_REASON,
+                                "status": "ready-verified",
+                                "reason": "route passed a live models probe recently",
+                                "verified_via": "models",
                             },
                             "route_runtime_state": {
                                 "penalty": 6,
@@ -1617,7 +1621,8 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
     assert "Canonical lane    deepseek/chat" in result.stdout
     assert "Route type        direct" in result.stdout
     assert "Lane cluster      balanced-workhorse" in result.stdout
-    assert "Request-ready     ready" in result.stdout
+    assert "Request-ready     ready-verified" in result.stdout
+    assert "Verified via      models" in result.stdout
     assert "Transport profile openai-compatible" in result.stdout
     assert "Compatibility     native" in result.stdout
     assert "Chat path         /chat/completions" in result.stdout

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -209,13 +209,13 @@ class TestProviderHealthProbes:
                     "compatibility": "aggregator",
                     "probe_confidence": "medium",
                     "auth_mode": "bearer",
-                    "probe_strategy": "models",
-                    "models_path": "/models",
+                    "probe_strategy": "chat",
+                    "models_path": "",
                     "chat_path": "/chat/completions",
                     "image_generation_path": "/images/generations",
                     "image_edit_path": "/images/edits",
                     "requires_api_key": True,
-                    "supports_models_probe": True,
+                    "supports_models_probe": False,
                     "notes": ["aggregator route uses compatibility assumptions"],
                 },
             },
@@ -227,6 +227,110 @@ class TestProviderHealthProbes:
         assert readiness["status"] == "ready-compat"
         assert readiness["compatibility"] == "aggregator"
         assert readiness["probe_confidence"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_chat_probe_marks_aggregator_route_verified(self):
+        backend = ProviderBackend(
+            "kilocode",
+            {
+                "backend": "openai-compat",
+                "base_url": "https://api.kilo.example/v1",
+                "api_key": "secret",
+                "model": "glm-5-free",
+                "transport": {
+                    "profile": "kilo-openai-compat",
+                    "compatibility": "aggregator",
+                    "probe_confidence": "medium",
+                    "auth_mode": "bearer",
+                    "probe_strategy": "chat",
+                    "models_path": "",
+                    "chat_path": "/chat/completions",
+                    "image_generation_path": "/images/generations",
+                    "image_edit_path": "/images/edits",
+                    "requires_api_key": True,
+                    "supports_models_probe": False,
+                    "notes": ["aggregator route uses compatibility assumptions"],
+                },
+            },
+        )
+        captured: dict = {}
+
+        class _FakeResp:
+            status_code = 200
+            text = ""
+
+        async def _fake_post(url, json=None, headers=None, timeout=None, **_kw):
+            captured["url"] = url
+            captured["json"] = json or {}
+            captured["headers"] = headers or {}
+            captured["timeout"] = timeout
+            return _FakeResp()
+
+        backend._client.post = _fake_post  # type: ignore[attr-defined]
+
+        ok = await backend.probe_health(timeout_seconds=2.5)
+        readiness = backend.request_readiness()
+
+        assert ok is True
+        assert captured["url"] == "https://api.kilo.example/v1/chat/completions"
+        assert captured["json"]["messages"][0]["content"] == "ping"
+        assert readiness["status"] == "ready-verified"
+        assert readiness["verified_via"] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_models_or_chat_probe_falls_back_to_chat_for_endpoint_mismatch(self):
+        backend = ProviderBackend(
+            "openrouter-fallback",
+            {
+                "backend": "openai-compat",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "secret",
+                "model": "openrouter/auto",
+                "transport": {
+                    "profile": "openrouter-openai-compat",
+                    "compatibility": "aggregator",
+                    "probe_confidence": "high",
+                    "auth_mode": "bearer",
+                    "probe_strategy": "models_or_chat",
+                    "models_path": "/models",
+                    "chat_path": "/chat/completions",
+                    "image_generation_path": "/images/generations",
+                    "image_edit_path": "/images/edits",
+                    "requires_api_key": True,
+                    "supports_models_probe": True,
+                    "notes": ["marketplace route"],
+                },
+            },
+        )
+        captured: dict = {"calls": []}
+
+        class _ModelsResp:
+            status_code = 404
+            text = "unsupported path"
+
+        class _ChatResp:
+            status_code = 200
+            text = ""
+
+        async def _fake_get(url, headers=None, timeout=None, **_kw):
+            captured["calls"].append(("get", url))
+            return _ModelsResp()
+
+        async def _fake_post(url, json=None, headers=None, timeout=None, **_kw):
+            captured["calls"].append(("post", url))
+            return _ChatResp()
+
+        backend._client.get = _fake_get  # type: ignore[attr-defined]
+        backend._client.post = _fake_post  # type: ignore[attr-defined]
+
+        ok = await backend.probe_health(timeout_seconds=1.5)
+
+        assert ok is True
+        assert captured["calls"] == [
+            ("get", "https://openrouter.ai/api/v1/models"),
+            ("post", "https://openrouter.ai/api/v1/chat/completions"),
+        ]
+        assert backend.request_readiness()["verified_via"] == "chat"
 
     @pytest.mark.asyncio
     async def test_assistant_none_content_converted_to_empty_string(self):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from faigate.wizard import (
@@ -894,6 +895,62 @@ providers:
     assert "Configured: 2 | Ready now: 1" in rendered
     assert "- deepseek-chat  (ready)" in rendered
     assert "transport: openai-compatible | native | confidence: high" in rendered
+
+
+def test_build_provider_probe_report_live_probe_surfaces_verified_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+providers:
+  kilocode:
+    backend: openai-compat
+    api_key: "${KILOCODE_API_KEY}"
+    base_url: "https://api.kilo.example/v1"
+    model: "z-ai/glm-5:free"
+    tier: fallback
+""".strip(),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("KILOCODE_API_KEY=sk-demo\n", encoding="utf-8")
+
+    async def _fake_probe(*_args, **_kwargs):
+        return {
+            "kilocode": {
+                "healthy": True,
+                "avg_latency_ms": 41.0,
+                "last_error": "",
+                "request_readiness": {
+                    "ready": True,
+                    "status": "ready-verified",
+                    "reason": "route passed a live chat probe recently",
+                    "profile": "kilo-openai-compat",
+                    "compatibility": "aggregator",
+                    "probe_confidence": "high",
+                    "probe_strategy": "chat",
+                    "verified_via": "chat",
+                },
+            }
+        }
+
+    monkeypatch.setattr("faigate.wizard._probe_providers_live", _fake_probe)
+
+    report = build_provider_probe_report(
+        config_path=config_path,
+        env_file=env_file,
+        live_probe=True,
+    )
+
+    row = report["providers"][0]
+    assert report["summary"]["live_probe"] is True
+    assert row["status"] == "ready-verified"
+    assert row["probe_strategy"] == "chat"
+    assert row["verified_via"] == "chat"
+    rendered = render_provider_probe_text(report)
+    assert "Live probe: enabled" in rendered
+    assert "verified via: chat" in rendered
 
 
 def test_list_client_scenarios_exposes_opencode_quality_path(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add strategy-aware transport probing with  and  variants for provider routes
- let provider probe run optional live shallow probes and surface  /  operator signals
- update doctor and dashboard views plus tests for the stronger request-readiness semantics

## Verification
- ./.venv-check-313/bin/ruff check faigate/config.py faigate/dashboard.py faigate/lane_registry.py faigate/providers.py faigate/wizard.py tests/test_config.py tests/test_providers.py tests/test_wizard.py tests/test_menu_helpers.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_config.py tests/test_providers.py tests/test_wizard.py tests/test_menu_helpers.py -k 'transport or readiness or provider_probe or dashboard or doctor or probe'
- bash -n scripts/faigate-doctor scripts/faigate-provider-probe
- git diff --check