### PR TITLE
feat(dashboard): expose family readiness traces

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -247,6 +247,61 @@ def _lane_family_summary_from_stats(rows: list[dict[str, Any]]) -> list[dict[str
     return normalized
 
 
+def _selection_path_summary_from_stats(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not rows:
+        return []
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        normalized.append(
+            {
+                "selection_path": str(row.get("selection_path") or ""),
+                "lane_family": str(row.get("lane_family") or ""),
+                "runtime_window_state": str(row.get("runtime_window_state") or ""),
+                "recovered_recently": bool(row.get("recovered_recently")),
+                "requests": _safe_int(row.get("requests")),
+                "cost_usd": _safe_float(row.get("cost_usd")),
+                "avg_latency_ms": _safe_float(row.get("avg_latency_ms")),
+            }
+        )
+    return normalized
+
+
+def _render_lane_family_block(report: dict[str, Any], *, limit: int = 3) -> list[str]:
+    rows = report.get("lane_families") or []
+    if not rows:
+        return []
+    lines = ["Lane families"]
+    for row in rows[:limit]:
+        lines.append(
+            f"- {row.get('family')}: {_safe_int(row.get('providers'))} routes | "
+            f"{_safe_int(row.get('requests'))} req | cooldown={_safe_int(row.get('cooldown'))} | "
+            f"recovery={_safe_int(row.get('recovered'))}"
+        )
+    return lines
+
+
+def _render_selection_path_block(report: dict[str, Any], *, limit: int = 4) -> list[str]:
+    rows = report.get("selection_paths") or []
+    if not rows:
+        return []
+    lines = ["Selection paths"]
+    for row in rows[:limit]:
+        bits: list[str] = []
+        if row.get("lane_family"):
+            bits.append(str(row.get("lane_family")))
+        if row.get("runtime_window_state"):
+            bits.append(str(row.get("runtime_window_state")))
+        if row.get("recovered_recently"):
+            bits.append("recovery-watch")
+        suffix = f" [{' | '.join(bits)}]" if bits else ""
+        lines.append(
+            f"- {row.get('selection_path')}: {_safe_int(row.get('requests'))} req / "
+            f"{_format_usd(_safe_float(row.get('cost_usd')))} / "
+            f"{_format_latency_ms(_safe_float(row.get('avg_latency_ms')))}{suffix}"
+        )
+    return lines
+
+
 def _enrich_provider_rows_with_lane(
     rows: list[dict[str, Any]],
     provider_map: dict[str, dict[str, Any]],
@@ -338,12 +393,12 @@ def build_dashboard_report(
     lane_families = _lane_family_summary_from_stats(stats.get("lane_families") or [])
     if not lane_families:
         lane_families = _lane_family_summary(providers, inventory_provider_map)
+    selection_paths = _selection_path_summary_from_stats(stats.get("selection_paths") or [])
     readiness_breakdown = _request_readiness_breakdown(
         list(inventory_provider_map.values()) if inventory_provider_map else providers
     )
     routing = stats.get("routing") or []
     routing_paths = _routing_path_summary(routing)
-    selection_paths = stats.get("selection_paths") or []
     client_totals = stats.get("client_totals") or []
     client_highlights = stats.get("client_highlights") or _client_highlights(client_totals)
     daily = stats.get("daily") or []
@@ -818,6 +873,10 @@ def _render_providers(report: dict[str, Any]) -> str:
         lines.append("Operator hints")
         for hint in report["hints"][:3]:
             lines.append(f"- {hint}")
+    family_block = _render_lane_family_block(report)
+    if family_block:
+        lines.append("")
+        lines.extend(family_block)
     if report["decision_support"]:
         lines.append("")
         lines.append("Budget + routing hints")
@@ -878,6 +937,14 @@ def _render_activity(report: dict[str, Any]) -> str:
         lines.append(
             f"- {row.get('day')}: {_safe_int(row.get('requests'))} req | {_format_usd(_safe_float(row.get('cost_usd')))} | {_format_tokens(_safe_int(row.get('tokens')))} | {_safe_int(row.get('failures'))} fail"
         )
+    family_block = _render_lane_family_block(report)
+    if family_block:
+        lines.append("")
+        lines.extend(family_block)
+    path_block = _render_selection_path_block(report)
+    if path_block:
+        lines.append("")
+        lines.extend(path_block)
     lines.append("")
     lines.append("Operator actions")
     operator_rows = report["operator_actions"][:5]
@@ -906,8 +973,14 @@ def _render_alerts(report: dict[str, Any]) -> str:
             ]
         )
     lines.append("Context")
+    family_block = _render_lane_family_block(report)
+    if family_block:
+        lines.extend(family_block)
     for hint in report["hints"][:5]:
         lines.append(f"- {hint}")
+    path_block = _render_selection_path_block(report)
+    if path_block:
+        lines.extend(path_block)
     for hint in report["decision_support"][:5]:
         lines.append(f"- {hint}")
     return "\n".join(lines).rstrip() + "\n"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -652,6 +652,31 @@ def _attempt_metric_fields(
     }
 
 
+def _trace_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    selection_paths: dict[str, int] = {}
+    lane_families: dict[str, int] = {}
+    runtime_windows: dict[str, int] = {}
+    recovered_recently = 0
+    for row in rows:
+        selection_path = str(row.get("selection_path") or "").strip()
+        if selection_path:
+            selection_paths[selection_path] = selection_paths.get(selection_path, 0) + 1
+        lane_family = str(row.get("lane_family") or "").strip()
+        if lane_family:
+            lane_families[lane_family] = lane_families.get(lane_family, 0) + 1
+        runtime_window = str(row.get("runtime_window_state") or "").strip()
+        if runtime_window:
+            runtime_windows[runtime_window] = runtime_windows.get(runtime_window, 0) + 1
+        if bool(row.get("recovered_recently")):
+            recovered_recently += 1
+    return {
+        "selection_paths": dict(sorted(selection_paths.items())),
+        "lane_families": dict(sorted(lane_families.items())),
+        "runtime_windows": dict(sorted(runtime_windows.items())),
+        "recovered_recently": recovered_recently,
+    }
+
+
 def _decorate_direct_decision(decision: RoutingDecision) -> RoutingDecision:
     provider = _providers.get(decision.provider_name)
     if not provider:
@@ -1568,16 +1593,18 @@ async def traces(
     success: bool | None = None,
 ):
     """Recent enriched route traces for debugging and policy tuning."""
+    trace_rows = _metrics.get_recent(
+        limit,
+        provider=provider,
+        modality=modality,
+        client_profile=client_profile,
+        client_tag=client_tag,
+        layer=layer,
+        success=success,
+    )
     return {
-        "traces": _metrics.get_recent(
-            limit,
-            provider=provider,
-            modality=modality,
-            client_profile=client_profile,
-            client_tag=client_tag,
-            layer=layer,
-            success=success,
-        )
+        "traces": trace_rows,
+        "summary": _trace_summary(trace_rows),
     }
 
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -187,7 +187,24 @@ class _MetricsStub:
         return []
 
     def get_recent(self, *_args, **_kwargs):
-        return []
+        return [
+            {
+                "provider": "cloud-default",
+                "selection_path": "same-lane-route",
+                "lane_family": "deepseek",
+                "runtime_window_state": "cooldown",
+                "recovered_recently": 1,
+                "decision_details": {"same_model_route": True},
+            },
+            {
+                "provider": "cloud-default",
+                "selection_path": "primary-selected",
+                "lane_family": "openrouter",
+                "runtime_window_state": "clear",
+                "recovered_recently": 0,
+                "decision_details": {"same_model_route": False},
+            },
+        ]
 
     def get_operator_events(self, *_args, **_kwargs):
         return []
@@ -268,6 +285,18 @@ def test_stats_includes_client_highlights(api_client):
     assert body["lane_families"][1]["cooldown_requests"] == 3
     assert body["selection_paths"][0]["selection_path"] == "primary-selected"
     assert body["selection_paths"][0]["recovered_recently"] == 1
+
+
+def test_traces_include_operator_summary(api_client):
+    response = api_client.get("/api/traces")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["summary"]["selection_paths"]["primary-selected"] == 1
+    assert body["summary"]["selection_paths"]["same-lane-route"] == 1
+    assert body["summary"]["lane_families"]["deepseek"] == 1
+    assert body["summary"]["runtime_windows"]["cooldown"] == 1
+    assert body["summary"]["recovered_recently"] == 1
 
 
 def test_provider_discovery_endpoint_supports_filters(api_client, monkeypatch, tmp_path):

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1822,6 +1822,116 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
     assert "same-lane-route: 3 requests" in result.stdout
 
 
+def test_faigate_dashboard_activity_and_alerts_show_family_and_path_summaries(tmp_path: Path):
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {
+                        "providers_total": 2,
+                        "providers_healthy": 2,
+                        "providers_unhealthy": 0,
+                    },
+                    "request_readiness": {
+                        "providers_total": 2,
+                        "providers_ready": 2,
+                        "providers_not_ready": 0,
+                    },
+                    "providers": {},
+                }
+            ),
+            "/api/stats": json.dumps(
+                {
+                    "totals": {
+                        "total_requests": 20,
+                        "total_failures": 0,
+                        "total_prompt_tokens": 8000,
+                        "total_compl_tokens": 3000,
+                        "total_cost_usd": 0.6,
+                        "avg_latency_ms": 320.0,
+                    },
+                    "providers": [],
+                    "routing": [],
+                    "selection_paths": [
+                        {
+                            "selection_path": "same-lane-route",
+                            "lane_family": "deepseek",
+                            "runtime_window_state": "cooldown",
+                            "recovered_recently": 1,
+                            "requests": 6,
+                            "cost_usd": 0.18,
+                            "avg_latency_ms": 410.0,
+                        }
+                    ],
+                    "lane_families": [
+                        {
+                            "lane_family": "deepseek",
+                            "requests": 14,
+                            "providers": 2,
+                            "cost_usd": 0.42,
+                            "cooldown_requests": 2,
+                            "degraded_requests": 1,
+                            "recovered_requests": 1,
+                            "selection_paths": "same-lane-route,primary-selected",
+                        }
+                    ],
+                    "client_totals": [],
+                    "client_highlights": {},
+                    "operator_actions": [],
+                    "hourly": [
+                        {"hour_offset": 0, "requests": 20, "cost_usd": 0.6, "tokens": 11000}
+                    ],
+                    "daily": [
+                        {
+                            "day": "2026-03-20",
+                            "requests": 20,
+                            "cost_usd": 0.6,
+                            "tokens": 11000,
+                            "failures": 0,
+                        }
+                    ],
+                }
+            ),
+            "/api/providers": json.dumps({"providers": []}),
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["FAIGATE_DB_PATH"] = str(tmp_path / "faigate.db")
+
+    activity = subprocess.run(
+        ["bash", "scripts/faigate-dashboard", "--activity"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    alerts = subprocess.run(
+        ["bash", "scripts/faigate-dashboard", "--alerts"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Lane families" in activity.stdout
+    assert "- deepseek: 2 routes | 14 req | cooldown=2 | recovery=1" in activity.stdout
+    assert "Selection paths" in activity.stdout
+    assert (
+        "same-lane-route: 6 req / $0.18 / 410ms "
+        "[deepseek | cooldown | recovery-watch]" in activity.stdout
+    )
+    assert "Lane families" in alerts.stdout
+    assert "Selection paths" in alerts.stdout
+
+
 def test_faigate_provider_probe_summarizes_config_env_and_health(tmp_path: Path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text(


### PR DESCRIPTION
## Summary
- add lane-family and selection-path operator blocks to dashboard activity and alerts views
- expose a traces summary with lane families, selection paths, runtime windows, and recovery-watch counts
- cover the new dashboard and traces operator surfaces in API and shell-helper tests

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_api_hardening.py tests/test_menu_helpers.py -k "traces_include_operator_summary or dashboard_activity_and_alerts_show_family_and_path_summaries or dashboard_overview_summarizes_live_stats or dashboard_provider_detail_shows_canonical_lane"
- ./.venv-check-313/bin/ruff check faigate/dashboard.py faigate/main.py tests/test_api_hardening.py tests/test_menu_helpers.py