### PR TITLE
feat(ui): add route handoff guidance to preview and quick setup

### DIFF
--- a/faigate/main.py
+++ b/faigate/main.py
@@ -27,9 +27,13 @@ from . import __version__
 from .adaptation import AdaptiveRouteState
 from .config import Config, load_config
 from .hooks import AppliedHooks, HookExecutionError, RequestHookContext, apply_request_hooks
-from .lane_registry import get_provider_lane_binding
+from .lane_registry import get_provider_lane_binding, get_route_add_recommendations
 from .metrics import MetricsStore, calc_cost
-from .provider_catalog import build_provider_catalog_report, build_provider_discovery_view
+from .provider_catalog import (
+    build_provider_catalog_report,
+    build_provider_discovery_view,
+    build_provider_refresh_guidance,
+)
 from .providers import ProviderBackend, ProviderError
 from .router import Router, RoutingDecision
 from .updates import (
@@ -798,6 +802,84 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         if len(alternatives) >= 3:
             break
 
+    next_actions: list[dict[str, Any]] = []
+    configured_provider_names = set(getattr(_config, "providers", {}).keys()) if _config else set()
+    selected_refresh = build_provider_refresh_guidance(
+        [decision.provider_name],
+        freshness_overrides={
+            decision.provider_name: {
+                "freshness_status": selected.get("freshness_status"),
+                "review_age_days": selected.get("review_age_days"),
+            }
+        },
+        limit=1,
+    )
+    if selected_refresh:
+        refresh = selected_refresh[0]
+        next_actions.append(
+            {
+                "kind": "refresh-guidance",
+                "title": f"Review {decision.provider_name} before leaning on it heavily",
+                "detail": refresh.get("reason") or "",
+                "path": "Provider Probe or Dashboard -> Provider detail",
+                "target": decision.provider_name,
+                "refresh_url": refresh.get("refresh_url") or "",
+            }
+        )
+
+    add_recommendations = get_route_add_recommendations(
+        configured_provider_names=configured_provider_names,
+        canonical_model=selected["canonical_model"],
+        degrade_to=list(details.get("degrade_to") or []),
+        family=selected["lane_family"],
+    )
+    if add_recommendations:
+        top_add = add_recommendations[0]
+        next_actions.append(
+            {
+                "kind": "route-add",
+                "title": (
+                    f"Add {top_add.get('setup_provider_name') or top_add.get('provider_name')} "
+                    "for fuller lane coverage"
+                ),
+                "detail": str(top_add.get("reason") or ""),
+                "path": "Provider Setup -> Guided Route Additions",
+                "target": str(top_add.get("provider_name") or ""),
+                "strategy": str(top_add.get("strategy") or ""),
+            }
+        )
+
+    selected_cost = float(selected.get("estimated_request_cost_usd") or 0.0)
+    cheaper_alternative = next(
+        (
+            item
+            for item in alternatives
+            if float(item.get("estimated_request_cost_usd") or 0.0) > 0
+            and (
+                float(item.get("estimated_request_cost_usd") or 0.0)
+                <= max(0.0, selected_cost * 0.6)
+            )
+        ),
+        None,
+    )
+    if cheaper_alternative and str(details.get("routing_posture") or "") in {
+        "balanced",
+        "eco",
+        "auto",
+    }:
+        next_actions.append(
+            {
+                "kind": "cost-review",
+                "title": f"Review {cheaper_alternative['provider']} for cheaper default traffic",
+                "detail": (
+                    "A meaningfully cheaper alternative is already available if this request class "
+                    "starts dominating your normal traffic."
+                ),
+                "path": "Client Scenarios or Client Wizard",
+                "target": cheaper_alternative["provider"],
+            }
+        )
+
     return {
         "layer": decision.layer,
         "routing_posture": str(details.get("routing_posture") or ""),
@@ -809,6 +891,7 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         "selected": selected,
         "why_selected": why_selected,
         "alternatives": alternatives,
+        "next_actions": next_actions,
     }
 
 

--- a/scripts/faigate-menu
+++ b/scripts/faigate-menu
@@ -117,6 +117,31 @@ EOF
   fi
 }
 
