### PR TITLE
feat(runtime): add readiness cooldown windows

### DIFF
--- a/faigate/adaptation.py
+++ b/faigate/adaptation.py
@@ -6,15 +6,61 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+_HARD_COOLDOWN_WINDOWS = {
+    "auth-invalid": 1800,
+    "quota-exhausted": 1800,
+    "endpoint-mismatch": 900,
+    "model-unavailable": 900,
+    "rate-limited": 180,
+}
+_SOFT_DEGRADE_WINDOWS = {
+    "transport-error": 180,
+    "timeout": 120,
+    "degraded": 90,
+    "error": 60,
+}
+
 
 def _issue_type_from_error(error: str) -> str:
     lowered = str(error or "").lower()
     if any(token in lowered for token in ("quota", "insufficient_quota", "billing hard limit")):
         return "quota-exhausted"
+    if any(
+        token in lowered
+        for token in (
+            "auth",
+            "unauthorized",
+            "forbidden",
+            "invalid api key",
+            "incorrect api key",
+        )
+    ):
+        return "auth-invalid"
     if any(token in lowered for token in ("429", "rate limit", "rate-limit", "too many requests")):
         return "rate-limited"
     if any(token in lowered for token in ("timeout", "timed out")):
         return "timeout"
+    if any(
+        token in lowered
+        for token in (
+            "connection error",
+            "transport",
+            "dns",
+            "refused",
+            "unreachable",
+        )
+    ):
+        return "transport-error"
+    if any(
+        token in lowered
+        for token in (
+            "unknown url",
+            "unsupported path",
+            "unsupported url",
+            "bad route",
+        )
+    ):
+        return "endpoint-mismatch"
     if any(token in lowered for token in ("model", "not found", "unsupported")):
         return "model-unavailable"
     return "error"
@@ -50,10 +96,16 @@ class RoutePressure:
         penalty = min(self.consecutive_failures * 4, 20)
         if self.last_issue_type == "quota-exhausted":
             penalty += 24
+        elif self.last_issue_type == "auth-invalid":
+            penalty += 26
         elif self.last_issue_type == "rate-limited":
             penalty += 16
         elif self.last_issue_type == "timeout":
             penalty += 8
+        elif self.last_issue_type == "transport-error":
+            penalty += 10
+        elif self.last_issue_type == "endpoint-mismatch":
+            penalty += 20
         elif self.last_issue_type == "model-unavailable":
             penalty += 18
 
@@ -65,7 +117,53 @@ class RoutePressure:
             penalty += 3
         return penalty
 
+    def cooldown_window_seconds(self) -> int:
+        return int(_HARD_COOLDOWN_WINDOWS.get(self.last_issue_type, 0))
+
+    def degraded_window_seconds(self) -> int:
+        return int(_SOFT_DEGRADE_WINDOWS.get(self.last_issue_type, 0))
+
+    def _remaining_window_seconds(
+        self,
+        *,
+        active_window_seconds: int,
+        now: float | None = None,
+    ) -> int:
+        if active_window_seconds <= 0 or self.last_issue_at <= 0:
+            return 0
+        current_time = time.time() if now is None else now
+        return max(0, int(round((self.last_issue_at + active_window_seconds) - current_time)))
+
+    def cooldown_remaining_seconds(self, now: float | None = None) -> int:
+        return self._remaining_window_seconds(
+            active_window_seconds=self.cooldown_window_seconds(),
+            now=now,
+        )
+
+    def degraded_remaining_seconds(self, now: float | None = None) -> int:
+        return self._remaining_window_seconds(
+            active_window_seconds=self.degraded_window_seconds(),
+            now=now,
+        )
+
+    def cooldown_active(self, now: float | None = None) -> bool:
+        return self.cooldown_remaining_seconds(now=now) > 0
+
+    def degraded_active(self, now: float | None = None) -> bool:
+        return self.degraded_remaining_seconds(now=now) > 0
+
+    def window_state(self, now: float | None = None) -> str:
+        if self.cooldown_active(now=now):
+            return "cooldown"
+        if self.degraded_active(now=now):
+            return "degraded"
+        return "clear"
+
     def to_dict(self) -> dict[str, Any]:
