### PR TITLE
feat(router): score recent route recovery cautiously

### DIFF
--- a/faigate/router.py
+++ b/faigate/router.py
@@ -922,6 +922,7 @@ class Router:
         route_score = self._route_posture_score(lane, routing_posture)
         benchmark_score = self._benchmark_posture_score(lane, routing_posture)
         adaptation_penalty = int(runtime_state.get("penalty", 0) or 0)
+        recovery_score = self._recovery_posture_score(lane, runtime_state, routing_posture)
         image_score = 0
         image_policy_score = 0
         image_outputs_fit = True
@@ -977,6 +978,7 @@ class Router:
             + lane_score
             + route_score
             + benchmark_score
+            + recovery_score
             + image_score
             + image_policy_score
             - adaptation_penalty
@@ -996,6 +998,7 @@ class Router:
             "route_score": route_score,
             "benchmark_score": benchmark_score,
             "adaptation_penalty": adaptation_penalty,
+            "recovery_score": recovery_score,
             "image_score": image_score,
             "image_policy_score": image_policy_score,
             "headroom": headroom,
@@ -1018,6 +1021,11 @@ class Router:
             "runtime_issue_type": str(runtime_state.get("last_issue_type") or ""),
             "runtime_issue_detail": str(runtime_state.get("last_issue_detail") or ""),
             "runtime_penalty": adaptation_penalty,
+            "runtime_recovered_recently": bool(runtime_state.get("recovered_recently")),
+            "runtime_recovery_remaining_s": int(runtime_state.get("recovery_remaining_s") or 0),
+            "runtime_last_recovered_issue_type": str(
+                runtime_state.get("last_recovered_issue_type") or ""
+            ),
             "cache_mode": cache.get("mode", "none"),
             "locality_preference": locality_preference or "balanced",
             "routing_posture": routing_posture,
@@ -1104,6 +1112,36 @@ class Router:
             _BENCHMARK_POSTURE_SCORES["balanced"],
         )
         return benchmark_scores.get(str(lane.get("benchmark_cluster") or ""), 0)