+dynamic_operator_followups() {
+  local snapshot_output line route_gaps refresh_now review_soon top_refresh_provider top_add_provider
+  snapshot_output="$(collect_runtime_snapshot)"
+  while IFS= read -r line; do
+    case "$line" in
+      route_gaps=*) route_gaps="${line#route_gaps=}" ;;
+      refresh_now=*) refresh_now="${line#refresh_now=}" ;;
+      review_soon=*) review_soon="${line#review_soon=}" ;;
+      top_refresh_provider=*) top_refresh_provider="${line#top_refresh_provider=}" ;;
+      top_add_provider=*) top_add_provider="${line#top_add_provider=}" ;;
+    esac
+  done <<EOF
+$snapshot_output
+EOF
+
+  if [ "${route_gaps:-0}" -gt 0 ]; then
+    printf '%s\n' "Open Provider Setup -> Guided Route Additions next to close ${route_gaps} recommended lane gap(s)${top_add_provider:+, starting with ${top_add_provider}}."
+  fi
+  if [ "${refresh_now:-0}" -gt 0 ]; then
+    printf '%s\n' "Review stale route assumptions before heavier traffic leans on them${top_refresh_provider:+, starting with ${top_refresh_provider}}."
+  elif [ "${review_soon:-0}" -gt 0 ]; then
+    printf '%s\n' "Review aging route assumptions soon${top_refresh_provider:+, starting with ${top_refresh_provider}}."
+  fi
+}
+
 run_provider_setup_with_handoff() {
   local command_rc=0
   echo ""
@@ -142,6 +167,8 @@ import os
 import re
 
 import yaml
+from faigate.provider_catalog import build_provider_refresh_guidance
+from faigate.wizard import build_route_add_setup_plan
 
 config_path = Path(os.environ["FAIGATE_MENU_CONFIG"])
 env_path = Path(os.environ["FAIGATE_MENU_ENV"])
@@ -202,6 +229,33 @@ if len(presets) == 1:
 elif len(presets) > 1:
     preset_summary = f"{len(presets)} active"
 
+provider_names = [
+    name for name, payload in providers.items() if isinstance(payload, dict) and str(name).strip()
+]
+route_plan = build_route_add_setup_plan(
+    config_path=config_path,
+    env_file=env_path,
+    source_providers=provider_names,
+)
+refresh_guidance = build_provider_refresh_guidance(
+    provider_names,
+    freshness_overrides={
+        str(name): {
+            "freshness_status": str((payload.get("lane") or {}).get("freshness_status") or ""),
+            "review_age_days": (payload.get("lane") or {}).get("review_age_days"),
+            "freshness_hint": str((payload.get("lane") or {}).get("freshness_hint") or ""),
+        }
+        for name, payload in providers.items()
+        if isinstance(payload, dict)
+    },
+)
+top_refresh = refresh_guidance[0] if refresh_guidance else {}
+top_add = (
+    (route_plan.get("actionable_additions") or [{}])[0]
+    if route_plan.get("actionable_additions")
+    else {}
+)
+
 print(f"providers={len(providers)}")
 print(f"providers_ready={providers_ready}")
 print(f"providers_missing_keys={providers_missing_keys}")
@@ -212,13 +266,28 @@ print(f"profiles={len(profiles)}")
 print(f"presets={len(presets)}")
 print(f"preset_summary={preset_summary}")
 print(f"next_client={next_client or 'none'}")
+print(f"route_gaps={len(route_plan.get('actionable_additions') or [])}")
+print(f"route_gaps_ready={len(route_plan.get('auto_apply_additions') or [])}")
+print(f"route_gaps_manual={len(route_plan.get('manual_additions') or [])}")
+print(
+    "refresh_now="
+    + str(sum(1 for item in refresh_guidance if str(item.get("action") or "") == "refresh-now"))
+)
+print(
+    "review_soon="
+    + str(sum(1 for item in refresh_guidance if str(item.get("action") or "") == "review-soon"))
+)
+print(f"top_refresh_provider={top_refresh.get('provider', '')}")
+print(f"top_refresh_action={top_refresh.get('action_label', '')}")
+print(f"top_add_provider={top_add.get('setup_provider_name') or top_add.get('provider_name') or ''}")
 PY
 }
 
 collect_runtime_snapshot() {
   local state health_state bind snapshot_output line providers_count providers_ready providers_missing_keys
   local fallback_count default_mode default_profile profile_count preset_count
-  local preset_summary next_client
+  local preset_summary next_client route_gaps route_gaps_ready route_gaps_manual
+  local refresh_now review_soon top_refresh_provider top_refresh_action top_add_provider
   state="$(faigate_service_state)"
   if faigate_is_healthy; then
     health_state="healthy"
@@ -247,6 +316,14 @@ collect_runtime_snapshot() {
       presets=*) preset_count="${line#presets=}" ;;
       preset_summary=*) preset_summary="${line#preset_summary=}" ;;
       next_client=*) next_client="${line#next_client=}" ;;
