### PR TITLE
feat(ui): add actionable route-add guidance

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .lane_registry import get_route_add_recommendations
 from .metrics import MetricsStore
 
 
@@ -280,6 +281,19 @@ def _render_lane_family_block(report: dict[str, Any], *, limit: int = 3) -> list
     return lines
 
 
+def _render_route_add_block(report: dict[str, Any], *, limit: int = 3) -> list[str]:
+    rows = report.get("route_additions") or []
+    if not rows:
+        return []
+    lines = ["Route additions"]
+    for row in rows[:limit]:
+        lines.append(
+            f"- {row.get('family')}: add {row.get('add_provider')} "
+            f"({row.get('strategy')}) to strengthen {row.get('canonical_model') or 'the lane'}"
+        )
+    return lines
+
+
 def _render_selection_path_block(report: dict[str, Any], *, limit: int = 4) -> list[str]:
     rows = report.get("selection_paths") or []
     if not rows:
@@ -306,11 +320,20 @@ def _enrich_provider_rows_with_lane(
     rows: list[dict[str, Any]],
     provider_map: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    configured_provider_names = set(provider_map.keys()) or {
+        str(row.get("provider") or "") for row in rows if str(row.get("provider") or "")
+    }
     enriched: list[dict[str, Any]] = []
     for row in rows:
         provider_name = str(row.get("provider") or "")
         provider_inventory = dict(provider_map.get(provider_name) or {})
         lane = dict(provider_inventory.get("lane") or {})
+        add_recommendations = get_route_add_recommendations(
+            configured_provider_names=configured_provider_names,
+            canonical_model=str(lane.get("canonical_model") or ""),
+            degrade_to=[str(item) for item in (lane.get("degrade_to") or []) if str(item)],
+            family=str(lane.get("family") or ""),
+        )
         enriched.append(
             {
                 **row,
@@ -323,9 +346,46 @@ def _enrich_provider_rows_with_lane(
                 "transport": dict(provider_inventory.get("transport") or {}),
                 "request_readiness": dict(provider_inventory.get("request_readiness") or {}),
                 "route_runtime_state": dict(provider_inventory.get("route_runtime_state") or {}),
+                "route_add_recommendations": add_recommendations,
+                "recommended_add_provider": (
+                    str(add_recommendations[0].get("provider_name") or "")
+                    if add_recommendations
+                    else ""
+                ),
+                "recommended_add_strategy": (
+                    str(add_recommendations[0].get("strategy") or "")
+                    if add_recommendations
+                    else ""
+                ),
             }
         )
     return enriched
+
+
+def _route_add_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    totals: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        family = str(row.get("lane_family") or "unclassified")
+        add_provider = str(row.get("recommended_add_provider") or "")
+        if not add_provider:
+            continue
+        bucket = totals.setdefault(
+            family,
+            {
+                "family": family,
+                "providers": 0,
+                "top_provider": str(row.get("provider") or ""),
+                "add_provider": add_provider,
+                "strategy": str(row.get("recommended_add_strategy") or ""),
+                "canonical_model": str(row.get("canonical_model") or ""),
+            },
+        )
+        bucket["providers"] += 1
+    return sorted(
+        totals.values(),
+        key=lambda row: (row["providers"], row["family"]),
+        reverse=True,
+    )
 
 
 def _recommended_scenario_for_client(client_profile: str, *, expensive: bool = False) -> str | None:
@@ -390,6 +450,7 @@ def build_dashboard_report(
     providers = _enrich_provider_rows_with_lane(
         stats.get("providers") or [], inventory_provider_map
     )
+    route_additions = _route_add_summary(providers)
     lane_families = _lane_family_summary_from_stats(stats.get("lane_families") or [])
     if not lane_families:
         lane_families = _lane_family_summary(providers, inventory_provider_map)
@@ -665,6 +726,12 @@ def build_dashboard_report(
             hints.append(
                 f"{family_recoveries} route(s) are currently under recovery watch across the live lane families."
             )
+    if route_additions:
+        top_addition = route_additions[0]
+        decision_support.append(
+            f"Add-provider hint: add {top_addition['add_provider']} "
+            f"as a {top_addition['strategy']} for {top_addition['family']} traffic."
+        )
 
     return {
         "source": {
@@ -678,6 +745,7 @@ def build_dashboard_report(
         "health": health_payload or {},
         "providers": providers,
         "lane_families": lane_families,
+        "route_additions": route_additions,
         "clients": client_totals,
         "routing": routing,
         "routing_paths": routing_paths,
@@ -726,6 +794,7 @@ def build_dashboard_report(
             "lane_families": {
                 "cooldown_routes": sum(_safe_int(item.get("cooldown")) for item in lane_families),
                 "recovered_routes": sum(_safe_int(item.get("recovered")) for item in lane_families),
+                "route_additions": len(route_additions),
             },
             "drivers": {
                 "top_provider": top_provider,
@@ -799,6 +868,7 @@ def _render_overview(report: dict[str, Any]) -> str:
                 f"  Top family         {top_family.get('family')} ({_safe_int(top_family.get('providers'))} routes / {_safe_int(top_family.get('requests'))} req)",
                 f"  Cooldown routes    {_safe_int(report['cards']['lane_families']['cooldown_routes'])}",
                 f"  Recovery watch     {_safe_int(report['cards']['lane_families']['recovered_routes'])}",
+                f"  Add opportunities  {_safe_int(report['cards']['lane_families']['route_additions'])}",
             ]
         )
     if report["alerts"]:
@@ -877,6 +947,10 @@ def _render_providers(report: dict[str, Any]) -> str:
     if family_block:
         lines.append("")
         lines.extend(family_block)
+    route_add_block = _render_route_add_block(report)
+    if route_add_block:
+        lines.append("")
+        lines.extend(route_add_block)
     if report["decision_support"]:
         lines.append("")
         lines.append("Budget + routing hints")
@@ -941,6 +1015,10 @@ def _render_activity(report: dict[str, Any]) -> str:
     if family_block:
         lines.append("")
         lines.extend(family_block)
+    route_add_block = _render_route_add_block(report)
+    if route_add_block:
+        lines.append("")
+        lines.extend(route_add_block)
     path_block = _render_selection_path_block(report)
     if path_block:
         lines.append("")
@@ -976,6 +1054,9 @@ def _render_alerts(report: dict[str, Any]) -> str:
     family_block = _render_lane_family_block(report)
     if family_block:
         lines.extend(family_block)
+    route_add_block = _render_route_add_block(report)
+    if route_add_block:
+        lines.extend(route_add_block)
     for hint in report["hints"][:5]:
         lines.append(f"- {hint}")
     path_block = _render_selection_path_block(report)
@@ -1043,6 +1124,10 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
         lines.append(f"Probe payload     {request_readiness.get('probe_payload')}")
     if request_readiness.get("operator_hint"):
         lines.append(f"Operator hint     {request_readiness.get('operator_hint')}")
+    if row.get("recommended_add_provider"):
+        lines.append(
+            f"Add route         {row.get('recommended_add_provider')} ({row.get('recommended_add_strategy')})"
+        )
     if transport:
         lines.extend(
             [

--- a/faigate/lane_registry.py
+++ b/faigate/lane_registry.py
@@ -618,3 +618,82 @@ def get_canonical_model_routes(canonical_model: str) -> list[dict[str, Any]]:
     """Return known direct and aggregator execution routes for one canonical model."""
     routes = _CANONICAL_MODEL_ROUTE_REGISTRY.get(canonical_model, [])
     return deepcopy(routes)
+
+
+def get_route_add_recommendations(
+    *,
+    configured_provider_names: set[str] | list[str] | tuple[str, ...],
+    canonical_model: str = "",
+    degrade_to: list[str] | tuple[str, ...] | None = None,
+    family: str = "",
+) -> list[dict[str, Any]]:
+    """Return concrete provider additions that would improve route resilience.
+
+    Recommendations are ordered by usefulness:
+    1. same-lane mirrors for the exact canonical model
+    2. next-cluster providers from the configured degrade chain
+    3. remaining family siblings that are known in the catalog
+    """
+
+    configured = {str(name) for name in configured_provider_names if str(name)}
+    seen = set(configured)
+    recommendations: list[dict[str, Any]] = []
+
+    def add_route_candidates(target_model: str, strategy: str) -> None:
+        for route in get_canonical_model_routes(target_model):
+            provider_name = str(route.get("provider_name") or "")
+            if not provider_name or provider_name in seen:
+                continue
+            if strategy == "same-lane-add":
+                reason = f"adds a same-lane mirror for {target_model}"
+            else:
+                reason = f"adds a cluster fallback for {target_model}"
+            recommendations.append(
+                {
+                    "provider_name": provider_name,
+                    "strategy": strategy,
+                    "strategy_label": {
+                        "same-lane-add": "same lane",
+                        "cluster-add": "next cluster lane",
+                        "family-add": "family lane",
+                    }.get(strategy, "route addition"),
+                    "canonical_model": target_model,
+                    "provider_family": str(route.get("provider_family") or ""),
+                    "route_type": str(route.get("route_type") or ""),
+                    "route_group": str(route.get("route_group") or ""),
+                    "reason": reason,
+                }
+            )
+            seen.add(provider_name)
+
+    if canonical_model:
+        add_route_candidates(canonical_model, "same-lane-add")
+
+    for target_model in degrade_to or []:
+        if str(target_model):
+            add_route_candidates(str(target_model), "cluster-add")
+
+    if family:
+        for provider_name, binding in sorted(_PROVIDER_LANE_BINDINGS.items()):
+            if provider_name in seen:
+                continue
+            if str(binding.get("family") or "") != family:
+                continue
+            recommendations.append(
+                {
+                    "provider_name": provider_name,
+                    "strategy": "family-add",
+                    "strategy_label": "family lane",
+                    "canonical_model": str(binding.get("canonical_model") or ""),
+                    "provider_family": family,
+                    "route_type": str(binding.get("route_type") or ""),
+                    "route_group": "family-lane",
+                    "reason": (
+                        f"adds another {family} family lane "
+                        "for recovery and routing flexibility"
+                    ),
+                }
+            )
+            seen.add(provider_name)
+
+    return recommendations

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -17,6 +17,7 @@ from .lane_registry import (
     get_canonical_model_routes,
     get_provider_lane_binding,
     get_provider_transport_binding,
+    get_route_add_recommendations,
 )
 from .provider_catalog import get_provider_catalog
 from .providers import ProviderBackend
@@ -1249,6 +1250,12 @@ def build_provider_probe_report(
         "family-route": 0,
         "none": 0,
     }
+    add_counts = {
+        "same-lane-add": 0,
+        "cluster-add": 0,
+        "family-add": 0,
+        "none": 0,
+    }
     family_summaries = _build_probe_family_summaries(rows)
     for row in rows:
         recommendation = _pick_probe_recommendation(row=row, rows=rows)
@@ -1260,12 +1267,30 @@ def build_provider_probe_report(
         row["family_summary"] = dict(
             family_summaries.get(str(row.get("lane_family") or "unclassified")) or {}
         )
+        add_recommendations = get_route_add_recommendations(
+            configured_provider_names=configured_names,
+            canonical_model=str(row.get("canonical_model") or ""),
+            degrade_to=list(row.get("degrade_to") or []),
+            family=str(row.get("lane_family") or ""),
+        )
+        row["add_recommendations"] = add_recommendations
+        row["recommended_add_provider"] = (
+            str(add_recommendations[0].get("provider_name") or "") if add_recommendations else ""
+        )
+        row["recommended_add_strategy"] = (
+            str(add_recommendations[0].get("strategy") or "") if add_recommendations else "none"
+        )
+        add_counts[row["recommended_add_strategy"]] = (
+            add_counts.get(row["recommended_add_strategy"], 0) + 1
+        )
         row["next_action"] = _combine_probe_next_action(
             current_hint=str(row.get("next_action") or ""),
             action_group=str(row.get("action_group") or "inspect"),
             family=str(row.get("lane_family") or ""),
             preferred_route=str(recommendation["provider"] or ""),
             strategy=str(recommendation["strategy"] or "none"),
+            add_provider=str(row.get("recommended_add_provider") or ""),
+            add_strategy=str(row.get("recommended_add_strategy") or "none"),
         )
 
     return {
@@ -1279,6 +1304,7 @@ def build_provider_probe_report(
             "families": list(family_summaries.values()),
             "mirror_gaps": sum(1 for row in rows if row.get("known_mirror_gaps")),
             "recommendations": recommendation_counts,
+            "add_recommendations": add_counts,
         },
     }
 
@@ -1326,6 +1352,17 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                 f"same-lane={recommendations.get('same-lane-route', 0)}",
                 f"cluster={recommendations.get('cluster-degrade', 0)}",
                 f"family={recommendations.get('family-route', 0)}",
+            ]
+        )
+    )
+    add_recommendations = summary.get("add_recommendations") or {}
+    lines.append(
+        "Add guidance: "
+        + " | ".join(
+            [
+                f"same-lane={add_recommendations.get('same-lane-add', 0)}",
+                f"cluster={add_recommendations.get('cluster-add', 0)}",
+                f"family={add_recommendations.get('family-add', 0)}",
             ]
         )
     )
@@ -1380,6 +1417,22 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                 + "known mirrors not configured: "
                 + ", ".join(row["known_mirror_gaps"][:3])
             )
+        if row.get("recommended_add_provider"):
+            lines.append(
+                "  "
+                + "add now: "
+                + f"{row['recommended_add_provider']} "
+                + f"({row.get('recommended_add_strategy') or 'route-addition'})"
+            )
+        add_recommendations = row.get("add_recommendations") or []
+        if len(add_recommendations) > 1:
+            other_options = [
+                f"{item.get('provider_name')} ({item.get('strategy')})"
+                for item in add_recommendations[1:3]
+                if item.get("provider_name")
+            ]
+            if other_options:
+                lines.append("  " + "other add options: " + ", ".join(other_options))
         if row.get("next_action"):
             lines.append("  " + f"next: {row['next_action']}")
     lines.append("")
@@ -1546,29 +1599,40 @@ def _combine_probe_next_action(
     family: str,
     preferred_route: str,
     strategy: str,
+    add_provider: str,
+    add_strategy: str,
 ) -> str:
-    if not preferred_route:
-        return current_hint
     strategy_label = {
         "same-lane-route": "same lane",
         "cluster-degrade": "next cluster lane",
         "family-route": "family route",
     }.get(strategy, "fallback route")
+    add_strategy_label = {
+        "same-lane-add": "same-lane mirror",
+        "cluster-add": "next cluster lane",
+        "family-add": "family lane",
+    }.get(add_strategy, "route addition")
     traffic_label = family or "this"
-    if action_group == "hold":
+    if preferred_route:
+        if action_group == "hold":
+            return (
+                f"{current_hint}; prefer {preferred_route} as the {strategy_label} "
+                f"for {traffic_label} traffic meanwhile"
+            )
+        if action_group == "watch":
+            return (
+                f"{current_hint}; favor {preferred_route} as the {strategy_label} "
+                f"for steady {traffic_label} traffic"
+            )
+        if action_group in {"fix-now", "inspect"}:
+            return (
+                f"{current_hint}; route {traffic_label} traffic through {preferred_route} "
+                f"as the {strategy_label} until fixed"
+            )
+    if add_provider and action_group in {"hold", "watch", "fix-now", "inspect"}:
         return (
-            f"{current_hint}; prefer {preferred_route} as the {strategy_label} "
-            f"for {traffic_label} traffic meanwhile"
-        )
-    if action_group == "watch":
-        return (
-            f"{current_hint}; favor {preferred_route} as the {strategy_label} "
-            f"for steady {traffic_label} traffic"
-        )
-    if action_group in {"fix-now", "inspect"}:
-        return (
-            f"{current_hint}; route {traffic_label} traffic through {preferred_route} "
-            f"as the {strategy_label} until fixed"
+            f"{current_hint}; add {add_provider} as a {add_strategy_label} "
+            f"for {traffic_label} traffic"
         )
     return current_hint
 

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -85,7 +85,7 @@ import yaml
 from faigate.onboarding import collect_provider_env_requirements
 from faigate.provider_catalog import build_provider_catalog_report
 from faigate.config import ConfigError, load_config
-from faigate.lane_registry import get_canonical_model_routes
+from faigate.lane_registry import get_canonical_model_routes, get_route_add_recommendations
 
 config_path = Path(os.environ.get("FAIGATE_CONFIG_FILE", ""))
 raw_config = {}
@@ -152,6 +152,12 @@ if health_raw:
         "same-lane-route": 0,
         "cluster-degrade": 0,
         "family-route": 0,
+        "none": 0,
+    }
+    add_counts = {
+        "same-lane-add": 0,
+        "cluster-add": 0,
+        "family-add": 0,
         "none": 0,
     }
     rows = []
@@ -228,6 +234,12 @@ if health_raw:
             mirror_gap_routes += 1
         lane_cluster = str(lane.get("cluster") or "")
         degrade_to = [str(item) for item in (lane.get("degrade_to") or []) if str(item)]
+        add_recommendations = get_route_add_recommendations(
+            configured_provider_names=configured_provider_names,
+            canonical_model=canonical_model,
+            degrade_to=degrade_to,
+            family=family,
+        )
         rows.append(
             {
                 "provider": provider_name,
@@ -236,6 +248,7 @@ if health_raw:
                 "lane_cluster": lane_cluster,
                 "degrade_to": degrade_to,
                 "known_mirror_gaps": known_mirror_gaps,
+                "add_recommendations": add_recommendations,
                 "action": action_group,
                 "ready": bool(request_readiness.get("ready")),
                 "status": status,
@@ -336,6 +349,15 @@ if health_raw:
                 f"[ok] request-ready mirror gap: {row['provider']} -> "
                 + ", ".join(row["known_mirror_gaps"][:3])
             )
+        add_recommendations = row["add_recommendations"]
+        if add_recommendations:
+            top_add = add_recommendations[0]
+            add_strategy = str(top_add.get("strategy") or "route-addition")
+            add_counts[add_strategy] = add_counts.get(add_strategy, 0) + 1
+            print(
+                f"[ok] request-ready add route: {row['provider']} -> "
+                f"{top_add.get('provider_name')} ({add_strategy})"
+            )
         preferred_route, strategy = pick_recommendation(row)
         recommendation_counts[strategy] = recommendation_counts.get(strategy, 0) + 1
         if preferred_route:
@@ -356,6 +378,12 @@ if health_raw:
             f"same-lane={recommendation_counts['same-lane-route']} | "
             f"cluster={recommendation_counts['cluster-degrade']} | "
             f"family={recommendation_counts['family-route']}"
+        )
+        print(
+            "[ok] request-ready add guidance: "
+            f"same-lane={add_counts['same-lane-add']} | "
+            f"cluster={add_counts['cluster-add']} | "
+            f"family={add_counts['family-add']}"
         )
         print(
             f"[ok] request-ready mirror gaps: {mirror_gap_routes} routes have known mirrors not configured"

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1828,6 +1828,7 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
     assert "Verified via      models" in result.stdout
     assert "Probe payload     openai-chat-minimal | user='ping' | max_tokens=1" in result.stdout
     assert "Operator hint     route can carry live traffic" in result.stdout
+    assert "Add route         openrouter-fallback (same-lane-add)" in result.stdout
     assert "Transport profile openai-compatible" in result.stdout
     assert "Compatibility     native" in result.stdout
     assert "Chat path         /chat/completions" in result.stdout
@@ -2260,6 +2261,11 @@ providers:
         "request-ready mirror gap: anthropic-claude -> openrouter-anthropic-opus"
         in result.stdout
     )
+    assert (
+        "request-ready add route: anthropic-claude -> openrouter-anthropic-opus (same-lane-add)"
+        in result.stdout
+    )
+    assert "request-ready add guidance: same-lane=1 | cluster=0 | family=0" in result.stdout
     assert (
         "request-ready mirror gaps: 1 routes have known mirrors not configured"
         in result.stdout

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1190,9 +1190,13 @@ providers:
 
     row = report["providers"][0]
     assert "openrouter-anthropic-opus" in row["known_mirror_gaps"]
+    assert row["recommended_add_provider"] == "openrouter-anthropic-opus"
+    assert row["recommended_add_strategy"] == "same-lane-add"
     rendered = render_provider_probe_text(report)
     assert "Mirror gaps: 1 routes with known mirrors not configured" in rendered
+    assert "Add guidance: same-lane=1 | cluster=0 | family=0" in rendered
     assert "known mirrors not configured: openrouter-anthropic-opus" in rendered
+    assert "add now: openrouter-anthropic-opus (same-lane-add)" in rendered
 
 
 def test_list_client_scenarios_exposes_opencode_quality_path(tmp_path: Path):


### PR DESCRIPTION
## Summary
- turn mirror gaps into concrete add-provider recommendations from the lane registry
- surface the same add-route guidance across provider-probe, faigate-doctor, and dashboard views
- add focused coverage for wizard, doctor, and dashboard operator outputs

## Testing
- ./.venv-check-313/bin/ruff check faigate/lane_registry.py faigate/wizard.py faigate/dashboard.py tests/test_wizard.py tests/test_menu_helpers.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_menu_helpers.py -k provider_probe\ or\ doctor\ or\ dashboard_provider_detail\ or\ mirror\ or\ family_route\ or\ same_lane\ or\ cluster\ or\ activity_and_alerts
- bash -n scripts/faigate-doctor