+        cooldown_window_s = self.cooldown_window_seconds()
+        degraded_window_s = self.degraded_window_seconds()
+        cooldown_remaining_s = self.cooldown_remaining_seconds()
+        degraded_remaining_s = self.degraded_remaining_seconds()
         return {
             "consecutive_failures": self.consecutive_failures,
             "last_issue_type": self.last_issue_type,
@@ -74,6 +172,22 @@ class RoutePressure:
             "last_success_at": self.last_success_at,
             "avg_latency_ms": round(self.avg_latency_ms, 1),
             "penalty": self.penalty(),
+            "cooldown_window_s": cooldown_window_s,
+            "cooldown_remaining_s": cooldown_remaining_s,
+            "cooldown_until": (
+                round(self.last_issue_at + cooldown_window_s, 3)
+                if cooldown_window_s and self.last_issue_at
+                else 0.0
+            ),
+            "degraded_window_s": degraded_window_s,
+            "degraded_remaining_s": degraded_remaining_s,
+            "degraded_until": (
+                round(self.last_issue_at + degraded_window_s, 3)
+                if degraded_window_s and self.last_issue_at
+                else 0.0
+            ),
+            "window_state": self.window_state(),
+            "request_blocked": self.cooldown_active(),
         }
 
 

--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -870,6 +870,12 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
                 f"Last issue type   {runtime_state.get('last_issue_type') or 'n/a'}",
             ]
         )
+        if runtime_state.get("window_state") and runtime_state.get("window_state") != "clear":
+            lines.append(f"Runtime window    {runtime_state.get('window_state')}")
+        if runtime_state.get("cooldown_remaining_s"):
+            lines.append(f"Cooldown left     {_safe_int(runtime_state.get('cooldown_remaining_s'))}s")
+        if runtime_state.get("degraded_remaining_s"):
+            lines.append(f"Degraded left     {_safe_int(runtime_state.get('degraded_remaining_s'))}s")
     if provider in unhealthy:
         lines.append(f"Live issue        {unhealthy[provider]['detail']}")
     if provider_routing_paths:

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -400,6 +400,9 @@ def _provider_request_readiness(provider: Any) -> dict[str, Any]:
     runtime_state = _provider_runtime_state_snapshot().get(getattr(provider, "name", ""), {})
     runtime_penalty = int(runtime_state.get("penalty", 0) or 0)
     runtime_issue_type = str(runtime_state.get("last_issue_type") or "")
+    runtime_window_state = str(runtime_state.get("window_state") or "clear")
+    runtime_cooldown_remaining = int(runtime_state.get("cooldown_remaining_s", 0) or 0)
+    runtime_degraded_remaining = int(runtime_state.get("degraded_remaining_s", 0) or 0)
 
     if hasattr(provider, "request_readiness"):
         state = dict(provider.request_readiness() or {})
@@ -415,8 +418,39 @@ def _provider_request_readiness(provider: Any) -> dict[str, Any]:
     state["runtime_penalty"] = runtime_penalty
     state["runtime_issue_type"] = runtime_issue_type
     state["runtime_cooldown_active"] = False
+    state["runtime_window_state"] = runtime_window_state
+    state["runtime_cooldown_remaining_s"] = runtime_cooldown_remaining
+    state["runtime_degraded_remaining_s"] = runtime_degraded_remaining
+    state["runtime_cooldown_until"] = float(runtime_state.get("cooldown_until", 0.0) or 0.0)
+    state["runtime_degraded_until"] = float(runtime_state.get("degraded_until", 0.0) or 0.0)
 