+      route_gaps=*) route_gaps="${line#route_gaps=}" ;;
+      route_gaps_ready=*) route_gaps_ready="${line#route_gaps_ready=}" ;;
+      route_gaps_manual=*) route_gaps_manual="${line#route_gaps_manual=}" ;;
+      refresh_now=*) refresh_now="${line#refresh_now=}" ;;
+      review_soon=*) review_soon="${line#review_soon=}" ;;
+      top_refresh_provider=*) top_refresh_provider="${line#top_refresh_provider=}" ;;
+      top_refresh_action=*) top_refresh_action="${line#top_refresh_action=}" ;;
+      top_add_provider=*) top_add_provider="${line#top_add_provider=}" ;;
     esac
   done <<EOF
 $snapshot_output
@@ -265,11 +342,20 @@ EOF
   printf 'presets=%s\n' "$preset_count"
   printf 'preset_summary=%s\n' "${preset_summary:-none yet}"
   printf 'next_client=%s\n' "${next_client:-none}"
+  printf 'route_gaps=%s\n' "${route_gaps:-0}"
+  printf 'route_gaps_ready=%s\n' "${route_gaps_ready:-0}"
+  printf 'route_gaps_manual=%s\n' "${route_gaps_manual:-0}"
+  printf 'refresh_now=%s\n' "${refresh_now:-0}"
+  printf 'review_soon=%s\n' "${review_soon:-0}"
+  printf 'top_refresh_provider=%s\n' "${top_refresh_provider:-}"
+  printf 'top_refresh_action=%s\n' "${top_refresh_action:-}"
+  printf 'top_add_provider=%s\n' "${top_add_provider:-}"
 }
 
 render_summary_cards() {
   local snapshot_output line state health_state bind providers_count providers_ready providers_missing_keys
   local fallback_count default_mode default_profile profile_count preset_count preset_summary next_client
+  local route_gaps refresh_now review_soon
   snapshot_output="$(collect_runtime_snapshot)"
   while IFS= read -r line; do
     case "$line" in
@@ -286,6 +372,9 @@ render_summary_cards() {
       presets=*) preset_count="${line#presets=}" ;;
       preset_summary=*) preset_summary="${line#preset_summary=}" ;;
       next_client=*) next_client="${line#next_client=}" ;;
+      route_gaps=*) route_gaps="${line#route_gaps=}" ;;
+      refresh_now=*) refresh_now="${line#refresh_now=}" ;;
+      review_soon=*) review_soon="${line#review_soon=}" ;;
     esac
   done <<EOF
 $snapshot_output
