### PR TITLE
feat(runtime): track route recovery after retries

### DIFF
--- a/faigate/adaptation.py
+++ b/faigate/adaptation.py
@@ -19,6 +19,7 @@ _SOFT_DEGRADE_WINDOWS = {
     "degraded": 90,
     "error": 60,
 }
+_RECOVERY_WINDOW_SECONDS = 300
 
 
 def _issue_type_from_error(error: str) -> str:
@@ -74,11 +75,25 @@ class RoutePressure:
     last_issue_detail: str = ""
     last_issue_at: float = 0.0
     last_success_at: float = 0.0
+    last_recovered_issue_type: str = ""
+    last_recovered_issue_detail: str = ""
+    last_recovered_at: float = 0.0
     avg_latency_ms: float = 0.0
     _latencies: list[float] = field(default_factory=list)
 
     def record_success(self, latency_ms: float = 0.0) -> None:
+        if self.last_issue_type:
+            self.last_recovered_issue_type = self.last_issue_type
+            self.last_recovered_issue_detail = self.last_issue_detail
+            self.last_recovered_at = time.time()
+        else:
+            self.last_recovered_issue_type = ""
+            self.last_recovered_issue_detail = ""
+            self.last_recovered_at = 0.0
         self.consecutive_failures = 0
+        self.last_issue_type = ""
+        self.last_issue_detail = ""
+        self.last_issue_at = 0.0
         self.last_success_at = time.time()
         if latency_ms > 0:
             self._latencies.append(latency_ms)
@@ -159,17 +174,33 @@ class RoutePressure:
             return "degraded"
         return "clear"
 
+    def recovery_remaining_seconds(self, now: float | None = None) -> int:
+        if self.last_recovered_at <= 0:
+            return 0
+        current_time = time.time() if now is None else now
+        return max(
+            0,
+            int(round((self.last_recovered_at + _RECOVERY_WINDOW_SECONDS) - current_time)),
+        )
+
+    def recovered_recently(self, now: float | None = None) -> bool:
+        return self.recovery_remaining_seconds(now=now) > 0
+
     def to_dict(self) -> dict[str, Any]:
         cooldown_window_s = self.cooldown_window_seconds()
         degraded_window_s = self.degraded_window_seconds()
         cooldown_remaining_s = self.cooldown_remaining_seconds()
         degraded_remaining_s = self.degraded_remaining_seconds()
+        recovery_remaining_s = self.recovery_remaining_seconds()
         return {
             "consecutive_failures": self.consecutive_failures,
             "last_issue_type": self.last_issue_type,
             "last_issue_detail": self.last_issue_detail,
             "last_issue_at": self.last_issue_at,
             "last_success_at": self.last_success_at,
+            "last_recovered_issue_type": self.last_recovered_issue_type,
+            "last_recovered_issue_detail": self.last_recovered_issue_detail,
+            "last_recovered_at": self.last_recovered_at,
             "avg_latency_ms": round(self.avg_latency_ms, 1),
             "penalty": self.penalty(),
             "cooldown_window_s": cooldown_window_s,
@@ -188,6 +219,9 @@ class RoutePressure:
             ),
             "window_state": self.window_state(),
             "request_blocked": self.cooldown_active(),
+            "recovery_window_s": _RECOVERY_WINDOW_SECONDS,
+            "recovery_remaining_s": recovery_remaining_s,
+            "recovered_recently": recovery_remaining_s > 0,
         }
 
 

--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -876,6 +876,13 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
             lines.append(f"Cooldown left     {_safe_int(runtime_state.get('cooldown_remaining_s'))}s")
         if runtime_state.get("degraded_remaining_s"):
             lines.append(f"Degraded left     {_safe_int(runtime_state.get('degraded_remaining_s'))}s")
+        if runtime_state.get("recovered_recently"):
+            lines.append(
+                f"Recovered from    {runtime_state.get('last_recovered_issue_type') or 'n/a'}"
+            )
+            lines.append(
+                f"Recovery watch    {_safe_int(runtime_state.get('recovery_remaining_s'))}s"
+            )
     if provider in unhealthy:
         lines.append(f"Live issue        {unhealthy[provider]['detail']}")
     if provider_routing_paths:

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -403,6 +403,9 @@ def _provider_request_readiness(provider: Any) -> dict[str, Any]:
     runtime_window_state = str(runtime_state.get("window_state") or "clear")
     runtime_cooldown_remaining = int(runtime_state.get("cooldown_remaining_s", 0) or 0)
     runtime_degraded_remaining = int(runtime_state.get("degraded_remaining_s", 0) or 0)
+    runtime_recovered_recently = bool(runtime_state.get("recovered_recently"))
+    runtime_recovery_remaining = int(runtime_state.get("recovery_remaining_s", 0) or 0)
+    runtime_last_recovered_issue = str(runtime_state.get("last_recovered_issue_type") or "")
 
     if hasattr(provider, "request_readiness"):
         state = dict(provider.request_readiness() or {})
