### PR TITLE
feat(ui): bring route-add guidance into scenarios

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -871,6 +871,12 @@ def _render_overview(report: dict[str, Any]) -> str:
                 f"  Add opportunities  {_safe_int(report['cards']['lane_families']['route_additions'])}",
             ]
         )
+        route_additions = report.get("route_additions") or []
+        if route_additions:
+            top_addition = route_additions[0]
+            lines.append(
+                f"  Next add           {top_addition.get('add_provider')} ({top_addition.get('strategy')})"
+            )
     if report["alerts"]:
         alert = report["alerts"][0]
         lines.extend(

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -1832,6 +1832,51 @@ def _scenario_deemphasized_providers(provider_names: list[str]) -> list[str]:
     ]
 
 
+def _scenario_route_additions(
+    provider_names: list[str],
+    *,
+    configured_names: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    baseline = set(configured_names or set()) | set(provider_names)
+    recommendations: list[dict[str, Any]] = []
+    seen_additions = set(baseline)
+    for provider_name in provider_names:
+        lane = get_provider_lane_binding(provider_name)
+        additions = get_route_add_recommendations(
+            configured_provider_names=seen_additions,
+            canonical_model=str(lane.get("canonical_model") or ""),
+            degrade_to=[str(item) for item in (lane.get("degrade_to") or []) if str(item)],
+            family=str(lane.get("family") or ""),
+        )
+        for item in additions:
+            add_provider = str(item.get("provider_name") or "")
+            if not add_provider or add_provider in seen_additions:
+                continue
+            enriched = dict(item)
+            enriched["source_provider"] = provider_name
+            recommendations.append(enriched)
+            seen_additions.add(add_provider)
+    return recommendations
+
+
+def _scenario_route_addition_lines(additions: list[dict[str, Any]], *, limit: int = 3) -> list[str]:
+    lines: list[str] = []
+    for item in additions[:limit]:
+        provider_name = str(item.get("provider_name") or "")
+        if not provider_name:
+            continue
+        strategy = str(item.get("strategy") or "route-addition")
+        source_provider = str(item.get("source_provider") or "")
+        reason = str(item.get("reason") or "")
+        line = f"{provider_name} ({strategy})"
+        if source_provider:
+            line += f" for {source_provider}"
+        if reason:
+            line += f" - {reason}"
+        lines.append(line)
+    return lines
+
+
 def list_client_scenarios(
     *,
     env_file: str | Path | None = None,
@@ -1844,6 +1889,7 @@ def list_client_scenarios(
         preferred = _scenario_provider_selection_for_spec(spec)
         ready = [name for name in preferred if name in detected]
         configured_hits = [name for name in preferred if name in configured]
+        route_additions = _scenario_route_additions(preferred, configured_names=configured)
         scenarios.append(
             {
                 "id": scenario_id,
@@ -1865,6 +1911,8 @@ def list_client_scenarios(
                 "family_hint": _scenario_family_hint(preferred),
                 "route_mirrors": _scenario_route_mirrors(preferred),
                 "degrade_chains": _scenario_degrade_chains(preferred),
+                "route_additions": route_additions,
+                "route_addition_lines": _scenario_route_addition_lines(route_additions),
             }
         )
     return scenarios
@@ -1897,6 +1945,9 @@ def render_client_scenarios_text(
         if item.get("degrade_chains"):
             for degrade_line in item["degrade_chains"]:
                 lines.append("  " + f"degrade chain: {degrade_line}")
+        if item.get("route_addition_lines"):
+            for add_line in item["route_addition_lines"]:
+                lines.append("  " + f"add for fuller coverage: {add_line}")
         if item["ready_providers"]:
             lines.append("  " + "ready now: " + ", ".join(item["ready_providers"]))
         elif item["recommended_providers"]:
@@ -1955,6 +2006,16 @@ def apply_client_scenario(
     profile = dict(profiles.get(spec["client"], {}))
     profile["routing_mode"] = spec["routing_mode"]
     profiles[spec["client"]] = profile
+    merged_provider_names = set((merged.get("providers") or {}).keys())
+    active_provider_names = [
+        name
+        for name in _scenario_provider_selection_for_spec(spec)
+        if name in merged_provider_names
+    ]
+    route_additions = _scenario_route_additions(
+        active_provider_names,
+        configured_names=merged_provider_names,
+    )
     return {
         "scenario": {
             "id": scenario_id,
@@ -1965,12 +2026,14 @@ def apply_client_scenario(
         },
         "config": merged,
         "summary": build_config_change_summary(config_path=config_path, updated_config=merged),
+        "route_additions": route_additions,
     }
 
 
 def render_client_scenario_summary(payload: dict[str, Any]) -> str:
     scenario = payload.get("scenario") or {}
     summary = payload.get("summary") or {}
+    route_additions = payload.get("route_additions") or []
     scenario_spec = _CLIENT_SCENARIOS.get(str(scenario.get("id", "")), {})
     lines = [
         "Client scenario summary",
@@ -2003,6 +2066,18 @@ def render_client_scenario_summary(payload: dict[str, Any]) -> str:
             )
     if lines[-1] == "Change preview":
         lines.append("- no config changes beyond confirming the current scenario")
+    if route_additions:
+        lines.extend(["", "Operator follow-up"])
+        for item in route_additions[:3]:
+            lines.append(
+                "- add route: "
+                + f"{item.get('provider_name')} ({item.get('strategy')})"
+                + (
+                    f" for {item.get('source_provider')}"
+                    if item.get("source_provider")
+                    else ""
+                )
+            )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1692,6 +1692,8 @@ def test_faigate_dashboard_overview_summarizes_live_stats(tmp_path: Path):
     assert "Top family         deepseek" in result.stdout
     assert "Cooldown routes    1" in result.stdout
     assert "Recovery watch     1" in result.stdout
+    assert "Add opportunities" in result.stdout
+    assert "Next add" in result.stdout
     assert "Top alert" in result.stdout
 
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1216,6 +1216,11 @@ def test_list_client_scenarios_exposes_opencode_quality_path(tmp_path: Path):
         line.startswith("anthropic/opus-4.6 ->")
         for line in by_id["opencode-quality"]["degrade_chains"]
     )
+    assert by_id["opencode-quality"]["route_additions"]
+    assert (
+        by_id["opencode-quality"]["route_additions"][0]["provider_name"]
+        == "openrouter-anthropic-opus"
+    )
 
 
 def test_apply_client_scenario_sets_client_profile_mode_and_adds_providers(tmp_path: Path):
@@ -1262,6 +1267,8 @@ client_profiles:
     assert "Operator guidance" in summary
     assert "best when:" in summary
     assert "Change preview" in summary
+    assert "Operator follow-up" in summary
+    assert "add route:" in summary
 
 
 def test_render_client_scenarios_text_mentions_opencode_free(tmp_path: Path):
@@ -1275,4 +1282,5 @@ def test_render_client_scenarios_text_mentions_opencode_free(tmp_path: Path):
     assert "best when:" in rendered
     assert "tradeoff:" in rendered
     assert "known route mirrors:" in rendered or "degrade chain:" in rendered
+    assert "add for fuller coverage:" in rendered
     assert "ready now" in rendered or "needs keys for" in rendered


### PR DESCRIPTION
## Summary
- bring route-add guidance into client scenario listings and apply summaries
- show follow-up add-route recommendations after scenario application, not just in probe and doctor
- make dashboard overview surface the next add opportunity directly

## Testing
- ./.venv-check-313/bin/ruff check faigate/wizard.py faigate/dashboard.py tests/test_wizard.py tests/test_menu_helpers.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_wizard.py tests/test_menu_helpers.py -k client_scenario\ or\ dashboard_overview\ or\ dashboard_provider_detail\ or\ activity_and_alerts\ or\ provider_probe\ or\ doctor\ or\ mirror
- bash -n scripts/faigate-client-scenarios scripts/faigate-doctor scripts/faigate-dashboard
