### PR TITLE
feat(ui): align operator priority handoffs across probe and dashboard

### DIFF
--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -450,6 +450,51 @@ def _render_refresh_guidance_block(report: dict[str, Any], *, limit: int = 3) ->
     return lines
 
 
+def _build_priority_next(
+    *,
+    route_additions: list[dict[str, Any]],
+    refresh_summary: dict[str, int],
+    providers_request_not_ready: int,
+    unhealthy_count: int,
+    total_requests: int,
+    providers_request_ready: int,
+    fallback_pct: float,
+) -> dict[str, str]:
+    if route_additions:
+        top_add = route_additions[0]
+        return {
+            "path": "Provider Setup -> Guided Route Additions",
+            "why": (
+                "known route additions are still open, starting with "
+                f"{top_add.get('add_provider')} ({top_add.get('strategy')})."
+            ),
+        }
+    if refresh_summary.get("refresh_now", 0) > 0:
+        return {
+            "path": "Dashboard -> Provider detail",
+            "why": "stale benchmark and cost assumptions should be refreshed before heavier traffic leans on them.",
+        }
+    if providers_request_not_ready > 0 or unhealthy_count > 0:
+        return {
+            "path": "Provider Probe or Doctor",
+            "why": "some routes are not request-ready yet or the live health view still shows degraded providers.",
+        }
+    if total_requests == 0 and providers_request_ready > 0:
+        return {
+            "path": "Client Quickstarts",
+            "why": "the gateway is ready enough that the next real step is wiring in a client and sending live traffic.",
+        }
+    if fallback_pct >= 20.0:
+        return {
+            "path": "Client Scenarios or Client Wizard",
+            "why": "fallback routing is carrying a meaningful share of traffic and the client defaults should be tightened.",
+        }
+    return {
+        "path": "Providers or Clients",
+        "why": "the gateway is live; inspect provider and client detail views for the next focused tuning pass.",
+    }
+
+
 def _recommended_scenario_for_client(client_profile: str, *, expensive: bool = False) -> str | None:
     mapping = {
         "opencode": "opencode-eco" if expensive else "opencode-balanced",
@@ -824,6 +869,20 @@ def build_dashboard_report(
             f"as a {top_addition['strategy']} for {top_addition['family']} traffic."
         )
 
+    priority_next = _build_priority_next(
+        route_additions=route_additions,
+        refresh_summary=refresh_summary,
+        providers_request_not_ready=_safe_int(
+            ((health_payload or {}).get("request_readiness") or {}).get("providers_not_ready")
+        ),
+        unhealthy_count=len(unhealthy_providers),
+        total_requests=total_requests,
+        providers_request_ready=_safe_int(
+            ((health_payload or {}).get("request_readiness") or {}).get("providers_ready")
+        ),
+        fallback_pct=fallback_pct,
+    )
+
     return {
         "source": {
             "mode": source_mode,
@@ -847,6 +906,7 @@ def build_dashboard_report(
         "operator_actions": operator_actions,
         "client_highlights": client_highlights,
         "decision_support": decision_support,
+        "priority_next": priority_next,
         "cards": {
             "traffic": {
                 "requests": total_requests,
@@ -993,6 +1053,16 @@ def _render_overview(report: dict[str, Any]) -> str:
         )
     elif report["hints"]:
         lines.extend(["", "Operator note", f"  {report['hints'][0]}"])
+    priority_next = report.get("priority_next") or {}
+    if priority_next:
+        lines.extend(
+            [
+                "",
+                "Priority next",
+                f"  {priority_next.get('path')}",
+                f"  {priority_next.get('why')}",
+            ]
+        )
     if report["decision_support"]:
         lines.extend(["", "Decision support", f"  {report['decision_support'][0]}"])
     refresh_block = _render_refresh_guidance_block(report, limit=1)
@@ -1144,6 +1214,16 @@ def _render_activity(report: dict[str, Any]) -> str:
     if refresh_block:
         lines.append("")
         lines.extend(refresh_block)
+    priority_next = report.get("priority_next") or {}
+    if priority_next:
+        lines.extend(
+            [
+                "",
+                "Priority next",
+                f"- path: {priority_next.get('path')}",
+                f"- why : {priority_next.get('why')}",
+            ]
+        )
     lines.append("")
     lines.append("Operator actions")
     operator_rows = report["operator_actions"][:5]
@@ -1188,6 +1268,16 @@ def _render_alerts(report: dict[str, Any]) -> str:
         lines.extend(path_block)
     for hint in report["decision_support"][:5]:
         lines.append(f"- {hint}")
+    priority_next = report.get("priority_next") or {}
+    if priority_next:
+        lines.extend(
+            [
+                "",
+                "Priority next",
+                f"- path: {priority_next.get('path')}",
+                f"- why : {priority_next.get('why')}",
+            ]
+        )
     return "\n".join(lines).rstrip() + "\n"
 
 

--- a/faigate/wizard.py
+++ b/faigate/wizard.py
@@ -1329,6 +1329,65 @@ def build_provider_probe_report(
     }
 
 
+def _provider_probe_priority_next(report: dict[str, Any]) -> dict[str, str]:
+    summary = report.get("summary") or {}
+    actions = summary.get("actions") or {}
+    refresh_actions = summary.get("refresh_actions") or {}
+
+    if int(summary.get("configured") or 0) == 0:
+        return {
+            "path": "Provider Setup",
+            "why": "no provider sources are configured yet, so there is nothing real to probe.",
+        }
+    if int(actions.get("fix-now") or 0) > 0:
+        return {
+            "path": "API Keys or Provider Setup",
+            "why": (
+                "at least one configured route still needs credentials, "
+                "endpoint fixes, or model cleanup."
+            ),
+        }
+    if int(summary.get("mirror_gaps") or 0) > 0:
+        return {
+            "path": "Provider Setup -> Guided Route Additions",
+            "why": (
+                "known same-lane or cluster mirrors are still missing from "
+                "the configured route inventory."
+            ),
+        }
+    if int(refresh_actions.get("refresh-now") or 0) > 0:
+        return {
+            "path": "Dashboard -> Provider detail",
+            "why": (
+                "one or more active routes rely on stale benchmark and cost "
+                "assumptions that should be refreshed now."
+            ),
+        }
+    if int(actions.get("hold") or 0) > 0 or int(actions.get("watch") or 0) > 0:
+        return {
+            "path": "Doctor or Dashboard -> Provider detail",
+            "why": (
+                "runtime cooldown or recovery pressure is active and should be "
+                "checked before routing heavier traffic."
+            ),
+        }
+    if int(summary.get("ready") or 0) > 0:
+        return {
+            "path": "Client Scenarios or Client Quickstarts",
+            "why": (
+                "the provider layer looks ready enough to move on to client "
+                "defaults and real client wiring."
+            ),
+        }
+    return {
+        "path": "Validate",
+        "why": (
+            "the probe ran, but the next operator action is still to tighten "
+            "the current config and env state."
+        ),
+    }
+
+
 def render_provider_probe_text(report: dict[str, Any]) -> str:
     lines = ["Provider probe", ""]
     summary = report.get("summary") or {}
@@ -1399,6 +1458,15 @@ def render_provider_probe_text(report: dict[str, Any]) -> str:
                 f"review-soon={refresh_actions.get('review-soon', 0)}",
             ]
         )
+    )
+    priority_next = _provider_probe_priority_next(report)
+    lines.extend(
+        [
+            "",
+            "Priority next",
+            f"- path: {priority_next['path']}",
+            f"- why : {priority_next['why']}",
+        ]
     )
     lines.append("")
     for row in report.get("providers", []):

--- a/scripts/faigate-doctor
+++ b/scripts/faigate-doctor
@@ -438,6 +438,33 @@ if health_raw:
                 if item.get("refresh_url"):
                     detail += f" -> {item['refresh_url']}"
                 print(detail)
+        if action_counts["fix-now"] > 0:
+            print(
+                "[ok] request-ready priority next: API Keys or Provider Setup -> "
+                "at least one configured route still needs credentials or endpoint cleanup"
+            )
+        elif mirror_gap_routes > 0:
+            print(
+                "[ok] request-ready priority next: Provider Setup -> Guided Route Additions -> "
+                "known same-lane or cluster mirrors are still missing"
+            )
+        elif refresh_guidance and any(
+            str(item.get("action") or "") == "refresh-now" for item in refresh_guidance
+        ):
+            print(
+                "[ok] request-ready priority next: Dashboard -> Provider detail -> "
+                "refresh stale benchmark and cost assumptions before heavier traffic leans on them"
+            )
+        elif action_counts["hold"] > 0 or action_counts["watch"] > 0:
+            print(
+                "[ok] request-ready priority next: Doctor or Dashboard -> Provider detail -> "
+                "runtime cooldown or recovery pressure is active"
+            )
+        elif ready > 0:
+            print(
+                "[ok] request-ready priority next: Client Scenarios or Client Quickstarts -> "
+                "the provider layer looks ready enough to move on to client defaults and wiring"
+            )
 PY
 then
   status=1

--- a/scripts/faigate-menu
+++ b/scripts/faigate-menu
@@ -110,7 +110,10 @@ run_and_pause_with_priority_receipt() {
     faigate_ui_warn "Command exited with status ${command_rc}."
   fi
   priority_step="$(priority_next_step_line)"
-  show_next_steps "$title" "$priority_step" "${steps[@]}"
+  show_next_steps "$title" \
+    "$priority_step" \
+    "Quick Setup shortcut: return here and press r to open the current recommended path directly." \
+    "${steps[@]}"
   faigate_ui_pause
   return 0
 }

--- a/tests/test_menu_helpers.py
+++ b/tests/test_menu_helpers.py
@@ -452,6 +452,8 @@ providers:
     assert "[openai-compatible | native | confidence=high]" in result.stdout
     assert "request-ready payload: deepseek-chat -> openai-chat-minimal" in result.stdout
     assert "request-ready next step: deepseek-chat -> route can carry live traffic" in result.stdout
+    assert "request-ready priority next:" in result.stdout
+    assert "Provider Setup -> Guided Route Additions" in result.stdout
 
 
 def test_faigate_doctor_reports_runtime_cooldown_windows(tmp_path: Path):
@@ -1402,6 +1404,7 @@ client_profiles:
 
     assert "Validation completed." in result.stdout
     assert "Recommended next:" in result.stdout
+    assert "Quick Setup shortcut:" in result.stdout
     assert "Fix any missing env or endpoint warnings before restart work." in result.stdout
 
 
@@ -2210,12 +2213,15 @@ def test_faigate_dashboard_activity_and_alerts_show_family_and_path_summaries(tm
     assert "Lane families" in activity.stdout
     assert "- deepseek: 2 routes | 14 req | cooldown=2 | recovery=1" in activity.stdout
     assert "Selection paths" in activity.stdout
+    assert "Priority next" in activity.stdout
+    assert "Providers or Clients" in activity.stdout
     assert (
         "same-lane-route: 6 req / $0.18 / 410ms "
         "[deepseek | cooldown | recovery-watch]" in activity.stdout
     )
     assert "Lane families" in alerts.stdout
     assert "Selection paths" in alerts.stdout
+    assert "Priority next" in alerts.stdout
 
 
 def test_faigate_provider_probe_summarizes_config_env_and_health(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add priority next guidance to provider probe, dashboard activity, alerts, and doctor surfaces
- extend quick setup receipts with a direct recommended-path reminder
- align menu helper coverage with the new operator priority guidance

## Testing
- ./.venv-check-313/bin/ruff check faigate/wizard.py faigate/dashboard.py tests/test_menu_helpers.py
- ./.venv-check-313/bin/ruff format --check faigate/wizard.py faigate/dashboard.py tests/test_menu_helpers.py
- bash -n scripts/faigate-doctor scripts/faigate-menu scripts/faigate-provider-probe
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py::test_faigate_doctor_reports_request_readiness_when_health_is_live
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py::test_faigate_provider_probe_summarizes_config_env_and_health
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py::test_faigate_dashboard_activity_and_alerts_show_family_and_path_summaries
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_menu_helpers.py::test_faigate_menu_quick_setup_validate_shows_next_steps