@@ -306,6 +395,14 @@ EOF
   printf "  %-18s %s\n" "Ready" "$providers_ready"
   printf "  %-18s %s\n" "Missing keys" "$providers_missing_keys"
   printf "  %-18s %s\n" "Fallbacks" "$fallback_count"
+  if [ "${route_gaps:-0}" -gt 0 ]; then
+    printf "  %-18s %s\n" "Route gaps" "$route_gaps"
+  fi
+  if [ "${refresh_now:-0}" -gt 0 ]; then
+    printf "  %-18s %s\n" "Refresh now" "$refresh_now"
+  elif [ "${review_soon:-0}" -gt 0 ]; then
+    printf "  %-18s %s\n" "Review soon" "$review_soon"
+  fi
   echo ""
   printf "  %bClients%b\n" "$FAIGATE_UI_BOLD" "$FAIGATE_UI_RESET"
   printf "  %-18s %s\n" "Default profile" "$default_profile"
@@ -334,6 +431,7 @@ EOF
 
 render_quick_setup_guidance() {
   local snapshot_output line health_state providers_count providers_ready providers_missing_keys
+  local route_gaps refresh_now review_soon top_refresh_provider top_refresh_action top_add_provider
   snapshot_output="$(collect_runtime_snapshot)"
   while IFS= read -r line; do
     case "$line" in
@@ -341,6 +439,12 @@ render_quick_setup_guidance() {
       providers=*) providers_count="${line#providers=}" ;;
       providers_ready=*) providers_ready="${line#providers_ready=}" ;;
       providers_missing_keys=*) providers_missing_keys="${line#providers_missing_keys=}" ;;
+      route_gaps=*) route_gaps="${line#route_gaps=}" ;;
+      refresh_now=*) refresh_now="${line#refresh_now=}" ;;
+      review_soon=*) review_soon="${line#review_soon=}" ;;
+      top_refresh_provider=*) top_refresh_provider="${line#top_refresh_provider=}" ;;
+      top_refresh_action=*) top_refresh_action="${line#top_refresh_action=}" ;;
+      top_add_provider=*) top_add_provider="${line#top_add_provider=}" ;;
     esac
   done <<EOF
 $snapshot_output
@@ -350,6 +454,12 @@ EOF
     faigate_ui_tip "Start with Provider Setup to add sources, then fill in keys and run Full Config Wizard to generate the first usable config."
   elif [ "${providers_missing_keys:-0}" != "0" ] || [ "${providers_ready:-0}" = "0" ]; then
     faigate_ui_tip "Some configured providers are still missing API keys. Fill them in next, then rerun Validate."
+  elif [ "${route_gaps:-0}" -gt 0 ]; then
+    faigate_ui_tip "The config is live, but ${route_gaps} recommended route addition(s) are still open. Open Provider Setup -> Guided Route Additions next${top_add_provider:+, starting with ${top_add_provider}}."
+  elif [ "${refresh_now:-0}" -gt 0 ]; then
+    faigate_ui_tip "The gateway is up, but ${top_refresh_provider:-one or more active routes} should be ${top_refresh_action:-reviewed} before heavier traffic leans on current benchmark and cost assumptions."
+  elif [ "${review_soon:-0}" -gt 0 ]; then
+    faigate_ui_tip "The gateway looks ready. Review aging route assumptions soon${top_refresh_provider:+, starting with ${top_refresh_provider}}."
   elif [ "${health_state:-unreachable}" != "healthy" ]; then
     faigate_ui_tip "Config looks close. Restart + Verify is the next best step so the gateway can pick up the current config."
   else