@@ -423,6 +426,9 @@ def _provider_request_readiness(provider: Any) -> dict[str, Any]:
     state["runtime_degraded_remaining_s"] = runtime_degraded_remaining
     state["runtime_cooldown_until"] = float(runtime_state.get("cooldown_until", 0.0) or 0.0)
     state["runtime_degraded_until"] = float(runtime_state.get("degraded_until", 0.0) or 0.0)
+    state["runtime_recovered_recently"] = runtime_recovered_recently
+    state["runtime_recovery_remaining_s"] = runtime_recovery_remaining
+    state["runtime_last_recovered_issue_type"] = runtime_last_recovered_issue
 
     if runtime_window_state == "cooldown" and runtime_issue_type in {
         "auth-invalid",
@@ -449,6 +455,16 @@ def _provider_request_readiness(provider: Any) -> dict[str, Any]:
         )
         state["operator_hint"] = (
             "prefer lower-pressure siblings while this route recovers"
+        )
+    elif runtime_recovered_recently and bool(state.get("ready")):
+        state["status"] = "ready-recovered"
+        state["reason"] = (
+            "route recovered via a recent successful retry after "
+            f"{runtime_last_recovered_issue.replace('-', ' ') or 'runtime'} issues "
+            f"({runtime_recovery_remaining}s recovery watch left)"
+        )
+        state["operator_hint"] = (
+            "route can carry traffic again; keep it under observation during the recovery window"
         )
     elif runtime_penalty >= 20 and runtime_issue_type in {
         "quota-exhausted",
@@ -600,6 +616,10 @@ def _attempt_metric_fields(
             "actual_canonical_model": str(actual_lane.get("canonical_model") or ""),
             "actual_route_type": str(actual_lane.get("route_type") or ""),
             "actual_lane_cluster": str(actual_lane.get("cluster") or ""),
+            "attempt_runtime_state": _provider_runtime_state_snapshot().get(
+                attempted_provider,
+                {},
+            ),
             **relation,
         }
     )

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -158,6 +158,11 @@ if health_raw:
         runtime_window_state = str(request_readiness.get("runtime_window_state") or "clear")
         runtime_cooldown_remaining = int(request_readiness.get("runtime_cooldown_remaining_s") or 0)
         runtime_degraded_remaining = int(request_readiness.get("runtime_degraded_remaining_s") or 0)
+        runtime_recovered_recently = bool(request_readiness.get("runtime_recovered_recently"))
+        runtime_recovery_remaining = int(request_readiness.get("runtime_recovery_remaining_s") or 0)
+        runtime_last_recovered_issue = str(
+            request_readiness.get("runtime_last_recovered_issue_type") or ""
+        )
         profile_bits = []
         if profile:
             profile_bits.append(profile)
@@ -187,6 +192,11 @@ if health_raw:
             print(
                 f"[ok] request-ready runtime: {provider_name} -> penalty={runtime_penalty}"
                 f" | issue={runtime_issue_type or 'n/a'}{cooldown_suffix}{window_suffix}"
+            )
+        if runtime_recovered_recently:
+            print(
+                f"[ok] request-ready recovery: {provider_name} -> recovered from "
+                f"{runtime_last_recovered_issue or 'n/a'} | watch {runtime_recovery_remaining}s"
             )
     if total:
         print(f"[ok] request readiness summary: {ready}/{total} provider routes look request-ready")

--- a/tests/test_adaptation.py
+++ b/tests/test_adaptation.py
@@ -36,3 +36,17 @@ def test_adaptive_route_state_provider_snapshot_exposes_window_metadata() -> Non
     assert snapshot["last_issue_type"] == "endpoint-mismatch"
     assert snapshot["window_state"] == "cooldown"
     assert snapshot["cooldown_until"] > 0
+
+
+def test_route_pressure_success_clears_window_and_marks_recent_recovery() -> None:
+    route = RoutePressure(provider_name="deepseek-chat")
+
+    route.record_failure("429 rate limit")
+    route.record_success(latency_ms=120.0)
+    snapshot = route.to_dict()
+
+    assert snapshot["last_issue_type"] == ""
+    assert snapshot["window_state"] == "clear"
+    assert snapshot["recovered_recently"] is True
+    assert snapshot["last_recovered_issue_type"] == "rate-limited"
+    assert snapshot["recovery_remaining_s"] > 0

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -525,6 +525,87 @@ def test_faigate_doctor_reports_runtime_cooldown_windows(tmp_path: Path):
     )
 
 
