### PR TITLE
feat(ui): add operator action guidance to readiness tools

### DIFF
--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -1103,6 +1103,13 @@ def build_provider_probe_report(
         }
     rows: list[dict[str, Any]] = []
     ready_count = 0
+    action_counts = {
+        "fix-now": 0,
+        "hold": 0,
+        "watch": 0,
+        "route": 0,
+        "inspect": 0,
+    }
 
     for name, provider in sorted(configured.items()):
         transport_defaults = get_provider_transport_binding(
@@ -1110,6 +1117,7 @@ def build_provider_probe_report(
             backend=str(provider.get("backend", "openai-compat") or "openai-compat"),
             contract=str(provider.get("contract", "generic") or "generic"),
         )
+        lane_binding = get_provider_lane_binding(name)
         api_key = str(provider.get("api_key", "") or "").strip()
         env_name = _extract_env_reference(api_key)
         missing_key = bool(env_name) and not bool(env_values.get(env_name))
@@ -1153,6 +1161,28 @@ def build_provider_probe_report(
             else:
                 status = "configured"
             status_reason = last_error or "configured but not reporting healthy yet"
+        runtime_window_state = str(request_readiness.get("runtime_window_state") or "clear")
+        runtime_cooldown_active = bool(request_readiness.get("runtime_cooldown_active"))
+        runtime_recovered_recently = bool(request_readiness.get("runtime_recovered_recently"))
+        action_group = _classify_probe_action(
+            status=status,
+            missing_key=missing_key,
+            ready=bool(request_readiness.get("ready")),
+            runtime_window_state=runtime_window_state,
+            runtime_cooldown_active=runtime_cooldown_active,
+            runtime_recovered_recently=runtime_recovered_recently,
+        )
+        action_counts[action_group] += 1
+        operator_hint = str(request_readiness.get("operator_hint") or "")
+        next_action = operator_hint or _default_probe_action_hint(
+            action_group=action_group,
+            provider_name=name,
+            family=str(
+                (provider.get("lane") or {}).get("family")
+                or lane_binding.get("family")
+                or ""
+            ),
+        )
         rows.append(
             {
                 "provider": name,
@@ -1165,6 +1195,9 @@ def build_provider_probe_report(
                 "env": env_name,
                 "healthy": healthy,
                 "avg_latency_ms": float(health.get("avg_latency_ms", 0.0) or 0.0),
+                "lane_family": str(
+                    (provider.get("lane") or {}).get("family") or lane_binding.get("family") or ""
+                ),
                 "transport_profile": str(
                     request_readiness.get("profile")
                     or (provider.get("transport") or {}).get("profile")
@@ -1191,7 +1224,9 @@ def build_provider_probe_report(
                 ),
                 "probe_payload": str(request_readiness.get("probe_payload") or ""),
                 "verified_via": str(request_readiness.get("verified_via") or ""),
-                "operator_hint": str(request_readiness.get("operator_hint") or ""),
+                "operator_hint": operator_hint,
+                "action_group": action_group,
+                "next_action": next_action,
             }
         )
 
@@ -1202,6 +1237,7 @@ def build_provider_probe_report(
             "ready": ready_count,
             "health_live": health_payload is not None,
             "live_probe": live_probe,
+            "actions": action_counts,
         },
     }
 
@@ -1218,12 +1254,25 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
     )
     if summary.get("live_probe"):
         lines.append("Live probe: enabled (using transport-specific shallow request probes)")
+    actions = summary.get("actions") or {}
+    action_bits = [
+        f"fix-now={actions.get('fix-now', 0)}",
+        f"hold={actions.get('hold', 0)}",
+        f"watch={actions.get('watch', 0)}",
+        f"route={actions.get('route', 0)}",
+        f"inspect={actions.get('inspect', 0)}",
+    ]
+    lines.append("Action summary: " + " | ".join(action_bits))
     lines.append("")
     for row in report.get("providers", []):
         lines.append(f"- {row['provider']}  ({row['status']})")
         lines.append(
             "  " + f"model: {row['model']} | tier: {row['tier']} | contract: {row['contract']}"
         )
+        if row.get("lane_family") or row.get("action_group"):
+            family = row.get("lane_family") or "unclassified"
+            action = row.get("action_group") or "inspect"
+            lines.append("  " + f"family: {family} | action: {action}")
         if row.get("transport_profile"):
             lines.append(
                 "  "
@@ -1247,8 +1296,8 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
         if row.get("avg_latency_ms"):
             lines.append("  " + f"latency: {row['avg_latency_ms']:.1f} ms")
         lines.append("  " + f"why: {row['reason']}")
-        if row.get("operator_hint"):
-            lines.append("  " + f"next: {row['operator_hint']}")
+        if row.get("next_action"):
+            lines.append("  " + f"next: {row['next_action']}")
     lines.append("")
     lines.append(
         "Tip: Ready means config, env, and the current /health "
@@ -1258,6 +1307,59 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
         "Tip: Missing-key or model-unavailable states should be fixed before client rollout."
     )
     return "\n".join(lines) + "\n"
+
+
+def _classify_probe_action(
+    *,
+    status: str,
+    missing_key: bool,
+    ready: bool,
+    runtime_window_state: str,
+    runtime_cooldown_active: bool,
+    runtime_recovered_recently: bool,
+) -> str:
+    if missing_key or status in {
+        "missing-key",
+        "unresolved-key",
+        "auth-invalid",
+        "endpoint-mismatch",
+        "model-unavailable",
+    }:
+        return "fix-now"
+    if (
+        runtime_cooldown_active
+        or runtime_window_state == "cooldown"
+        or status in {"quota-exhausted", "rate-limited"}
+    ):
+        return "hold"
+    if (
+        runtime_recovered_recently
+        or runtime_window_state == "degraded"
+        or status == "ready-recovered"
+    ):
+        return "watch"
+    if ready or status in {"ready", "ready-verified", "ready-compat"}:
+        return "route"
+    return "inspect"
+
+
+def _default_probe_action_hint(*, action_group: str, provider_name: str, family: str) -> str:
+    family_label = family or "this route"
+    if action_group == "fix-now":
+        return (
+            "fix credentials, model mapping, or endpoint settings "
+            f"before routing {provider_name}"
+        )
+    if action_group == "hold":
+        return f"hold {provider_name} out of primary traffic until the cooldown pressure clears"
+    if action_group == "watch":
+        return (
+            f"keep {provider_name} in light traffic while the {family_label} "
+            "recovery window stays open"
+        )
+    if action_group == "route":
+        return f"route can carry live traffic for the {family_label} lane"
+    return f"inspect runtime hints for {provider_name} before making it a primary lane"
 
 
 def _scenario_provider_selection(*, purpose: str, client: str) -> list[str]:

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -139,6 +139,25 @@ if health_raw:
     providers = (health_payload.get("providers") or {})
     ready = 0
     total = 0
+    action_counts = {
+        "fix-now": 0,
+        "hold": 0,
+        "watch": 0,
+        "route": 0,
+        "inspect": 0,
+    }
+
+    def classify_action(*, status: str, ready: bool, cooldown_active: bool, window_state: str, recovered_recently: bool) -> str:
+        if status in {"missing-key", "unresolved-key", "auth-invalid", "endpoint-mismatch", "model-unavailable"}:
+            return "fix-now"
+        if cooldown_active or window_state == "cooldown" or status in {"quota-exhausted", "rate-limited"}:
+            return "hold"
+        if recovered_recently or window_state == "degraded" or status == "ready-recovered":
+            return "watch"
+        if ready or status in {"ready", "ready-verified", "ready-compat"}:
+            return "route"
+        return "inspect"
+
     for provider_name, payload in sorted(providers.items()):
         total += 1
         request_readiness = payload.get("request_readiness") or {}
@@ -163,6 +182,16 @@ if health_raw:
         runtime_last_recovered_issue = str(
             request_readiness.get("runtime_last_recovered_issue_type") or ""
         )
+        lane = payload.get("lane") or {}
+        family = str(lane.get("family") or "")
+        action_group = classify_action(
+            status=status,
+            ready=bool(request_readiness.get("ready")),
+            cooldown_active=cooldown_active,
+            window_state=runtime_window_state,
+            recovered_recently=runtime_recovered_recently,
+        )
+        action_counts[action_group] += 1
         profile_bits = []
         if profile:
             profile_bits.append(profile)
@@ -178,6 +207,9 @@ if health_raw:
             print(f"[ok] request-ready: {provider_name} -> {status}{profile_suffix} ({reason})")
         else:
             print(f"[warn] request-ready: {provider_name} -> {status}{profile_suffix} ({reason})")
+        if family or action_group:
+            family_label = family or "unclassified"
+            print(f"[ok] request-ready action: {provider_name} -> {action_group} [{family_label}]")
         if probe_payload:
             print(f"[ok] request-ready payload: {provider_name} -> {probe_payload}")
         if operator_hint:
@@ -200,6 +232,12 @@ if health_raw:
             )
     if total:
         print(f"[ok] request readiness summary: {ready}/{total} provider routes look request-ready")
+        print(
+            "[ok] request-ready actions: "
+            f"fix-now={action_counts['fix-now']} | hold={action_counts['hold']} | "
+            f"watch={action_counts['watch']} | route={action_counts['route']} | "
+            f"inspect={action_counts['inspect']}"
+        )
 PY
 then
   status=1

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -442,6 +442,11 @@ providers:
 
     assert "request-ready: deepseek-chat -> ready" in result.stdout
     assert "request readiness summary: 1/1 provider routes look request-ready" in result.stdout
+    assert "request-ready action: deepseek-chat -> route [unclassified]" in result.stdout
+    assert (
+        "request-ready actions: fix-now=0 | hold=0 | watch=0 | route=1 | inspect=0"
+        in result.stdout
+    )
     assert "[openai-compatible | native | confidence=high]" in result.stdout
     assert "request-ready payload: deepseek-chat -> openai-chat-minimal" in result.stdout
     assert "request-ready next step: deepseek-chat -> route can carry live traffic" in result.stdout
@@ -519,9 +524,14 @@ def test_faigate_doctor_reports_runtime_cooldown_windows(tmp_path: Path):
     )
 
     assert "request-ready: deepseek-chat -> rate-limited" in result.stdout
+    assert "request-ready action: deepseek-chat -> hold [unclassified]" in result.stdout
     assert (
         "request-ready runtime: deepseek-chat -> penalty=24 | issue=rate-limited "
         "| cooldown active | cooldown 120s left" in result.stdout
+    )
+    assert (
+        "request-ready actions: fix-now=0 | hold=1 | watch=0 | route=0 | inspect=0"
+        in result.stdout
     )
 
 
@@ -600,8 +610,13 @@ def test_faigate_doctor_reports_recent_route_recovery(tmp_path: Path):
     )
 
     assert "request-ready: deepseek-chat -> ready-recovered" in result.stdout