-    if runtime_penalty >= 20 and runtime_issue_type in {
+    if runtime_window_state == "cooldown" and runtime_issue_type in {
+        "auth-invalid",
+        "endpoint-mismatch",
+        "model-unavailable",
+        "quota-exhausted",
+        "rate-limited",
+    }:
+        state["ready"] = False
+        state["status"] = runtime_issue_type
+        state["reason"] = (
+            "route is in runtime cooldown for another "
+            f"{runtime_cooldown_remaining}s after recent {runtime_issue_type.replace('-', ' ')} failures"
+        )
+        state["runtime_cooldown_active"] = True
+        state["operator_hint"] = (
+            "keep this route out of primary traffic until the cooldown pressure drops"
+        )
+    elif runtime_window_state == "degraded" and runtime_issue_type and bool(state.get("ready")):
+        state["status"] = "ready-degraded"
+        state["reason"] = (
+            "route is still request-ready but operating under recent "
+            f"{runtime_issue_type.replace('-', ' ')} pressure for another {runtime_degraded_remaining}s"
+        )
+        state["operator_hint"] = (
+            "prefer lower-pressure siblings while this route recovers"
+        )
+    elif runtime_penalty >= 20 and runtime_issue_type in {
         "quota-exhausted",
         "rate-limited",
         "model-unavailable",

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -155,6 +155,9 @@ if health_raw:
         runtime_penalty = int(request_readiness.get("runtime_penalty") or 0)
         runtime_issue_type = str(request_readiness.get("runtime_issue_type") or "")
         cooldown_active = bool(request_readiness.get("runtime_cooldown_active"))
+        runtime_window_state = str(request_readiness.get("runtime_window_state") or "clear")
+        runtime_cooldown_remaining = int(request_readiness.get("runtime_cooldown_remaining_s") or 0)
+        runtime_degraded_remaining = int(request_readiness.get("runtime_degraded_remaining_s") or 0)
         profile_bits = []
         if profile:
             profile_bits.append(profile)
@@ -176,9 +179,14 @@ if health_raw:
             print(f"[ok] request-ready next step: {provider_name} -> {operator_hint}")
         if runtime_penalty or runtime_issue_type:
             cooldown_suffix = " | cooldown active" if cooldown_active else ""
+            window_suffix = ""
+            if runtime_window_state == "cooldown" and runtime_cooldown_remaining:
+                window_suffix = f" | cooldown {runtime_cooldown_remaining}s left"
+            elif runtime_window_state == "degraded" and runtime_degraded_remaining:
+                window_suffix = f" | degraded {runtime_degraded_remaining}s left"
             print(
                 f"[ok] request-ready runtime: {provider_name} -> penalty={runtime_penalty}"
-                f" | issue={runtime_issue_type or 'n/a'}{cooldown_suffix}"
+                f" | issue={runtime_issue_type or 'n/a'}{cooldown_suffix}{window_suffix}"
             )
     if total:
         print(f"[ok] request readiness summary: {ready}/{total} provider routes look request-ready")

--- a/tests/test_adaptation.py
+++ b/tests/test_adaptation.py
@@ -1,0 +1,38 @@
+from faigate.adaptation import AdaptiveRouteState, RoutePressure
+
+
+def test_route_pressure_sets_hard_cooldown_for_auth_invalid() -> None:
+    route = RoutePressure(provider_name="anthropic-direct")
+
+    route.record_failure("401 invalid api key")
+    snapshot = route.to_dict()
+
+    assert snapshot["last_issue_type"] == "auth-invalid"
+    assert snapshot["window_state"] == "cooldown"
+    assert snapshot["request_blocked"] is True
+    assert snapshot["cooldown_remaining_s"] > 0
+    assert snapshot["degraded_remaining_s"] == 0
+
+
+def test_route_pressure_sets_soft_degrade_window_for_timeout() -> None:
+    route = RoutePressure(provider_name="deepseek-chat")
+
+    route.record_failure("Timeout: upstream timed out")
+    snapshot = route.to_dict()
+
+    assert snapshot["last_issue_type"] == "timeout"
+    assert snapshot["window_state"] == "degraded"
+    assert snapshot["request_blocked"] is False
+    assert snapshot["degraded_remaining_s"] > 0
+    assert snapshot["cooldown_remaining_s"] == 0
+
+
+def test_adaptive_route_state_provider_snapshot_exposes_window_metadata() -> None:
+    state = AdaptiveRouteState()
+
+    state.record_failure("openrouter-fallback", error="unsupported path /models")
+    snapshot = state.provider_snapshot("openrouter-fallback")
+
+    assert snapshot["last_issue_type"] == "endpoint-mismatch"
+    assert snapshot["window_state"] == "cooldown"
+    assert snapshot["cooldown_until"] > 0

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -412,6 +412,9 @@ providers:
                                 "runtime_penalty": 0,
                                 "runtime_issue_type": "",
                                 "runtime_cooldown_active": False,
+                                "runtime_window_state": "clear",
+                                "runtime_cooldown_remaining_s": 0,
+                                "runtime_degraded_remaining_s": 0,
                             },
                         }
                     },
@@ -442,6 +445,84 @@ providers:
     assert "[openai-compatible | native | confidence=high]" in result.stdout
     assert "request-ready payload: deepseek-chat -> openai-chat-minimal" in result.stdout
     assert "request-ready next step: deepseek-chat -> route can carry live traffic" in result.stdout
