### PR TITLE
feat(router): explain benchmark and cost-aware route choices

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -347,6 +347,12 @@ def _enrich_provider_rows_with_lane(
                 "lane_name": str(lane.get("name") or ""),
                 "route_type": str(lane.get("route_type") or ""),
                 "lane_cluster": str(lane.get("cluster") or ""),
+                "benchmark_cluster": str(lane.get("benchmark_cluster") or ""),
+                "cost_tier": str(
+                    ((provider_inventory.get("capabilities") or {}).get("cost_tier"))
+                    or lane.get("quality_tier")
+                    or ""
+                ),
                 "transport": dict(provider_inventory.get("transport") or {}),
                 "request_readiness": dict(provider_inventory.get("request_readiness") or {}),
                 "route_runtime_state": dict(provider_inventory.get("route_runtime_state") or {}),
@@ -388,6 +394,19 @@ def _route_add_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         key=lambda row: (row["providers"], row["family"]),
         reverse=True,
     )
+
+
+def _provider_routing_fit(row: dict[str, Any]) -> str:
+    benchmark_cluster = str(row.get("benchmark_cluster") or "")
+    cost_tier = str(row.get("cost_tier") or "")
+    route_type = str(row.get("route_type") or "")
+    if benchmark_cluster and cost_tier:
+        return f"{benchmark_cluster} with a {cost_tier} cost posture over {route_type or 'default'} routing"
+    if benchmark_cluster:
+        return f"{benchmark_cluster} over {route_type or 'default'} routing"
+    if cost_tier:
+        return f"{cost_tier} cost posture over {route_type or 'default'} routing"
+    return route_type or "n/a"
 
 
 def _recommended_scenario_for_client(client_profile: str, *, expensive: bool = False) -> str | None:
@@ -856,6 +875,11 @@ def _render_overview(report: dict[str, Any]) -> str:
         f"  Top provider        {top_provider.get('provider')} ({top_provider.get('requests')} req, {_format_usd(_safe_float(top_provider.get('cost_usd')))})"
         if top_provider
         else "  Top provider        no traffic yet",
+        (
+            f"  Route fit           {_provider_routing_fit(top_provider)}"
+            if top_provider
+            else "  Route fit           n/a"
+        ),
         f"  Top client          {top_client.get('client_tag') or top_client.get('client_profile')} ({top_client.get('requests')} req, {_format_usd(_safe_float(top_client.get('cost_usd')))})"
         if top_client
         else "  Top client          no traffic yet",
@@ -1122,6 +1146,9 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
         f"Canonical lane    {row.get('canonical_model') or 'n/a'}",
         f"Route type        {row.get('route_type') or 'n/a'}",
         f"Lane cluster      {row.get('lane_cluster') or 'n/a'}",
+        f"Benchmark focus   {row.get('benchmark_cluster') or 'n/a'}",
+        f"Cost tier         {row.get('cost_tier') or 'n/a'}",
+        f"Routing fit       {_provider_routing_fit(row)}",
         f"Request-ready     {request_readiness.get('status') or 'n/a'}",
     ]
     if request_readiness.get("reason"):

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -677,6 +677,11 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
     details = dict(decision.details or {})
     request_insights = dict(details.get("request_insights") or {})
     heuristic_match = dict(details.get("heuristic_match") or {})
+    rankings = list(details.get("candidate_ranking") or details.get("score_ranking") or [])
+    selected_row = next(
+        (row for row in rankings if str(row.get("provider") or "") == decision.provider_name),
+        {},
+    )
     selected = {
         "provider": decision.provider_name,
         "canonical_model": str(details.get("canonical_model") or ""),
@@ -684,6 +689,11 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         "lane_name": str(details.get("lane_name") or ""),
         "route_type": str(details.get("route_type") or ""),
         "lane_cluster": str(details.get("lane_cluster") or ""),
+        "benchmark_cluster": str(
+            details.get("benchmark_cluster") or selected_row.get("benchmark_cluster") or ""
+        ),
+        "cost_tier": str(details.get("cost_tier") or selected_row.get("cost_tier") or ""),
+        "estimated_request_cost_usd": float(selected_row.get("estimated_request_cost_usd") or 0.0),
         "selection_path": str(details.get("selection_path") or "primary-selected"),
     }
 
@@ -712,13 +722,24 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         why_selected.append(
             "Simple-query routing was suppressed because the request looked riskier."
         )