+    assert "request-ready action: deepseek-chat -> watch [unclassified]" in result.stdout
     assert (
         "request-ready recovery: deepseek-chat -> recovered from rate-limited | watch 240s"
+        in result.stdout
+    )
+    assert (
+        "request-ready actions: fix-now=0 | hold=0 | watch=1 | route=0 | inspect=0"
         in result.stdout
     )
 
@@ -1986,6 +2001,7 @@ providers:
 
     assert "Provider probe" in result.stdout
     assert "Configured: 2 | Ready now: 1" in result.stdout
+    assert "Action summary: fix-now=1 | hold=0 | watch=0 | route=1 | inspect=0" in result.stdout
     assert "- deepseek-chat  (ready)" in result.stdout
     assert "- anthropic-claude  (missing-key)" in result.stdout
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -891,9 +891,13 @@ providers:
     assert by_name["deepseek-chat"]["status"] == "ready"
     assert by_name["anthropic-claude"]["status"] == "missing-key"
     assert by_name["deepseek-chat"]["transport_profile"] == "openai-compatible"
+    assert by_name["deepseek-chat"]["action_group"] == "route"
+    assert by_name["anthropic-claude"]["action_group"] == "fix-now"
     rendered = render_provider_probe_text(report)
     assert "Configured: 2 | Ready now: 1" in rendered
