### PR TITLE
feat(metrics): aggregate lane family readiness windows

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -227,6 +227,26 @@ def _lane_family_summary(
     )
 
 
+def _lane_family_summary_from_stats(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not rows:
+        return []
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        normalized.append(
+            {
+                "family": str(row.get("lane_family") or "unclassified"),
+                "providers": _safe_int(row.get("providers")),
+                "requests": _safe_int(row.get("requests")),
+                "cost_usd": _safe_float(row.get("cost_usd")),
+                "cooldown": _safe_int(row.get("cooldown_requests")),
+                "degraded": _safe_int(row.get("degraded_requests")),
+                "recovered": _safe_int(row.get("recovered_requests")),
+                "selection_paths": str(row.get("selection_paths") or ""),
+            }
+        )
+    return normalized
+
+
 def _enrich_provider_rows_with_lane(
     rows: list[dict[str, Any]],
     provider_map: dict[str, dict[str, Any]],
@@ -315,12 +335,15 @@ def build_dashboard_report(
     providers = _enrich_provider_rows_with_lane(
         stats.get("providers") or [], inventory_provider_map
     )
-    lane_families = _lane_family_summary(providers, inventory_provider_map)
+    lane_families = _lane_family_summary_from_stats(stats.get("lane_families") or [])
+    if not lane_families:
+        lane_families = _lane_family_summary(providers, inventory_provider_map)
     readiness_breakdown = _request_readiness_breakdown(
         list(inventory_provider_map.values()) if inventory_provider_map else providers
     )
     routing = stats.get("routing") or []
     routing_paths = _routing_path_summary(routing)
+    selection_paths = stats.get("selection_paths") or []
     client_totals = stats.get("client_totals") or []
     client_highlights = stats.get("client_highlights") or _client_highlights(client_totals)
     daily = stats.get("daily") or []
@@ -603,6 +626,7 @@ def build_dashboard_report(
         "clients": client_totals,
         "routing": routing,
         "routing_paths": routing_paths,
+        "selection_paths": selection_paths,
         "daily": daily,
         "hourly": hourly,
         "operator_actions": operator_actions,

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -575,11 +575,16 @@ def _attempt_relation_details(selected_provider: str, attempted_provider: str) -
 
 def _decision_metric_fields(decision: RoutingDecision) -> dict[str, Any]:
     details = dict(decision.details or {})
+    runtime_state = dict(details.get("route_runtime_state") or {})
     return {
         "canonical_model": str(details.get("canonical_model") or ""),
+        "lane_family": str(details.get("lane_family") or ""),
         "route_type": str(details.get("route_type") or ""),
         "lane_cluster": str(details.get("lane_cluster") or ""),
         "selection_path": str(details.get("selection_path") or ""),
+        "runtime_window_state": str(runtime_state.get("window_state") or ""),
+        "recovered_recently": bool(runtime_state.get("recovered_recently")),
+        "last_recovered_issue_type": str(runtime_state.get("last_recovered_issue_type") or ""),
         "decision_details": details,
     }
 
@@ -628,10 +633,20 @@ def _attempt_metric_fields(
         "canonical_model": str(
             actual_lane.get("canonical_model") or details.get("canonical_model") or ""
         ),
+        "lane_family": str(actual_lane.get("family") or details.get("lane_family") or ""),
         "route_type": str(actual_lane.get("route_type") or details.get("route_type") or ""),
         "lane_cluster": str(actual_lane.get("cluster") or details.get("lane_cluster") or ""),
         "selection_path": str(
             relation.get("selection_path") or details.get("selection_path") or ""
+        ),
+        "runtime_window_state": str(
+            (details.get("attempt_runtime_state") or {}).get("window_state") or ""
+        ),
+        "recovered_recently": bool(
+            (details.get("attempt_runtime_state") or {}).get("recovered_recently")
+        ),
+        "last_recovered_issue_type": str(
+            (details.get("attempt_runtime_state") or {}).get("last_recovered_issue_type") or ""
         ),
         "decision_details": details,
     }
@@ -1505,8 +1520,10 @@ async def stats(
     return {
         "totals": _metrics.get_totals(**filters),
         "providers": _metrics.get_provider_summary(**filters),
+        "lane_families": _metrics.get_lane_family_breakdown(**filters),
         "modalities": _metrics.get_modality_breakdown(**filters),
         "routing": _metrics.get_routing_breakdown(**filters),
+        "selection_paths": _metrics.get_selection_path_breakdown(**filters),
         "clients": _metrics.get_client_breakdown(**filters),
         "client_totals": client_totals,
         "client_highlights": _client_highlights(client_totals),

--- a/faigate/metrics.py
+++ b/faigate/metrics.py
@@ -53,9 +53,13 @@ CREATE TABLE IF NOT EXISTS requests (
     decision_reason TEXT DEFAULT '',
     confidence      REAL DEFAULT 0,
     canonical_model TEXT DEFAULT '',
+    lane_family     TEXT DEFAULT '',
     route_type      TEXT DEFAULT '',
     lane_cluster    TEXT DEFAULT '',
     selection_path  TEXT DEFAULT '',
+    runtime_window_state TEXT DEFAULT '',
+    recovered_recently INTEGER DEFAULT 0,
+    last_recovered_issue_type TEXT DEFAULT '',
     decision_details TEXT DEFAULT '{}',
     attempt_order   TEXT DEFAULT '[]'
 );
@@ -89,9 +93,13 @@ _OPTIONAL_COLUMNS: dict[str, str] = {
     "decision_reason": "TEXT DEFAULT ''",
     "confidence": "REAL DEFAULT 0",
     "canonical_model": "TEXT DEFAULT ''",
+    "lane_family": "TEXT DEFAULT ''",
     "route_type": "TEXT DEFAULT ''",
     "lane_cluster": "TEXT DEFAULT ''",
     "selection_path": "TEXT DEFAULT ''",
+    "runtime_window_state": "TEXT DEFAULT ''",
+    "recovered_recently": "INTEGER DEFAULT 0",
+    "last_recovered_issue_type": "TEXT DEFAULT ''",
     "decision_details": "TEXT DEFAULT '{}'",
     "attempt_order": "TEXT DEFAULT '[]'",
 }
@@ -152,9 +160,13 @@ class MetricsStore:
         decision_reason: str = "",
         confidence: float = 0.0,
         canonical_model: str = "",
+        lane_family: str = "",
         route_type: str = "",
         lane_cluster: str = "",
         selection_path: str = "",
+        runtime_window_state: str = "",
+        recovered_recently: bool = False,
+        last_recovered_issue_type: str = "",
         decision_details: dict[str, Any] | None = None,
         attempt_order: list[str] | None = None,
     ) -> None:
@@ -167,9 +179,10 @@ class MetricsStore:
                    prompt_tok,compl_tok,cache_hit,cache_miss,
                    cost_usd,latency_ms,success,error,
                     requested_model,modality,client_profile,client_tag,
-                    decision_reason,confidence,canonical_model,route_type,lane_cluster,
-                    selection_path,decision_details,attempt_order)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    decision_reason,confidence,canonical_model,lane_family,route_type,lane_cluster,
+                    selection_path,runtime_window_state,recovered_recently,last_recovered_issue_type,
+                    decision_details,attempt_order)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     time.time(),
                     provider,
@@ -191,9 +204,13 @@ class MetricsStore:
                     decision_reason,
                     confidence,
                     canonical_model,
+                    lane_family,
                     route_type,
                     lane_cluster,
                     selection_path,
+                    runtime_window_state,
+                    1 if recovered_recently else 0,
+                    last_recovered_issue_type,
                     json.dumps(decision_details or {}, sort_keys=True),
                     json.dumps(attempt_order or []),
                 ),
@@ -259,6 +276,7 @@ class MetricsStore:
                 ROUND(SUM(cost_usd),6)                          AS cost_usd,
                 ROUND(AVG(latency_ms),1)                        AS avg_latency_ms,
                 MAX(canonical_model)                            AS canonical_model,
+                MAX(lane_family)                                AS lane_family,
                 MAX(route_type)                                 AS route_type,
                 MAX(lane_cluster)                               AS lane_cluster
             FROM requests{where_sql} GROUP BY provider ORDER BY requests DESC
@@ -275,14 +293,57 @@ class MetricsStore:
         return self._q(
             f"""
             SELECT layer, rule_name, provider,
-                canonical_model, route_type, lane_cluster, selection_path,
+                canonical_model, lane_family, route_type, lane_cluster, selection_path,
+                runtime_window_state, recovered_recently, last_recovered_issue_type,
                 COUNT(*)                  AS requests,
                 ROUND(SUM(cost_usd),6)    AS cost_usd,
                 ROUND(AVG(latency_ms),1)  AS avg_latency_ms
             FROM requests{where_sql}
             GROUP BY layer, rule_name, provider,
-                canonical_model, route_type, lane_cluster, selection_path
+                canonical_model, lane_family, route_type, lane_cluster, selection_path,
+                runtime_window_state, recovered_recently, last_recovered_issue_type
             ORDER BY requests DESC
+        """,
+            params,
+        )
+
+    def get_lane_family_breakdown(self, **filters: Any) -> list[dict]:
+        where_sql, params = self._build_where_clause(filters)
+        return self._q(
+            f"""
+            SELECT lane_family,
+                COUNT(*) AS requests,
+                COUNT(DISTINCT provider) AS providers,
+                ROUND(SUM(cost_usd),6) AS cost_usd,
+                SUM(
+                    CASE WHEN runtime_window_state='cooldown' THEN 1 ELSE 0 END
+                ) AS cooldown_requests,
+                SUM(
+                    CASE WHEN runtime_window_state='degraded' THEN 1 ELSE 0 END
+                ) AS degraded_requests,
+                SUM(CASE WHEN recovered_recently=1 THEN 1 ELSE 0 END) AS recovered_requests,
+                GROUP_CONCAT(DISTINCT selection_path) AS selection_paths
+            FROM requests{where_sql}
+            GROUP BY lane_family
+            ORDER BY requests DESC, providers DESC, cost_usd DESC
+        """,
+            params,
+        )
+
+    def get_selection_path_breakdown(self, **filters: Any) -> list[dict]:
+        where_sql, params = self._build_where_clause(filters)
+        return self._q(
+            f"""
+            SELECT selection_path,
+                lane_family,
+                runtime_window_state,
+                recovered_recently,
+                COUNT(*) AS requests,
+                ROUND(SUM(cost_usd),6) AS cost_usd,
+                ROUND(AVG(latency_ms),1) AS avg_latency_ms
+            FROM requests{where_sql}
+            GROUP BY selection_path, lane_family, runtime_window_state, recovered_recently
+            ORDER BY requests DESC, cost_usd DESC
         """,
             params,
         )

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -97,11 +97,48 @@ class _MetricsStub:
     def get_provider_summary(self, **_kwargs):
         return []
 
+    def get_lane_family_breakdown(self, **_kwargs):
+        return [
+            {
+                "lane_family": "deepseek",
+                "requests": 12,
+                "providers": 1,
+                "cost_usd": 0.12,
+                "cooldown_requests": 0,
+                "degraded_requests": 0,
+                "recovered_requests": 2,
+                "selection_paths": "primary-selected",
+            },
+            {
+                "lane_family": "openrouter",
+                "requests": 5,
+                "providers": 1,
+                "cost_usd": 0.08,
+                "cooldown_requests": 3,
+                "degraded_requests": 0,
+                "recovered_requests": 0,
+                "selection_paths": "same-lane-route",
+            },
+        ]
+
     def get_modality_breakdown(self, **_kwargs):
         return []
 
     def get_routing_breakdown(self, **_kwargs):
         return []
+
+    def get_selection_path_breakdown(self, **_kwargs):
+        return [
+            {
+                "selection_path": "primary-selected",
+                "lane_family": "deepseek",
+                "runtime_window_state": "clear",
+                "recovered_recently": 1,
+                "requests": 12,
+                "cost_usd": 0.12,
+                "avg_latency_ms": 620.0,
+            }
+        ]
 
     def get_client_breakdown(self, **_kwargs):
         return []
@@ -227,6 +264,10 @@ def test_stats_includes_client_highlights(api_client):
     assert body["client_highlights"]["top_cost"]["client_tag"] == "batch-jobs"
     assert body["client_highlights"]["highest_failure_rate"]["client_tag"] == "batch-jobs"
     assert body["client_highlights"]["slowest_client"]["client_tag"] == "batch-jobs"
+    assert body["lane_families"][0]["lane_family"] == "deepseek"
+    assert body["lane_families"][1]["cooldown_requests"] == 3
+    assert body["selection_paths"][0]["selection_path"] == "primary-selected"
+    assert body["selection_paths"][0]["recovered_recently"] == 1
 
 
 def test_provider_discovery_endpoint_supports_filters(api_client, monkeypatch, tmp_path):

--- a/tests/test_metrics_traces.py
+++ b/tests/test_metrics_traces.py
@@ -27,9 +27,13 @@ def test_metrics_store_persists_trace_fields(tmp_path):
         decision_reason="Client profile 'local-only' selected a preferred provider",
         confidence=0.6,
         canonical_model="local/llama3",
+        lane_family="local",
         route_type="local",
         lane_cluster="local-workhorse",
         selection_path="profile-primary",
+        runtime_window_state="clear",
+        recovered_recently=True,
+        last_recovered_issue_type="timeout",
         decision_details={"canonical_model": "local/llama3", "route_type": "local"},
         attempt_order=["local-worker", "cloud-default"],
     )
@@ -42,9 +46,13 @@ def test_metrics_store_persists_trace_fields(tmp_path):
     assert recent[0]["decision_reason"].startswith("Client profile")
     assert recent[0]["confidence"] == 0.6
     assert recent[0]["canonical_model"] == "local/llama3"
+    assert recent[0]["lane_family"] == "local"
     assert recent[0]["route_type"] == "local"
     assert recent[0]["lane_cluster"] == "local-workhorse"
     assert recent[0]["selection_path"] == "profile-primary"
+    assert recent[0]["runtime_window_state"] == "clear"
+    assert recent[0]["recovered_recently"] == 1
+    assert recent[0]["last_recovered_issue_type"] == "timeout"
     assert recent[0]["decision_details"]["canonical_model"] == "local/llama3"
     assert recent[0]["attempt_order"] == ["local-worker", "cloud-default"]
 
@@ -107,9 +115,13 @@ def test_metrics_store_migrates_existing_db(tmp_path):
     assert "modality" in columns
     assert "attempt_order" in columns
     assert "canonical_model" in columns
+    assert "lane_family" in columns
     assert "route_type" in columns
     assert "lane_cluster" in columns
     assert "selection_path" in columns
+    assert "runtime_window_state" in columns
+    assert "recovered_recently" in columns
+    assert "last_recovered_issue_type" in columns
     assert "decision_details" in columns
     reopened.close()
 
@@ -168,13 +180,58 @@ def test_metrics_store_filters_recent_and_breakdowns(tmp_path):
     assert len(routing_rows) == 1
     assert routing_rows[0]["layer"] == "hook"
 
-    totals = metrics.get_totals(provider="cloud-default")
-    assert totals["total_requests"] == 1
-    assert totals["total_failures"] == 1
 
-    client_totals = metrics.get_client_totals()
-    assert len(client_totals) == 2
-    assert client_totals[0]["requests"] >= client_totals[1]["requests"]
+def test_metrics_store_aggregates_lane_family_and_selection_paths(tmp_path):
+    db_path = tmp_path / "families.db"
+    metrics = MetricsStore(str(db_path))
+    metrics.init()
+
+    metrics.log_request(
+        provider="deepseek-chat",
+        model="deepseek-chat",
+        modality="chat",
+        layer="heuristic",
+        rule_name="default",
+        cost_usd=0.03,
+        latency_ms=120.0,
+        canonical_model="deepseek/chat",
+        lane_family="deepseek",
+        route_type="direct",
+        lane_cluster="balanced-workhorse",
+        selection_path="primary-selected",
+        runtime_window_state="clear",
+        recovered_recently=True,
+        last_recovered_issue_type="rate-limited",
+    )
+    metrics.log_request(
+        provider="openrouter-fallback",
+        model="openrouter/auto",
+        modality="chat",
+        layer="fallback",
+        rule_name="fallback",
+        cost_usd=0.04,
+        latency_ms=200.0,
+        canonical_model="aggregator/openrouter-auto",
+        lane_family="openrouter",
+        route_type="aggregator",
+        lane_cluster="aggregator-fallback",
+        selection_path="same-lane-route",
+        runtime_window_state="cooldown",
+        recovered_recently=False,
+        last_recovered_issue_type="",
+    )
+
+    family_rows = metrics.get_lane_family_breakdown()
+    deepseek_row = next(row for row in family_rows if row["lane_family"] == "deepseek")
+    assert deepseek_row["recovered_requests"] == 1
+    openrouter_row = next(row for row in family_rows if row["lane_family"] == "openrouter")
+    assert openrouter_row["cooldown_requests"] == 1
+
+    selection_rows = metrics.get_selection_path_breakdown()
+    same_lane = next(row for row in selection_rows if row["selection_path"] == "same-lane-route")
+    assert same_lane["lane_family"] == "openrouter"
+    assert same_lane["runtime_window_state"] == "cooldown"
+    assert same_lane["recovered_recently"] == 0
 
     metrics.close()
 


### PR DESCRIPTION
## Summary
- persist lane-family and runtime-window metadata alongside request traces
- expose lane-family and selection-path readiness aggregations via /api/stats
- cover the new metrics and stats surfaces in store and API tests

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_metrics_traces.py tests/test_api_hardening.py -k "lane_family or selection_paths or client_highlights"
- ./.venv-check-313/bin/ruff check faigate/metrics.py faigate/main.py faigate/dashboard.py tests/test_metrics_traces.py tests/test_api_hardening.py