+    if selected.get("benchmark_cluster") and request_insights.get("signal_groups"):
+        why_selected.append(
+            f"Benchmark fit favored {selected['benchmark_cluster']} for "
+            + ", ".join(str(item) for item in request_insights.get("signal_groups") or [])
+            + "."
+        )
+    if selected.get("estimated_request_cost_usd"):
+        why_selected.append(
+            "Estimated request cost is about "
+            + f"${selected['estimated_request_cost_usd']:.6f}"
+            + f" on the {selected.get('cost_tier') or 'current'} cost lane."
+        )
     if selected["canonical_model"]:
         why_selected.append(
             f"Selected canonical lane {selected['canonical_model']} via {selected['route_type'] or 'default'} route."
         )
 
     alternatives: list[dict[str, Any]] = []
-    rankings = list(details.get("candidate_ranking") or details.get("score_ranking") or [])
     selected_score = None
     if rankings:
         for row in rankings:
@@ -736,12 +757,21 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
             reason_bits.append(f"runtime penalty {row.get('runtime_penalty')}")
         if row.get("route_type") and row.get("route_type") != selected["route_type"]:
             reason_bits.append(f"{row.get('route_type')} route")
+        if row.get("benchmark_cluster") and row.get("benchmark_cluster") != selected.get(
+            "benchmark_cluster"
+        ):
+            reason_bits.append(f"weaker benchmark fit ({row.get('benchmark_cluster')})")
+        if row.get("estimated_request_cost_usd"):
+            reason_bits.append(f"est. ${float(row.get('estimated_request_cost_usd') or 0.0):.6f}")
         alternatives.append(
             {
                 "provider": provider_name,
                 "canonical_model": str(row.get("canonical_model") or ""),
                 "route_type": str(row.get("route_type") or ""),
                 "lane_cluster": str(row.get("lane_cluster") or ""),
+                "benchmark_cluster": str(row.get("benchmark_cluster") or ""),
+                "cost_tier": str(row.get("cost_tier") or ""),
+                "estimated_request_cost_usd": float(row.get("estimated_request_cost_usd") or 0.0),
                 "reason": ", ".join(reason_bits)
                 if reason_bits
                 else "ranked below the selected route",

--- a/faigate/router.py
+++ b/faigate/router.py
@@ -197,6 +197,101 @@ _BENCHMARK_POSTURE_SCORES = {
     },
 }
 
+_BENCHMARK_SIGNAL_WEIGHTS = {
+    "architecture": {
+        "reasoning-coding": 4,
+        "quality-coding": 4,
+        "balanced-coding": 2,
+    },
+    "change-risk": {
+        "reasoning-coding": 4,
+        "quality-coding": 3,
+        "balanced-coding": 2,
+    },
+    "concurrency": {
+        "reasoning-coding": 4,
+        "quality-coding": 3,
+        "balanced-coding": 2,
+    },
+    "debugging": {
+        "reasoning-coding": 4,
+        "quality-coding": 3,
+        "balanced-coding": 2,
+        "fast-general": 1,
+    },
+    "quality": {
+        "quality-coding": 4,
+        "reasoning-coding": 3,
+        "balanced-coding": 2,
+    },
+}
+
+_COST_TIER_POSTURE_SCORES = {
+    "quality": {
+        "premium": 3,
+        "standard": 2,
+        "cheap": 1,
+        "marketplace": 1,
+        "budget": 0,
+        "free": -1,
+        "variable": 0,
+    },
+    "balanced": {
+        "premium": 1,
+        "standard": 4,
+        "cheap": 5,
+        "marketplace": 3,
+        "budget": 4,
+        "free": 4,
+        "variable": 2,
+    },
+    "eco": {
+        "premium": -2,
+        "standard": 3,
+        "cheap": 7,
+        "marketplace": 5,
+        "budget": 6,
+        "free": 8,
+        "variable": 3,
+    },
+    "free": {
+        "premium": -4,
+        "standard": 1,
+        "cheap": 5,
+        "marketplace": 6,
+        "budget": 7,
+        "free": 10,
+        "variable": 4,
+    },
+}
+
+_ESTIMATED_COST_POSTURE_BANDS = {
+    "quality": [
+        (0.0008, 3),
+        (0.0025, 2),
+        (0.0080, 0),
+        (0.0200, -1),
+    ],
+    "balanced": [
+        (0.0006, 6),
+        (0.0015, 5),
+        (0.0040, 3),
+        (0.0100, 0),
+    ],
+    "eco": [
+        (0.0004, 10),
+        (0.0010, 8),
+        (0.0030, 5),
+        (0.0080, 1),
+    ],
+    "free": [
+        (0.0002, 12),
+        (0.0007, 9),
+        (0.0020, 5),
+        (0.0060, 0),
+    ],
+}
+
 _FALLBACK_RELATION_WEIGHTS = {
     "quality": {
         "same_model_route": 40,
@@ -304,6 +399,34 @@ def _request_length_bucket(total_tokens: int) -> str:
     return "brief"
 
 
+def _estimated_request_cost_usd(provider: dict[str, Any], ctx: _RoutingContext | None) -> float:
+    """Estimate one rough request cost from provider pricing and current request shape."""
+    if ctx is None:
+        return 0.0
+    pricing = dict(provider.get("pricing") or {})
+    if not pricing:
+        return 0.0
+    prompt_rate = float(pricing.get("input", 0) or 0)
+    output_rate = float(pricing.get("output", 0) or 0)
+    cache_rate = float(pricing.get("cache_read", prompt_rate) or 0)
+    prompt_tokens = max(1, int(ctx.total_tokens or 0))
+    output_tokens = int(ctx.requested_output_tokens or 0)
+    if output_tokens <= 0:
+        output_tokens = min(1024, max(128, prompt_tokens // 2))
+
+    cache_mode = str((provider.get("cache") or {}).get("mode") or "none")
+    if ctx.stable_prefix_tokens >= 64 and cache_mode != "none":
+        cached_tokens = min(prompt_tokens, int(ctx.stable_prefix_tokens))
+        prompt_cost = (
+            (cached_tokens * cache_rate) + ((prompt_tokens - cached_tokens) * prompt_rate)
+        ) / 1_000_000
+    else:
+        prompt_cost = (prompt_tokens * prompt_rate) / 1_000_000
+
+    output_cost = (output_tokens * output_rate) / 1_000_000
+    return round(prompt_cost + output_cost, 6)
+
+
 def _build_request_insights(
     *,
     last_user_message: str,
@@ -356,6 +479,84 @@ def _build_request_insights(
             "high",
         },
     }
+
+
+def _benchmark_request_score(lane: dict[str, Any], ctx: _RoutingContext | None) -> int:
+    """Score one lane against the current request shape, not just the posture."""
+    if ctx is None or not lane:
+        return 0
+
+    benchmark_cluster = str(lane.get("benchmark_cluster") or "")
+    if not benchmark_cluster:
+        return 0
+
+    request_insights = dict(getattr(ctx, "request_insights", {}) or {})
+    signal_groups = [str(item) for item in (request_insights.get("signal_groups") or []) if item]
+    complexity_profile = str(request_insights.get("complexity_profile") or "")
+    length_bucket = str(request_insights.get("length_bucket") or "")
+    tool_context = bool(request_insights.get("tool_context"))
+
+    score = 0
+    for group in signal_groups:
+        score += _BENCHMARK_SIGNAL_WEIGHTS.get(group, {}).get(benchmark_cluster, 0)
+
+    if complexity_profile == "high":
+        if benchmark_cluster in {"reasoning-coding", "quality-coding"}:
+            score += 3
+        elif benchmark_cluster == "balanced-coding":
+            score += 1
+        elif benchmark_cluster in {"budget-chat", "free-coding"}:
+            score -= 1
+    elif complexity_profile == "medium":
+        if benchmark_cluster in {"reasoning-coding", "quality-coding", "balanced-coding"}:
+            score += 2
+        elif benchmark_cluster in {"budget-chat", "free-coding"}:
+            score -= 1
+    elif complexity_profile == "low":
+        if benchmark_cluster in {"budget-chat", "free-coding", "fast-general"}:
+            score += 1
+
+    if tool_context:
+        tool_strength = str(lane.get("tool_strength") or "").lower()
+        if tool_strength == "high":
+            score += 2
+        elif tool_strength == "mid":
+            score += 1
+
+    if length_bucket == "long":
+        context_strength = str(lane.get("context_strength") or "").lower()
+        if context_strength == "high":
+            score += 2
+        elif context_strength == "mid":
+            score += 1
+
+    return score
+
+
+def _cost_posture_score(
+    *,
+    estimated_cost_usd: float,
+    routing_posture: str,
+    cost_tier: str,
+) -> int:
+    """Convert rough cost fit into one posture-aware score."""
+    normalized_tier = str(cost_tier or "").lower()
+    tier_score = _COST_TIER_POSTURE_SCORES.get(
+        routing_posture,
+        _COST_TIER_POSTURE_SCORES["balanced"],
+    ).get(normalized_tier, 0)
+
+    if estimated_cost_usd <= 0:
+        return tier_score
+
+    bands = _ESTIMATED_COST_POSTURE_BANDS.get(
+        routing_posture,
+        _ESTIMATED_COST_POSTURE_BANDS["balanced"],
+    )
+    for threshold, score in bands:
+        if estimated_cost_usd <= threshold:
+            return score + max(0, tier_score // 2)
+    return -4 if routing_posture in {"eco", "free"} else -2
 
 
 def _merge_select_constraints(*selects: dict[str, Any]) -> dict[str, Any]:
@@ -959,6 +1160,10 @@ class Router:
                 "lane_score": 0,
                 "route_score": 0,
                 "benchmark_score": 0,
+                "benchmark_request_score": 0,
+                "cost_score": 0,
+                "estimated_request_cost_usd": 0.0,
+                "cost_tier": "",
                 "adaptation_penalty": 0,
                 "headroom": 0,
                 "sort_key": (0, 0, 0),
@@ -1025,6 +1230,14 @@ class Router:
         lane_score = self._lane_posture_score(lane, routing_posture)
         route_score = self._route_posture_score(lane, routing_posture)
         benchmark_score = self._benchmark_posture_score(lane, routing_posture)
+        benchmark_request_score = _benchmark_request_score(lane, ctx)
+        cost_tier = str(capabilities.get("cost_tier") or lane.get("quality_tier") or "")
+        estimated_request_cost_usd = _estimated_request_cost_usd(provider, ctx)
+        cost_score = _cost_posture_score(
+            estimated_cost_usd=estimated_request_cost_usd,
+            routing_posture=routing_posture,
+            cost_tier=cost_tier,
+        )
         adaptation_penalty = int(runtime_state.get("penalty", 0) or 0)
         recovery_score = self._recovery_posture_score(lane, runtime_state, routing_posture)
         image_score = 0
@@ -1082,6 +1295,8 @@ class Router:
             + lane_score
             + route_score
             + benchmark_score
+            + benchmark_request_score
+            + cost_score
             + recovery_score
             + image_score
             + image_policy_score
@@ -1101,6 +1316,10 @@ class Router:
             "lane_score": lane_score,
             "route_score": route_score,
             "benchmark_score": benchmark_score,
+            "benchmark_request_score": benchmark_request_score,
+            "cost_score": cost_score,
+            "estimated_request_cost_usd": estimated_request_cost_usd,
+            "cost_tier": cost_tier,
             "adaptation_penalty": adaptation_penalty,
             "recovery_score": recovery_score,
             "image_score": image_score,
@@ -1419,6 +1638,10 @@ class Router:
                     "route_type": details["route_type"],
                     "lane_cluster": details["lane_cluster"],
                     "benchmark_cluster": details["benchmark_cluster"],
+                    "benchmark_request_score": details["benchmark_request_score"],
+                    "cost_score": details["cost_score"],
+                    "estimated_request_cost_usd": details["estimated_request_cost_usd"],
+                    "cost_tier": details["cost_tier"],
                     "runtime_penalty": details["runtime_penalty"],
                     "runtime_issue_type": details["runtime_issue_type"],
                     "runtime_recovered_recently": details["runtime_recovered_recently"],

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -1869,6 +1869,29 @@ def _scenario_route_addition_lines(additions: list[dict[str, Any]], *, limit: in
     return lines
 
 
+def _scenario_routing_rationale_lines(
+    provider_names: list[str],
+    *,
+    limit: int = 4,
+) -> list[str]:
+    lines: list[str] = []
+    for provider_name in provider_names[:limit]:
+        lane = get_provider_lane_binding(provider_name)
+        if not lane:
+            continue
+        benchmark_cluster = str(lane.get("benchmark_cluster") or "general")
+        provider_factory = _PROVIDER_FACTORIES.get(provider_name) or {}
+        provider_caps = dict((provider_factory.get("provider") or {}).get("capabilities") or {})
+        cost_tier = str(provider_caps.get("cost_tier") or "variable")
+        route_type = str(lane.get("route_type") or "default")
+        role = _scenario_provider_role(provider_name)
+        line = f"{provider_name}: {benchmark_cluster} / {cost_tier} / {route_type}"
+        if role:
+            line += f" ({role})"
+        lines.append(line)
+    return lines
+
+
 def build_route_add_setup_plan(
     *,
     config_path: str | Path | None = None,
@@ -2140,6 +2163,16 @@ def render_client_scenario_summary(payload: dict[str, Any]) -> str:
     actionable_additions = list(route_add_setup_plan.get("actionable_additions") or [])
     route_additions = payload.get("route_additions") or []
     scenario_spec = _CLIENT_SCENARIOS.get(str(scenario.get("id", "")), {})
+    rationale_provider_names = [
+        str(item)
+        for item in (
+            summary.get("added_providers")
+            or summary.get("fallback_additions")
+            or _scenario_provider_selection_for_spec(scenario_spec)
+        )
+        if str(item)
+    ]
+    routing_rationale = _scenario_routing_rationale_lines(rationale_provider_names)
     lines = [
         "Client scenario summary",
         "",
@@ -2171,6 +2204,10 @@ def render_client_scenario_summary(payload: dict[str, Any]) -> str:
             )
     if lines[-1] == "Change preview":
         lines.append("- no config changes beyond confirming the current scenario")
+    if routing_rationale:
+        lines.extend(["", "Routing rationale"])
+        for line in routing_rationale:
+            lines.append("- " + line)
     if actionable_additions:
         lines.extend(["", "Operator follow-up"])
         for item in actionable_additions[:3]:

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -384,12 +384,24 @@ providers:
     api_key: "secret"
     model: "deepseek-reasoner"
     tier: reasoning
+    capabilities:
+      cost_tier: standard
+    pricing:
+      input: 0.55
+      output: 2.19
+      cache_read: 0.14
   gemini-flash-lite:
     backend: google-genai
     base_url: "https://google.example.com/v1beta"
     api_key: "secret"
     model: "gemini-2.5-flash-lite"
     tier: cheap
+    capabilities:
+      cost_tier: cheap
+    pricing:
+      input: 0.08
+      output: 0.30
+      cache_read: 0.02
 client_profiles:
   enabled: true
   default: generic
@@ -491,8 +503,16 @@ metrics:
     assert body["route_summary"]["complexity_profile"] in {"medium", "high"}
     assert "architecture" in body["route_summary"]["matched_keywords"]
     assert body["route_summary"]["selected"]["canonical_model"] == "deepseek/reasoner"
+    assert body["route_summary"]["selected"]["benchmark_cluster"] == "reasoning-coding"
+    assert body["route_summary"]["selected"]["cost_tier"] == "standard"
+    assert body["route_summary"]["selected"]["estimated_request_cost_usd"] > 0
     assert any("Opencode complexity bias" in item for item in body["route_summary"]["why_selected"])
+    assert any(
+        "Benchmark fit favored reasoning-coding" in item
+        for item in body["route_summary"]["why_selected"]
+    )
     assert body["route_summary"]["alternatives"][0]["provider"] == "gemini-flash-lite"
+    assert body["route_summary"]["alternatives"][0]["estimated_request_cost_usd"] > 0
 
 
 def test_image_edit_rejects_large_upload(api_client):

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1777,7 +1777,9 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
                                 "canonical_model": "deepseek/chat",
                                 "route_type": "direct",
                                 "cluster": "balanced-workhorse",
+                                "benchmark_cluster": "balanced-coding",
                             },
+                            "capabilities": {"cost_tier": "standard"},
                             "transport": {
                                 "profile": "openai-compatible",
                                 "compatibility": "native",
@@ -1823,6 +1825,12 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
     assert "Canonical lane    deepseek/chat" in result.stdout
     assert "Route type        direct" in result.stdout
     assert "Lane cluster      balanced-workhorse" in result.stdout
+    assert "Benchmark focus   balanced-coding" in result.stdout
+    assert "Cost tier         standard" in result.stdout
+    assert (
+        "Routing fit       balanced-coding with a standard cost posture over direct routing"
+        in result.stdout
+    )
     assert "Request-ready     ready-verified" in result.stdout
     assert "Verified via      models" in result.stdout
     assert "Probe payload     openai-chat-minimal | user='ping' | max_tokens=1" in result.stdout

--- a/tests/test_routing_dimensions.py
+++ b/tests/test_routing_dimensions.py
@@ -727,6 +727,111 @@ metrics:
 
 
 @pytest.mark.asyncio
+async def test_eco_posture_prefers_cheaper_same_cluster_route(tmp_path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  standard-workhorse:
+    backend: openai-compat
+    base_url: "https://standard.example.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+    tier: default
+    pricing:
+      input: 1.20
+      output: 4.80
+      cache_read: 0.60
+    lane:
+      family: deepseek
+      name: workhorse
+      canonical_model: deepseek/chat
+      route_type: direct
+      cluster: balanced-workhorse
+      benchmark_cluster: balanced-coding
+      quality_tier: mid
+      reasoning_strength: mid
+      context_strength: mid
+      tool_strength: medium
+      same_model_group: deepseek/chat
+  cheap-workhorse:
+    backend: openai-compat
+    base_url: "https://cheap.example.com/v1"
+    api_key: "secret"
+    model: "deepseek-chat"
+    tier: default
+    pricing:
+      input: 0.08
+      output: 0.32
+      cache_read: 0.02
+    lane:
+      family: deepseek
+      name: workhorse
+      canonical_model: deepseek/chat
+      route_type: direct
+      cluster: balanced-workhorse
+      benchmark_cluster: balanced-coding
+      quality_tier: mid
+      reasoning_strength: mid
+      context_strength: mid
+      tool_strength: medium
+      same_model_group: deepseek/chat
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic:
+      routing_mode: eco
+      prefer_tiers: ["default"]
+routing_modes:
+  enabled: true
+  default: eco
+  modes:
+    eco:
+      select:
+        prefer_tiers: ["default"]
+heuristic_rules:
+  enabled: false
+  rules: []
+fallback_chain: []
+metrics:
+  enabled: false
+""",
+        )
+    )
+    router = Router(cfg)
+
+    decision = await router.route(
+        [{"role": "user", "content": "Summarize this coding diff briefly and pragmatically."}],
+        model_requested="auto",
+        client_profile="generic",
+        profile_hints=cfg.client_profiles["profiles"]["generic"],
+        provider_health={
+            "standard-workhorse": {
+                "healthy": True,
+                "avg_latency_ms": 120,
+                "consecutive_failures": 0,
+            },
+            "cheap-workhorse": {
+                "healthy": True,
+                "avg_latency_ms": 120,
+                "consecutive_failures": 0,
+            },
+        },
+    )
+
+    assert decision.provider_name == "cheap-workhorse"
+    ranking = decision.details["candidate_ranking"]
+    assert ranking[0]["provider"] == "cheap-workhorse"
+    assert ranking[0]["cost_score"] > ranking[1]["cost_score"]
+    assert ranking[0]["estimated_request_cost_usd"] < ranking[1]["estimated_request_cost_usd"]
+
+
+@pytest.mark.asyncio
 async def test_runtime_route_pressure_penalty_demotes_hot_provider(tmp_path):
     cfg = load_config(
         _write_config(

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1272,6 +1272,8 @@ client_profiles:
     assert "Operator guidance" in summary
     assert "best when:" in summary
     assert "Change preview" in summary
+    assert "Routing rationale" in summary
+    assert "quality-coding" in summary or "reasoning-coding" in summary
     assert "Operator follow-up" in summary
     assert "Provider Setup -> Guided Route Additions" in summary
     assert "add route:" in summary


### PR DESCRIPTION
## Summary
- add benchmark- and estimated-cost-aware scoring to provider candidate ranking
- surface route rationale in route previews, dashboard provider details, and client scenario summaries
- extend targeted routing, API, wizard, and dashboard coverage for the new operator-facing explanations

## Testing
- `PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_routing_dimensions.py tests/test_api_hardening.py tests/test_wizard.py tests/test_menu_helpers.py -k "eco_posture_prefers_cheaper_same_cluster_route or route_preview_includes_route_summary_for_opencode_complexity or apply_client_scenario_sets_client_profile_mode_and_adds_providers or faigate_dashboard_provider_detail_shows_canonical_lane"`
- `./.venv-check-313/bin/ruff check faigate/router.py faigate/main.py faigate/dashboard.py faigate/wizard.py tests/test_routing_dimensions.py tests/test_api_hardening.py tests/test_wizard.py tests/test_menu_helpers.py`
- `./.venv-check-313/bin/ruff format --check faigate/router.py faigate/main.py faigate/dashboard.py faigate/wizard.py tests/test_routing_dimensions.py tests/test_api_hardening.py tests/test_wizard.py tests/test_menu_helpers.py`
