### PR TITLE
feat(ui): add curated refresh guidance to operator flows

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .lane_registry import get_route_add_recommendations
 from .metrics import MetricsStore
+from .provider_catalog import build_provider_refresh_guidance
 
 
 def _safe_int(value: Any) -> int:
@@ -420,6 +421,35 @@ def _freshness_summary(rows: list[dict[str, Any]]) -> dict[str, int]:
     return summary
 
 
+def _refresh_guidance_summary(items: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "refresh_now": sum(1 for item in items if str(item.get("action")) == "refresh-now"),
+        "review_soon": sum(1 for item in items if str(item.get("action")) == "review-soon"),
+    }
+
+
+def _render_refresh_guidance_block(report: dict[str, Any], *, limit: int = 3) -> list[str]:
+    rows = list(report.get("refresh_guidance") or [])[:limit]
+    if not rows:
+        return []
+    lines = ["Refresh guidance"]
+    for item in rows:
+        provider = str(item.get("provider") or "unknown")
+        freshness_status = str(item.get("freshness_status") or "unknown")
+        review_age_days = int(item.get("review_age_days") or -1)
+        age_suffix = f", {review_age_days}d" if review_age_days >= 0 else ""
+        line = (
+            f"- {provider}: {item.get('action_label') or item.get('action')}"
+            f" ({freshness_status}{age_suffix})"
+        )
+        if item.get("refresh_url"):
+            line += f" -> {item['refresh_url']}"
+        lines.append(line)
+        if item.get("reason"):
+            lines.append(f"  why: {item['reason']}")
+    return lines
+
+
 def _recommended_scenario_for_client(client_profile: str, *, expensive: bool = False) -> str | None:
     mapping = {
         "opencode": "opencode-eco" if expensive else "opencode-balanced",
@@ -491,6 +521,19 @@ def build_dashboard_report(
         list(inventory_provider_map.values()) if inventory_provider_map else providers
     )
     freshness = _freshness_summary(providers)
+    refresh_guidance = build_provider_refresh_guidance(
+        [str(row.get("provider") or "") for row in providers],
+        freshness_overrides={
+            str(row.get("provider") or ""): {
+                "freshness_status": row.get("freshness_status"),
+                "review_age_days": row.get("review_age_days"),
+                "freshness_hint": row.get("freshness_hint"),
+            }
+            for row in providers
+            if str(row.get("provider") or "")
+        },
+    )
+    refresh_summary = _refresh_guidance_summary(refresh_guidance)
     routing = stats.get("routing") or []
     routing_paths = _routing_path_summary(routing)
     client_totals = stats.get("client_totals") or []
@@ -767,6 +810,13 @@ def build_dashboard_report(
         hints.append(
             f"{freshness['aging']} route assumption(s) are aging and worth rechecking soon."
         )
+    if refresh_guidance:
+        top_refresh = refresh_guidance[0]
+        decision_support.append(
+            f"Refresh guidance: {top_refresh['provider']} is {top_refresh['freshness_status']} "
+            f"and should be {top_refresh['action_label']}"
+            + (f" via {top_refresh['refresh_url']}." if top_refresh.get("refresh_url") else ".")
+        )
     if route_additions:
         top_addition = route_additions[0]
         decision_support.append(
@@ -787,6 +837,7 @@ def build_dashboard_report(
         "providers": providers,
         "lane_families": lane_families,
         "route_additions": route_additions,
+        "refresh_guidance": refresh_guidance,
         "clients": client_totals,
         "routing": routing,
         "routing_paths": routing_paths,
@@ -839,6 +890,8 @@ def build_dashboard_report(
                 "fresh_routes": freshness.get("fresh", 0),
                 "aging_routes": freshness.get("aging", 0),
                 "stale_routes": freshness.get("stale", 0),
+                "refresh_now": refresh_summary.get("refresh_now", 0),
+                "review_soon": refresh_summary.get("review_soon", 0),
             },
             "drivers": {
                 "top_provider": top_provider,
@@ -942,6 +995,9 @@ def _render_overview(report: dict[str, Any]) -> str:
         lines.extend(["", "Operator note", f"  {report['hints'][0]}"])
     if report["decision_support"]:
         lines.extend(["", "Decision support", f"  {report['decision_support'][0]}"])
+    refresh_block = _render_refresh_guidance_block(report, limit=1)
+    if refresh_block:
+        lines.extend([""] + refresh_block)
     return "\n".join(lines) + "\n"
 
 
@@ -1008,6 +1064,10 @@ def _render_providers(report: dict[str, Any]) -> str:
     if route_add_block:
         lines.append("")
         lines.extend(route_add_block)
+    refresh_block = _render_refresh_guidance_block(report)
+    if refresh_block:
+        lines.append("")
+        lines.extend(refresh_block)
     if report["decision_support"]:
         lines.append("")
         lines.append("Budget + routing hints")
@@ -1080,6 +1140,10 @@ def _render_activity(report: dict[str, Any]) -> str:
     if path_block:
         lines.append("")
         lines.extend(path_block)
+    refresh_block = _render_refresh_guidance_block(report)
+    if refresh_block:
+        lines.append("")
+        lines.extend(refresh_block)
     lines.append("")
     lines.append("Operator actions")
     operator_rows = report["operator_actions"][:5]
@@ -1114,6 +1178,9 @@ def _render_alerts(report: dict[str, Any]) -> str:
     route_add_block = _render_route_add_block(report)
     if route_add_block:
         lines.extend(route_add_block)
+    refresh_block = _render_refresh_guidance_block(report)
+    if refresh_block:
+        lines.extend(refresh_block)
     for hint in report["hints"][:5]:
         lines.append(f"- {hint}")
     path_block = _render_selection_path_block(report)
@@ -1181,6 +1248,19 @@ def _render_provider_detail(report: dict[str, Any], provider_name: str) -> str:
         lines.append(f"Review age        {_safe_int(row.get('review_age_days'))}d")
     if row.get("freshness_hint"):
         lines.append(f"Freshness hint    {row.get('freshness_hint')}")
+    refresh_lookup = {
+        str(item.get("provider") or "").lower(): item
+        for item in report.get("refresh_guidance") or []
+    }
+    refresh_item = refresh_lookup.get(target)
+    if refresh_item:
+        lines.append(
+            f"Refresh action    {refresh_item.get('action_label') or refresh_item.get('action')}"
+        )
+        if refresh_item.get("refresh_url"):
+            lines.append(f"Refresh source    {refresh_item.get('refresh_url')}")
+        if refresh_item.get("reason"):
+            lines.append(f"Refresh note      {refresh_item.get('reason')}")
     if request_readiness.get("reason"):
         lines.append(f"Readiness detail  {request_readiness.get('reason')}")
     if request_readiness.get("verified_via"):

--- a/faigate/provider_catalog.py
+++ b/faigate/provider_catalog.py
@@ -229,6 +229,109 @@ def get_provider_catalog() -> dict[str, dict[str, Any]]:
     return payload
 
 
+def get_provider_catalog_entry(provider_name: str) -> dict[str, Any]:
+    """Return one curated provider catalog entry with discovery metadata."""
+    entry = _CATALOG.get(provider_name)
+    if not entry:
+        return {}
+    item = dict(entry)
+    item["discovery"] = _build_discovery_metadata(provider_name, entry)
+    return item
+
+
+def _refresh_state_from_review(last_reviewed: str) -> tuple[str, int]:
+    reviewed = str(last_reviewed or "").strip()
+    if not reviewed:
+        return "unknown", -1
+    reviewed_on = date.fromisoformat(reviewed)
+    age_days = max(0, (date.today() - reviewed_on).days)
+    if age_days <= 7:
+        return "fresh", age_days
+    if age_days <= 21:
+        return "aging", age_days
+    return "stale", age_days
+
+
+def build_provider_refresh_guidance(
+    provider_names: list[str] | tuple[str, ...],
+    *,
+    freshness_overrides: dict[str, dict[str, Any]] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return curated refresh guidance for providers with aging or stale assumptions."""
+    overrides = freshness_overrides or {}
+    guidance: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for provider_name in provider_names:
+        normalized_name = str(provider_name or "").strip()
+        if not normalized_name or normalized_name in seen:
+            continue
+        seen.add(normalized_name)
+
+        catalog_entry = get_provider_catalog_entry(normalized_name)
+        if not catalog_entry:
+            continue
+
+        override = dict(overrides.get(normalized_name) or {})
+        freshness_status = str(override.get("freshness_status") or "").strip().lower()
+        review_age_days_raw = override.get("review_age_days")
+        review_age_days = int(review_age_days_raw) if review_age_days_raw not in (None, "") else -1
+        freshness_hint = str(override.get("freshness_hint") or "").strip()
+
+        if not freshness_status:
+            freshness_status, review_age_days = _refresh_state_from_review(
+                str(catalog_entry.get("last_reviewed") or "")
+            )
+        if freshness_status not in {"aging", "stale"}:
+            continue
+
+        discovery = dict(catalog_entry.get("discovery") or {})
+        refresh_url = str(
+            discovery.get("resolved_url")
+            or catalog_entry.get("official_source_url")
+            or catalog_entry.get("signup_url")
+            or ""
+        ).strip()
+        action = "refresh-now" if freshness_status == "stale" else "review-soon"
+        action_label = "refresh now" if action == "refresh-now" else "review soon"
+        reason = freshness_hint or (
+            "benchmark and cost assumptions are stale; review before trusting them heavily"
+            if freshness_status == "stale"
+            else "benchmark and cost assumptions are aging and worth rechecking soon"
+        )
+        if catalog_entry.get("volatility") in {"medium", "high"} and catalog_entry.get(
+            "offer_track"
+        ) in {"free", "credit", "byok", "marketplace"}:
+            reason += " This route also sits on a more volatile offer track."
+
+        guidance.append(
+            {
+                "provider": normalized_name,
+                "action": action,
+                "action_label": action_label,
+                "freshness_status": freshness_status,
+                "review_age_days": review_age_days,
+                "reason": reason,
+                "refresh_url": refresh_url,
+                "offer_track": str(catalog_entry.get("offer_track") or ""),
+                "provider_type": str(catalog_entry.get("provider_type") or ""),
+                "notes": str(catalog_entry.get("notes") or ""),
+            }
+        )
+
+    guidance.sort(
+        key=lambda item: (
+            0 if item["action"] == "refresh-now" else 1,
+            -int(item.get("review_age_days") or -1),
+            str(item.get("provider") or ""),
+        )
+    )
+    if limit is not None:
+        return guidance[:limit]
+    return guidance
+
+
 def _alert(
     *,
     provider: str,

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -19,7 +19,7 @@ from .lane_registry import (
     get_provider_transport_binding,
     get_route_add_recommendations,
 )
-from .provider_catalog import get_provider_catalog
+from .provider_catalog import build_provider_refresh_guidance, get_provider_catalog
 from .providers import ProviderBackend
 
 ProviderFactory = dict[str, Any]
@@ -1296,6 +1296,16 @@ def build_provider_probe_report(
             add_strategy=str(row.get("recommended_add_strategy") or "none"),
         )
 
+    refresh_guidance = _refresh_guidance_from_rows(rows)
+    refresh_counts = {
+        "refresh-now": sum(
+            1 for item in refresh_guidance if str(item.get("action") or "") == "refresh-now"
+        ),
+        "review-soon": sum(
+            1 for item in refresh_guidance if str(item.get("action") or "") == "review-soon"
+        ),
+    }
+
     return {
         "providers": rows,
         "summary": {
@@ -1313,7 +1323,9 @@ def build_provider_probe_report(
             "mirror_gaps": sum(1 for row in rows if row.get("known_mirror_gaps")),
             "recommendations": recommendation_counts,
             "add_recommendations": add_counts,
+            "refresh_actions": refresh_counts,
         },
+        "refresh_guidance": refresh_guidance,
     }
 
 
@@ -1375,6 +1387,16 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                 f"same-lane={add_recommendations.get('same-lane-add', 0)}",
                 f"cluster={add_recommendations.get('cluster-add', 0)}",
                 f"family={add_recommendations.get('family-add', 0)}",
+            ]
+        )
+    )
+    refresh_actions = summary.get("refresh_actions") or {}
+    lines.append(
+        "Refresh actions: "
+        + " | ".join(
+            [
+                f"refresh-now={refresh_actions.get('refresh-now', 0)}",
+                f"review-soon={refresh_actions.get('review-soon', 0)}",
             ]
         )
     )
@@ -1447,6 +1469,21 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                 lines.append("  " + "other add options: " + ", ".join(other_options))
         if row.get("next_action"):
             lines.append("  " + f"next: {row['next_action']}")
+    refresh_guidance = list(report.get("refresh_guidance") or [])
+    if refresh_guidance:
+        lines.extend(["", "Refresh guidance"])
+        for item in refresh_guidance[:3]:
+            review_age_days = int(item.get("review_age_days") or -1)
+            age_suffix = f", {review_age_days}d" if review_age_days >= 0 else ""
+            line = (
+                f"- {item.get('provider')}: {item.get('action_label') or item.get('action')} "
+                f"({item.get('freshness_status')}{age_suffix})"
+            )
+            if item.get("refresh_url"):
+                line += f" -> {item['refresh_url']}"
+            lines.append(line)
+            if item.get("reason"):
+                lines.append("  " + f"why: {item['reason']}")
     lines.append("")
     lines.append(
         "Tip: Ready means config, env, and the current /health "
@@ -1891,6 +1928,45 @@ def _scenario_route_addition_lines(additions: list[dict[str, Any]], *, limit: in
     return lines
 
 
+def _refresh_guidance_from_rows(
+    rows: list[dict[str, Any]],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    return build_provider_refresh_guidance(
+        [str(row.get("provider") or "") for row in rows],
+        freshness_overrides={
+            str(row.get("provider") or ""): {
+                "freshness_status": row.get("freshness_status"),
+                "review_age_days": row.get("review_age_days"),
+                "freshness_hint": row.get("freshness_hint"),
+            }
+            for row in rows
+            if str(row.get("provider") or "")
+        },
+        limit=limit,
+    )
+
+
+def _scenario_refresh_guidance_lines(
+    provider_names: list[str],
+    *,
+    limit: int = 2,
+) -> list[str]:
+    guidance = build_provider_refresh_guidance(provider_names, limit=limit)
+    lines: list[str] = []
+    for item in guidance:
+        line = f"{item.get('provider')}: {item.get('action_label')} ({item.get('freshness_status')}"
+        review_age_days = int(item.get("review_age_days") or -1)
+        if review_age_days >= 0:
+            line += f", {review_age_days}d"
+        line += ")"
+        if item.get("refresh_url"):
+            line += f" via {item['refresh_url']}"
+        lines.append(line)
+    return lines
+
+
 def _scenario_routing_rationale_lines(
     provider_names: list[str],
     *,
@@ -1933,6 +2009,7 @@ def build_route_add_setup_plan(
         candidates,
         configured_names=configured_names,
     )
+    refresh_guidance = build_provider_refresh_guidance(candidates, limit=3)
     actionable: list[dict[str, Any]] = []
     auto_apply: list[dict[str, Any]] = []
     manual: list[dict[str, Any]] = []
@@ -1966,6 +2043,7 @@ def build_route_add_setup_plan(
         "actionable_additions": actionable,
         "auto_apply_additions": auto_apply,
         "manual_additions": manual,
+        "refresh_guidance": refresh_guidance,
     }
 
 
@@ -2019,6 +2097,19 @@ def render_route_add_setup_plan_text(plan: dict[str, Any]) -> str:
         lines.append(
             f"Tip: {len(manual)} route addition(s) still need input before they can be written."
         )
+    refresh_guidance = list(plan.get("refresh_guidance") or [])
+    if refresh_guidance:
+        lines.extend(["", "Refresh guidance"])
+        for item in refresh_guidance[:3]:
+            review_age_days = int(item.get("review_age_days") or -1)
+            age_suffix = f", {review_age_days}d" if review_age_days >= 0 else ""
+            line = (
+                f"- {item.get('provider')}: {item.get('action_label') or item.get('action')} "
+                f"({item.get('freshness_status')}{age_suffix})"
+            )
+            if item.get("refresh_url"):
+                line += f" -> {item['refresh_url']}"
+            lines.append(line)
     lines.append("")
     lines.append("Tip: Use Guided Route Additions in Provider Setup")
     lines.append("     to add these sources without re-selecting them manually.")
@@ -2061,6 +2152,7 @@ def list_client_scenarios(
                 "degrade_chains": _scenario_degrade_chains(preferred),
                 "route_additions": route_additions,
                 "route_addition_lines": _scenario_route_addition_lines(route_additions),
+                "refresh_guidance_lines": _scenario_refresh_guidance_lines(preferred),
             }
         )
     return scenarios
@@ -2096,6 +2188,9 @@ def render_client_scenarios_text(
         if item.get("route_addition_lines"):
             for add_line in item["route_addition_lines"]:
                 lines.append("  " + f"add for fuller coverage: {add_line}")
+        if item.get("refresh_guidance_lines"):
+            for refresh_line in item["refresh_guidance_lines"]:
+                lines.append("  " + f"refresh before leaning on: {refresh_line}")
         if item["ready_providers"]:
             lines.append("  " + "ready now: " + ", ".join(item["ready_providers"]))
         elif item["recommended_providers"]:
@@ -2235,6 +2330,11 @@ def render_client_scenario_summary(payload: dict[str, Any]) -> str:
     if routing_rationale:
         lines.extend(["", "Routing rationale"])
         for line in routing_rationale:
+            lines.append("- " + line)
+    refresh_guidance_lines = _scenario_refresh_guidance_lines(rationale_provider_names)
+    if refresh_guidance_lines:
+        lines.extend(["", "Refresh guidance"])
+        for line in refresh_guidance_lines:
             lines.append("- " + line)
     if actionable_additions:
         lines.extend(["", "Operator follow-up"])

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -83,7 +83,7 @@ from pathlib import Path
 
 import yaml
 from faigate.onboarding import collect_provider_env_requirements
-from faigate.provider_catalog import build_provider_catalog_report
+from faigate.provider_catalog import build_provider_catalog_report, build_provider_refresh_guidance
 from faigate.config import ConfigError, load_config
 from faigate.lane_registry import (
     get_canonical_model_routes,
@@ -385,6 +385,18 @@ if health_raw:
                 f"[ok] request-ready preferred route: {row['provider']} -> {preferred_route} "
                 f"({strategy})"
             )
+    refresh_guidance = build_provider_refresh_guidance(
+        [str(row.get("provider") or "") for row in rows],
+        freshness_overrides={
+            str(row.get("provider") or ""): {
+                "freshness_status": row.get("freshness_status"),
+                "review_age_days": row.get("review_age_days"),
+                "freshness_hint": row.get("freshness_hint"),
+            }
+            for row in rows
+            if str(row.get("provider") or "")
+        },
+    )
     if total:
         print(f"[ok] request readiness summary: {ready}/{total} provider routes look request-ready")
         print(
@@ -408,6 +420,24 @@ if health_raw:
         print(
             f"[ok] request-ready mirror gaps: {mirror_gap_routes} routes have known mirrors not configured"
         )
+        if refresh_guidance:
+            print(
+                "[ok] request-ready refresh actions: "
+                + f"refresh-now={sum(1 for item in refresh_guidance if str(item.get('action')) == 'refresh-now')} | "
+                + f"review-soon={sum(1 for item in refresh_guidance if str(item.get('action')) == 'review-soon')}"
+            )
+            for item in refresh_guidance[:3]:
+                detail = (
+                    f"[ok] request-ready refresh: {item.get('provider')} -> "
+                    f"{item.get('action_label')} ({item.get('freshness_status')}"
+                )
+                review_age_days = int(item.get("review_age_days") or -1)
+                if review_age_days >= 0:
+                    detail += f", {review_age_days}d"
+                detail += ")"
+                if item.get("refresh_url"):
+                    detail += f" -> {item['refresh_url']}"
+                print(detail)
 PY
 then
   status=1

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -627,6 +627,74 @@ def test_faigate_doctor_reports_recent_route_recovery(tmp_path: Path):
     )
 
 
+def test_faigate_doctor_reports_refresh_guidance_for_stale_routes(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    env_file = tmp_path / "faigate.env"
+    config_file.write_text("server: {}\nproviders: {}\n", encoding="utf-8")
+    env_file.write_text("", encoding="utf-8")
+
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {
+                        "providers_total": 1,
+                        "providers_healthy": 1,
+                        "providers_unhealthy": 0,
+                    },
+                    "request_readiness": {
+                        "providers_total": 1,
+                        "providers_ready": 1,
+                        "providers_not_ready": 0,
+                    },
+                    "providers": {
+                        "deepseek-chat": {
+                            "healthy": True,
+                            "lane": {
+                                "family": "deepseek",
+                                "canonical_model": "deepseek/chat",
+                                "cluster": "balanced-workhorse",
+                                "freshness_status": "stale",
+                                "review_age_days": 29,
+                                "freshness_hint": (
+                                    "review this route before trusting benchmark assumptions"
+                                ),
+                            },
+                            "request_readiness": {
+                                "ready": True,
+                                "status": "ready",
+                                "reason": _READY_REASON,
+                            },
+                        }
+                    },
+                }
+            ),
+            "/v1/models": json.dumps({"data": []}),
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_ENV_FILE"] = str(env_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-doctor"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "request-ready refresh actions: refresh-now=1 | review-soon=0" in result.stdout
+    assert "request-ready refresh: deepseek-chat -> refresh now (stale, 29d)" in result.stdout
+
+
 def test_faigate_service_lib_detects_homebrew_runtime_paths(tmp_path: Path):
     env = os.environ.copy()
     env["FAIGATE_CONFIG_FILE"] = "/opt/homebrew/etc/faigate/config.yaml"
@@ -1862,6 +1930,112 @@ def test_faigate_dashboard_provider_detail_shows_canonical_lane(tmp_path: Path):
     assert "Last issue type   rate-limited" in result.stdout
     assert "Observed attempt paths" in result.stdout
     assert "same-lane-route: 3 requests" in result.stdout
+
+
+def test_faigate_dashboard_provider_detail_shows_refresh_guidance_for_stale_lane(tmp_path: Path):
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {
+                        "providers_total": 1,
+                        "providers_healthy": 1,
+                        "providers_unhealthy": 0,
+                    },
+                    "providers": {
+                        "deepseek-chat": {
+                            "healthy": True,
+                            "tier": "default",
+                            "request_readiness": {
+                                "ready": True,
+                                "status": "ready",
+                                "reason": "route looks request-ready from runtime state",
+                            },
+                        }
+                    },
+                }
+            ),
+            "/api/stats": json.dumps(
+                {
+                    "totals": {
+                        "total_requests": 4,
+                        "total_failures": 0,
+                        "total_prompt_tokens": 1000,
+                        "total_compl_tokens": 500,
+                        "total_cost_usd": 0.08,
+                        "avg_latency_ms": 220.0,
+                    },
+                    "providers": [
+                        {
+                            "provider": "deepseek-chat",
+                            "requests": 4,
+                            "failures": 0,
+                            "total_tokens": 1500,
+                            "prompt_tokens": 1000,
+                            "completion_tokens": 500,
+                            "cost_usd": 0.08,
+                            "avg_latency_ms": 220.0,
+                        }
+                    ],
+                    "routing": [],
+                    "client_totals": [],
+                    "client_highlights": {},
+                    "operator_actions": [],
+                    "hourly": [],
+                    "daily": [],
+                }
+            ),
+            "/api/providers": json.dumps(
+                {
+                    "providers": [
+                        {
+                            "name": "deepseek-chat",
+                            "lane": {
+                                "family": "deepseek",
+                                "name": "workhorse",
+                                "canonical_model": "deepseek/chat",
+                                "route_type": "direct",
+                                "cluster": "balanced-workhorse",
+                                "benchmark_cluster": "balanced-coding",
+                                "freshness_status": "stale",
+                                "review_age_days": 24,
+                                "freshness_hint": (
+                                    "benchmark and cost assumptions are stale; "
+                                    "review before trusting them heavily"
+                                ),
+                            },
+                            "capabilities": {"cost_tier": "standard"},
+                            "request_readiness": {
+                                "ready": True,
+                                "status": "ready",
+                                "reason": "route looks request-ready from runtime state",
+                            },
+                        }
+                    ]
+                }
+            ),
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["FAIGATE_DB_PATH"] = str(tmp_path / "faigate.db")
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-dashboard", "--provider", "deepseek-chat"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Refresh action    refresh now" in result.stdout
+    assert "Refresh source    https://platform.deepseek.com/" in result.stdout
 
 
 def test_faigate_dashboard_activity_and_alerts_show_family_and_path_summaries(tmp_path: Path):

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -6,6 +6,7 @@ from faigate.config import load_config
 from faigate.provider_catalog import (
     build_provider_catalog_report,
     build_provider_discovery_view,
+    build_provider_refresh_guidance,
 )
 
 
@@ -275,3 +276,26 @@ metrics:
     assert [item["provider"] for item in operator_view["providers"]] == ["openrouter-fallback"]
     assert [item["provider"] for item in disclosed_view["providers"]] == ["openrouter-fallback"]
     assert [item["provider"] for item in free_view["providers"]] == ["kilocode"]
+
+
+def test_build_provider_refresh_guidance_prefers_stale_entries():
+    guidance = build_provider_refresh_guidance(
+        ["deepseek-chat", "openrouter-fallback"],
+        freshness_overrides={
+            "deepseek-chat": {
+                "freshness_status": "stale",
+                "review_age_days": 29,
+                "freshness_hint": "review this route before trusting benchmark assumptions",
+            },
+            "openrouter-fallback": {
+                "freshness_status": "aging",
+                "review_age_days": 12,
+                "freshness_hint": "marketplace assumptions should be reviewed soon",
+            },
+        },
+    )
+
+    assert [item["provider"] for item in guidance] == ["deepseek-chat", "openrouter-fallback"]
+    assert guidance[0]["action"] == "refresh-now"
+    assert guidance[0]["refresh_url"].startswith("https://")
+    assert guidance[1]["action"] == "review-soon"

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1013,6 +1013,56 @@ providers:
     assert "Action summary: fix-now=0 | hold=0 | watch=0 | route=1 | inspect=0" in rendered
 
 
+def test_render_provider_probe_text_shows_refresh_guidance():
+    rendered = render_provider_probe_text(
+        {
+            "summary": {
+                "configured": 1,
+                "ready": 1,
+                "health_live": True,
+                "live_probe": False,
+                "actions": {
+                    "fix-now": 0,
+                    "hold": 0,
+                    "watch": 0,
+                    "route": 1,
+                    "inspect": 0,
+                },
+                "freshness": {"fresh": 0, "aging": 0, "stale": 1},
+                "families": [],
+                "mirror_gaps": 0,
+                "recommendations": {
+                    "same-lane-route": 0,
+                    "cluster-degrade": 0,
+                    "family-route": 0,
+                },
+                "add_recommendations": {
+                    "same-lane-add": 0,
+                    "cluster-add": 0,
+                    "family-add": 0,
+                },
+                "refresh_actions": {"refresh-now": 1, "review-soon": 0},
+            },
+            "providers": [],
+            "refresh_guidance": [
+                {
+                    "provider": "deepseek-chat",
+                    "action": "refresh-now",
+                    "action_label": "refresh now",
+                    "freshness_status": "stale",
+                    "review_age_days": 28,
+                    "reason": "review this route before trusting benchmark assumptions",
+                    "refresh_url": "https://platform.deepseek.com/",
+                }
+            ],
+        }
+    )
+
+    assert "Refresh actions: refresh-now=1 | review-soon=0" in rendered
+    assert "Refresh guidance" in rendered
+    assert "deepseek-chat: refresh now (stale, 28d)" in rendered
+
+
 def test_build_provider_probe_report_prefers_same_lane_then_cluster_route(tmp_path: Path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -1279,6 +1329,64 @@ client_profiles:
     assert "add route:" in summary
 
 
+def test_render_client_scenario_summary_includes_refresh_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-chat:
+    backend: openai-compat
+    api_key: "${DEEPSEEK_API_KEY}"
+    base_url: "https://api.deepseek.com/v1"
+    model: "deepseek-chat"
+fallback_chain:
+  - deepseek-chat
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+    opencode:
+      routing_mode: auto
+""".strip(),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "DEEPSEEK_API_KEY=sk-demo\nOPENAI_API_KEY=sk-openai\nANTHROPIC_API_KEY=sk-ant\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "faigate.wizard.build_provider_refresh_guidance",
+        lambda *_args, **_kwargs: [
+            {
+                "provider": "anthropic-claude",
+                "action": "review-soon",
+                "action_label": "review soon",
+                "freshness_status": "aging",
+                "review_age_days": 14,
+                "refresh_url": "https://console.anthropic.com/",
+            }
+        ],
+    )
+
+    payload = apply_client_scenario(
+        scenario_id="opencode-quality",
+        config_path=config_path,
+        env_file=env_file,
+    )
+
+    summary = render_client_scenario_summary(payload)
+    assert "Refresh guidance" in summary
+    assert "anthropic-claude: review soon (aging, 14d)" in summary
+
+
 def test_render_client_scenarios_text_mentions_opencode_free(tmp_path: Path):
     env_file = tmp_path / ".env"
     env_file.write_text("KILOCODE_API_KEY=kilo-demo\nBLACKBOX_API_KEY=bb-demo\n", encoding="utf-8")
@@ -1390,3 +1498,46 @@ providers:
     assert "Ready to add now" in rendered
     assert "Need input first" in rendered
     assert "deepseek-chat" in rendered
+
+
+def test_render_route_add_setup_plan_text_includes_refresh_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+providers:
+  anthropic-claude:
+    backend: anthropic-compat
+    api_key: "${ANTHROPIC_API_KEY}"
+    base_url: "https://api.anthropic.com/v1"
+    model: "claude-opus-4-6"
+""".strip(),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("ANTHROPIC_API_KEY=sk-ant\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "faigate.wizard.build_provider_refresh_guidance",
+        lambda *_args, **_kwargs: [
+            {
+                "provider": "anthropic-claude",
+                "action": "refresh-now",
+                "action_label": "refresh now",
+                "freshness_status": "stale",
+                "review_age_days": 25,
+                "refresh_url": "https://console.anthropic.com/",
+            }
+        ],
+    )
+
+    plan = build_route_add_setup_plan(
+        config_path=config_path,
+        env_file=env_file,
+        source_providers=["anthropic-claude"],
+    )
+
+    rendered = render_route_add_setup_plan_text(plan)
+    assert "Refresh guidance" in rendered
+    assert "anthropic-claude: refresh now (stale, 25d)" in rendered


### PR DESCRIPTION
## Summary
- add curated provider refresh guidance based on lane freshness and catalog discovery links
- surface refresh actions across dashboard, doctor, provider probe, and scenario/route setup flows
- extend coverage for refresh guidance in provider catalog, wizard flows, and dashboard detail views

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_provider_catalog.py tests/test_wizard.py tests/test_menu_helpers.py -k "refresh_guidance or provider_probe or client_scenario or route_add_setup_plan or dashboard_provider_detail or doctor_reports_refresh_guidance"
- ./.venv-check-313/bin/ruff check faigate/provider_catalog.py faigate/dashboard.py faigate/wizard.py tests/test_provider_catalog.py tests/test_wizard.py tests/test_menu_helpers.py
- ./.venv-check-313/bin/ruff format --check faigate/provider_catalog.py faigate/dashboard.py faigate/wizard.py tests/test_provider_catalog.py tests/test_wizard.py tests/test_menu_helpers.py
- bash -n scripts/faigate-doctor scripts/faigate-provider-probe scripts/faigate-dashboard