+    assert "Action summary: fix-now=1 | hold=0 | watch=0 | route=1 | inspect=0" in rendered
     assert "- deepseek-chat  (ready)" in rendered
+    assert "family: deepseek | action: route" in rendered
     assert "transport: openai-compatible | native | confidence: high | strategy: models" in rendered
 
 
@@ -940,6 +944,7 @@ providers:
 
     row = report["providers"][0]
     assert row["status"] == "ready-verified"
+    assert row["action_group"] == "route"
     assert row["verified_via"] == "chat"
     assert "kilo-chat-minimal" in row["probe_payload"]
     rendered = render_provider_probe_text(report)
@@ -997,11 +1002,13 @@ providers:
     row = report["providers"][0]
     assert report["summary"]["live_probe"] is True
     assert row["status"] == "ready-verified"
+    assert row["action_group"] == "route"
     assert row["probe_strategy"] == "chat"
     assert row["verified_via"] == "chat"
     rendered = render_provider_probe_text(report)
     assert "Live probe: enabled" in rendered
     assert "verified via: chat" in rendered
+    assert "Action summary: fix-now=0 | hold=0 | watch=0 | route=1 | inspect=0" in rendered
 
 
 def test_list_client_scenarios_exposes_opencode_quality_path(tmp_path: Path):


### PR DESCRIPTION
## Summary
- classify provider probe and doctor readiness output into operator action groups
- surface family/action summaries and default next-step guidance in provider-probe
- add doctor summaries for route/watch/hold/fix-now/inspect and cover the behavior with tests

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_menu_helpers.py -k 'provider_probe or doctor or request_readiness or recovery or cooldown'
- ./.venv-check-313/bin/ruff check faigate/wizard.py tests/test_wizard.py tests/test_menu_helpers.py
- bash -n scripts/faigate-doctor