+
+
+def test_faigate_doctor_reports_runtime_cooldown_windows(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    env_file = tmp_path / "faigate.env"
+    config_file.write_text("server: {}\nproviders: {}\n", encoding="utf-8")
+    env_file.write_text("", encoding="utf-8")
+
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {
+                        "providers_total": 1,
+                        "providers_healthy": 1,
+                        "providers_unhealthy": 0,
+                    },
+                    "request_readiness": {
+                        "providers_total": 1,
+                        "providers_ready": 0,
+                        "providers_not_ready": 1,
+                    },
+                    "providers": {
+                        "deepseek-chat": {
+                            "healthy": True,
+                            "request_readiness": {
+                                "ready": False,
+                                "status": "rate-limited",
+                                "reason": (
+                                    "route is in runtime cooldown for another 120s "
+                                    "after recent rate limited failures"
+                                ),
+                                "profile": "openai-compatible",
+                                "compatibility": "native",
+                                "probe_confidence": "high",
+                                "probe_payload": "openai-chat-minimal | user='ping' | max_tokens=1",
+                                "operator_hint": (
+                                    "keep this route out of primary traffic until "
+                                    "the cooldown pressure drops"
+                                ),
+                                "runtime_penalty": 24,
+                                "runtime_issue_type": "rate-limited",
+                                "runtime_cooldown_active": True,
+                                "runtime_window_state": "cooldown",
+                                "runtime_cooldown_remaining_s": 120,
+                                "runtime_degraded_remaining_s": 0,
+                            },
+                        }
+                    },
+                }
+            ),
+            "/v1/models": json.dumps({"data": []}),
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_ENV_FILE"] = str(env_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-doctor"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "request-ready: deepseek-chat -> rate-limited" in result.stdout
+    assert (
+        "request-ready runtime: deepseek-chat -> penalty=24 | issue=rate-limited "
+        "| cooldown active | cooldown 120s left" in result.stdout
+    )
 
 
 def test_faigate_service_lib_detects_homebrew_runtime_paths(tmp_path: Path):

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -776,9 +776,46 @@ class TestProviderCoverage:
         assert readiness["status"] == "rate-limited"
         assert readiness["runtime_penalty"] >= 20
         assert readiness["runtime_cooldown_active"] is True
+        assert readiness["runtime_window_state"] == "cooldown"
+        assert readiness["runtime_cooldown_remaining_s"] > 0
         assert readiness["operator_hint"] == (
             "keep this route out of primary traffic until the cooldown pressure drops"
         )
+
+    @pytest.mark.asyncio
+    async def test_health_request_readiness_marks_timeout_routes_as_degraded(
+        self, preview_config
+    ):
+        main_module._adaptive_state.record_failure(
+            "cloud-default",
+            error="Timeout: upstream timed out",
+        )
+
+        response = await health()
+
+        readiness = response["providers"]["cloud-default"]["request_readiness"]
+        assert readiness["ready"] is True
+        assert readiness["status"] == "ready-degraded"
+        assert readiness["runtime_window_state"] == "degraded"
+        assert readiness["runtime_degraded_remaining_s"] > 0
+        assert (
+            readiness["operator_hint"]
+            == "prefer lower-pressure siblings while this route recovers"
+        )
+
+    @pytest.mark.asyncio
+    async def test_health_request_readiness_blocks_auth_invalid_routes_immediately(
+        self, preview_config
+    ):
+        main_module._adaptive_state.record_failure("cloud-default", error="401 invalid api key")
+
+        response = await health()
+
+        readiness = response["providers"]["cloud-default"]["request_readiness"]
+        assert readiness["ready"] is False
+        assert readiness["status"] == "auth-invalid"
+        assert readiness["runtime_window_state"] == "cooldown"
+        assert readiness["runtime_cooldown_active"] is True
 
     @pytest.mark.asyncio
     async def test_provider_inventory_filters_by_capability(self, preview_config):


### PR DESCRIPTION
## Summary
- add issue-class-specific cooldown and degraded windows to adaptive route state
- feed runtime window metadata into request-readiness, doctor output, and dashboard provider detail
- add focused tests for auth-invalid cooldowns, timeout degradation, and doctor cooldown reporting

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_adaptation.py tests/test_route_introspection.py tests/test_menu_helpers.py -k "cooldown or request_readiness or adaptation or runtime_cooldown_windows"
- ./.venv-check-313/bin/ruff check faigate/adaptation.py faigate/main.py faigate/dashboard.py tests/test_adaptation.py tests/test_route_introspection.py tests/test_menu_helpers.py
- bash -n scripts/faigate-doctor