@@ -494,10 +604,13 @@ run_config_wizard() {
     else
       offer_guided_route_additions_now "Full Config Wizard"
     fi
+    local -a dynamic_steps=()
+    mapfile -t dynamic_steps < <(dynamic_operator_followups)
     show_next_steps "Wizard wrote the config." \
       "Restart + Verify to load the new config." \
       "Run Validate if you changed providers or routing defaults." \
-      "Open Clients when you want the first consumer wired in."
+      "Open Clients when you want the first consumer wired in." \
+      "${dynamic_steps[@]}"
     faigate_ui_pause
     printf "  Restart fusionAIze Gate to apply changes? [y/N]: "
     read -r restart_choice
@@ -589,10 +702,13 @@ run_client_wizard() {
     else
       offer_guided_route_additions_now "Client Wizard"
     fi
+    local -a dynamic_steps=()
+    mapfile -t dynamic_steps < <(dynamic_operator_followups)
     show_next_steps "Client-scoped config update completed." \
       "Restart + Verify to activate the new client default." \
       "Use Client Matrix to confirm the profile and match intent." \
-      "Use the client drilldown to grab the exact setup hints again."
+      "Use the client drilldown to grab the exact setup hints again." \
+      "${dynamic_steps[@]}"
     faigate_ui_pause
   else
     cmd_args+=(--dry-run-summary)

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -518,6 +518,11 @@ metrics:
     )
     assert body["route_summary"]["alternatives"][0]["provider"] == "gemini-flash-lite"
     assert body["route_summary"]["alternatives"][0]["estimated_request_cost_usd"] > 0
+    assert body["route_summary"]["next_actions"]
+    assert any(
+        item["kind"] == "cost-review" and item["path"] == "Client Scenarios or Client Wizard"
+        for item in body["route_summary"]["next_actions"]
+    )
 
 
 def test_image_edit_rejects_large_upload(api_client):

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -1400,6 +1400,68 @@ client_profiles:
     assert "Fix any missing env or endpoint warnings before restart work." in result.stdout
 
 
+def test_faigate_menu_quick_setup_surfaces_guided_route_additions(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  anthropic-claude:
+    backend: anthropic-compat
+    api_key: "${ANTHROPIC_API_KEY}"
+    base_url: "https://api.anthropic.com/v1"
+    model: "claude-opus-4-6"
+fallback_chain:
+  - anthropic-claude
+client_profiles:
+  enabled: true
+  default: generic
+  profiles:
+    generic: {}
+""".strip(),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ANTHROPIC_API_KEY=sk-ant\nOPENROUTER_API_KEY=sk-openrouter\n",
+        encoding="utf-8",
+    )
+    fake_bin = _write_fake_curl(
+        tmp_path,
+        {
+            "/health": json.dumps(
+                {
+                    "status": "ok",
+                    "summary": {"providers_total": 1, "providers_healthy": 1},
+                }
+            )
+        },
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAIGATE_CONFIG_FILE"] = str(config_file)
+    env["FAIGATE_ENV_FILE"] = str(env_file)
+    env["FAIGATE_PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "scripts/faigate-menu"],
+        cwd=REPO_ROOT,
+        env=env,
+        input="1\nq\n",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "fusionAIze Gate Quick Setup" in result.stdout
+    assert "Route gaps" in result.stdout
+    assert "Provider Setup -> Guided Route Additions next" in result.stdout
+
+
 def test_faigate_server_settings_updates_config_and_creates_backup(tmp_path: Path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text(


### PR DESCRIPTION
## Summary
- add next-action handoff guidance to route previews, including refresh, route-add, and cost review suggestions
- surface route gaps and freshness pressure directly in Quick Setup and append dynamic operator follow-ups after write flows
- cover the new preview and Quick Setup guidance with targeted API and menu tests

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_api_hardening.py -k route_preview
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py -k quick_setup_surfaces_guided_route_additions
- ./.venv-check-313/bin/ruff check faigate/main.py tests/test_api_hardening.py tests/test_menu_helpers.py
- ./.venv-check-313/bin/ruff format --check faigate/main.py tests/test_api_hardening.py tests/test_menu_helpers.py
- bash -n scripts/faigate-menu
- git diff --check