+
+    def _recovery_posture_score(
+        self,
+        lane: dict[str, Any],
+        runtime_state: dict[str, Any],
+        routing_posture: str,
+    ) -> int:
+        if not bool(runtime_state.get("recovered_recently")):
+            return 0
+
+        recovery_window = max(1, int(runtime_state.get("recovery_window_s") or 0))
+        recovery_remaining = max(0, int(runtime_state.get("recovery_remaining_s") or 0))
+        freshness = min(1.0, recovery_remaining / recovery_window)
+
+        route_type = str(lane.get("route_type") or "").lower()
+        trust_bonus_by_route = {
+            "local": 5.0,
+            "direct": 4.0,
+            "aggregator": 2.0,
+        }
+        caution_penalty_by_posture = {
+            "quality": 5.0,
+            "balanced": 3.0,
+            "eco": 2.0,
+            "free": 1.0,
+        }
+        trust_bonus = trust_bonus_by_route.get(route_type, 2.0)
+        caution_penalty = caution_penalty_by_posture.get(routing_posture, 3.0)
+        score = (trust_bonus * (1.0 - freshness)) - (caution_penalty * freshness)
+        return int(round(score))
 
     def _fallback_relation_details(
         self,

--- a/tests/test_routing_dimensions.py
+++ b/tests/test_routing_dimensions.py
@@ -451,6 +451,197 @@ metrics:
 
 
 @pytest.mark.asyncio
+async def test_quality_posture_tempers_freshly_recovered_route(tmp_path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  stable-direct:
+    backend: openai-compat
+    base_url: "https://stable.example.com/v1"
+    api_key: "secret"
+    model: "claude-sonnet-4-6"
+    tier: mid
+    lane:
+      family: anthropic
+      name: workhorse
+      canonical_model: anthropic/sonnet-4.6
+      route_type: direct
+      cluster: quality-workhorse
+      benchmark_cluster: quality-coding
+      quality_tier: high
+      reasoning_strength: high
+      same_model_group: anthropic/sonnet-4.6
+  recovered-direct:
+    backend: openai-compat
+    base_url: "https://recovered.example.com/v1"
+    api_key: "secret"
+    model: "claude-sonnet-4-6"
+    tier: mid
+    lane:
+      family: anthropic
+      name: workhorse
+      canonical_model: anthropic/sonnet-4.6
+      route_type: direct
+      cluster: quality-workhorse
+      benchmark_cluster: quality-coding
+      quality_tier: high
+      reasoning_strength: high
+      same_model_group: anthropic/sonnet-4.6
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic:
+      routing_mode: premium
+      prefer_tiers: ["mid"]
+routing_modes:
+  enabled: true
+  default: auto
+  modes:
+    premium:
+      select:
+        prefer_tiers: ["mid"]
+heuristic_rules:
+  enabled: false
+  rules: []
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+    router = Router(cfg)
+
+    decision = await router.route(
+        [{"role": "user", "content": "Review this architecture decision in depth."}],
+        model_requested="auto",
+        client_profile="generic",
+        profile_hints=cfg.client_profiles["profiles"]["generic"],
+        provider_health={
+            "stable-direct": {"healthy": True, "avg_latency_ms": 110, "consecutive_failures": 0},
+            "recovered-direct": {"healthy": True, "avg_latency_ms": 95, "consecutive_failures": 0},
+        },
+        provider_runtime_state={
+            "recovered-direct": {
+                "penalty": 0,
+                "window_state": "clear",
+                "recovered_recently": True,
+                "recovery_window_s": 300,
+                "recovery_remaining_s": 280,
+                "last_recovered_issue_type": "rate-limited",
+            }
+        },
+    )
+
+    assert decision.provider_name == "stable-direct"
+    ranking = decision.details["candidate_ranking"]
+    assert ranking[0]["provider"] == "stable-direct"
+    recovered_row = next(row for row in ranking if row["provider"] == "recovered-direct")
+    assert recovered_row["recovery_score"] < 0
+    assert recovered_row["runtime_recovered_recently"] is True
+
+
+@pytest.mark.asyncio
+async def test_balanced_posture_allows_older_recovered_route_back_to_top(tmp_path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  stable-direct:
+    backend: openai-compat
+    base_url: "https://stable.example.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+    tier: default
+    lane:
+      family: deepseek
+      name: workhorse
+      canonical_model: deepseek/chat
+      route_type: direct
+      cluster: balanced-workhorse
+      benchmark_cluster: balanced-coding
+      quality_tier: mid
+      reasoning_strength: mid
+      same_model_group: deepseek/chat
+  recovered-direct:
+    backend: openai-compat
+    base_url: "https://recovered.example.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+    tier: default
+    lane:
+      family: deepseek
+      name: workhorse
+      canonical_model: deepseek/chat
+      route_type: direct
+      cluster: balanced-workhorse
+      benchmark_cluster: balanced-coding
+      quality_tier: mid
+      reasoning_strength: mid
+      same_model_group: deepseek/chat
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic:
+      routing_mode: auto
+      prefer_tiers: ["default"]
+routing_modes:
+  enabled: true
+  default: auto
+  modes:
+    auto:
+      select:
+        prefer_tiers: ["default"]
+heuristic_rules:
+  enabled: false
+  rules: []
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+    router = Router(cfg)
+
+    decision = await router.route(
+        [{"role": "user", "content": "Keep this coding answer pragmatic and concise."}],
+        model_requested="auto",
+        client_profile="generic",
+        profile_hints=cfg.client_profiles["profiles"]["generic"],
+        provider_health={
+            "stable-direct": {"healthy": True, "avg_latency_ms": 180, "consecutive_failures": 0},
+            "recovered-direct": {"healthy": True, "avg_latency_ms": 90, "consecutive_failures": 0},
+        },
+        provider_runtime_state={
+            "recovered-direct": {
+                "penalty": 0,
+                "window_state": "clear",
+                "recovered_recently": True,
+                "recovery_window_s": 300,
+                "recovery_remaining_s": 40,
+                "last_recovered_issue_type": "timeout",
+            }
+        },
+    )
+
+    assert decision.provider_name == "recovered-direct"
+    ranking = decision.details["candidate_ranking"]
+    recovered_row = next(row for row in ranking if row["provider"] == "recovered-direct")
+    assert recovered_row["recovery_score"] > 0
+    assert recovered_row["runtime_last_recovered_issue_type"] == "timeout"
+
+
+@pytest.mark.asyncio
 async def test_eco_posture_prefers_budget_lane_over_premium_direct_provider(tmp_path):
     cfg = load_config(
         _write_config(


### PR DESCRIPTION
## Summary
- add a recovery-aware routing score so freshly recovered routes re-enter traffic carefully instead of bouncing straight back to the top
- include recovery score and recent recovery metadata in candidate diagnostics
- cover both cautious quality posture and older balanced recovery re-entry in routing tests

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_routing_dimensions.py -k "recovered or same_lane_route or quality_posture"
- ./.venv-check-313/bin/ruff check faigate/router.py tests/test_routing_dimensions.py