+def test_faigate_doctor_reports_recent_route_recovery(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    env_file = tmp_path / "faigate.env"
+    config_file.write_text("server: {}\nproviders: {}\n", encoding="utf-8")
+    env_file.write_text("", encoding="utf-8")
+
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {
+                        "providers_total": 1,
+                        "providers_healthy": 1,
+                        "providers_unhealthy": 0,
+                    },
+                    "request_readiness": {
+                        "providers_total": 1,
+                        "providers_ready": 1,
+                        "providers_not_ready": 0,
+                    },
+                    "providers": {
+                        "deepseek-chat": {
+                            "healthy": True,
+                            "request_readiness": {
+                                "ready": True,
+                                "status": "ready-recovered",
+                                "reason": (
+                                    "route recovered via a recent successful retry after "
+                                    "rate limited issues (240s recovery watch left)"
+                                ),
+                                "profile": "openai-compatible",
+                                "compatibility": "native",
+                                "probe_confidence": "high",
+                                "probe_payload": "openai-chat-minimal | user='ping' | max_tokens=1",
+                                "operator_hint": (
+                                    "route can carry traffic again; keep it under "
+                                    "observation during the recovery window"
+                                ),
+                                "runtime_penalty": 0,
+                                "runtime_issue_type": "",
+                                "runtime_cooldown_active": False,
+                                "runtime_window_state": "clear",
+                                "runtime_cooldown_remaining_s": 0,
+                                "runtime_degraded_remaining_s": 0,
+                                "runtime_recovered_recently": True,
+                                "runtime_recovery_remaining_s": 240,
+                                "runtime_last_recovered_issue_type": "rate-limited",
+                            },
+                        }
+                    },
+                }
+            ),
+            "/v1/models": json.dumps({"data": []}),
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_ENV_FILE"] = str(env_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-doctor"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "request-ready: deepseek-chat -> ready-recovered" in result.stdout
+    assert (
+        "request-ready recovery: deepseek-chat -> recovered from rate-limited | watch 240s"
+        in result.stdout
+    )
+
+
 def test_faigate_service_lib_detects_homebrew_runtime_paths(tmp_path: Path):
     env = os.environ.copy()
     env["FAIGATE_CONFIG_FILE"] = "/opt/homebrew/etc/faigate/config.yaml"

--- a/tests/test_route_introspection.py
+++ b/tests/test_route_introspection.py
@@ -818,6 +818,22 @@ class TestProviderCoverage:
         assert readiness["runtime_cooldown_active"] is True
 
     @pytest.mark.asyncio
+    async def test_health_request_readiness_marks_recently_recovered_routes(
+        self, preview_config
+    ):
+        main_module._adaptive_state.record_failure("cloud-default", error="429 rate limit")
+        main_module._adaptive_state.record_success("cloud-default", latency_ms=110.0)
+
+        response = await health()
+
+        readiness = response["providers"]["cloud-default"]["request_readiness"]
+        assert readiness["ready"] is True
+        assert readiness["status"] == "ready-recovered"
+        assert readiness["runtime_recovered_recently"] is True
+        assert readiness["runtime_last_recovered_issue_type"] == "rate-limited"
+        assert readiness["runtime_recovery_remaining_s"] > 0
+
+    @pytest.mark.asyncio
     async def test_provider_inventory_filters_by_capability(self, preview_config):
         response = await provider_inventory(capability="image_editing")
 
@@ -883,3 +899,43 @@ async def test_attempt_metric_fields_capture_same_lane_fallback(monkeypatch):
     assert metric_fields["route_type"] == "aggregator"
     assert metric_fields["selection_path"] == "same-lane-route"
     assert metric_fields["decision_details"]["same_model_route"] is True
+
+
+@pytest.mark.asyncio
+async def test_attempt_metric_fields_capture_runtime_recovery_state(monkeypatch):
+    monkeypatch.setattr(
+        main_module,
+        "_providers",
+        {
+            "deepseek-chat": _ProviderStub(
+                name="deepseek-chat",
+                model="deepseek-chat",
+                lane={
+                    "family": "deepseek",
+                    "name": "workhorse",
+                    "canonical_model": "deepseek/chat",
+                    "route_type": "direct",
+                    "cluster": "balanced-workhorse",
+                },
+            ),
+        },
+        raising=False,
+    )
+    main_module._adaptive_state.record_failure("deepseek-chat", error="429 rate limit")
+    main_module._adaptive_state.record_success("deepseek-chat", latency_ms=95.0)
+
+    metric_fields = _attempt_metric_fields(
+        main_module.RoutingDecision(
+            provider_name="deepseek-chat",
+            layer="heuristic",
+            rule_name="general-chat",
+            confidence=0.7,
+            reason="Heuristic matched",
+        ),
+        "deepseek-chat",
+        attempt_order=["deepseek-chat"],
+    )
+
+    runtime_state = metric_fields["decision_details"]["attempt_runtime_state"]
+    assert runtime_state["recovered_recently"] is True
+    assert runtime_state["last_recovered_issue_type"] == "rate-limited"


### PR DESCRIPTION
## Summary
- clear cooldown windows on successful retries and keep a short recovery-watch window with the recovered issue class
- surface recent recovery in request-readiness, doctor output, dashboard provider detail, and attempt decision details
- add focused tests for recovery state, recovered readiness, and attempt runtime recovery metadata

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_adaptation.py tests/test_route_introspection.py tests/test_menu_helpers.py -k "recovery or cooldown or request_readiness or adaptation"
- ./.venv-check-313/bin/ruff check faigate/adaptation.py faigate/main.py faigate/dashboard.py tests/test_adaptation.py tests/test_route_introspection.py tests/test_menu_helpers.py
- bash -n scripts/faigate-doctor