### PR TITLE
feat(router): explain short-complex route tradeoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to fusionAIze Gate should be documented here.
 
 The format is intentionally lightweight and human-readable. Group entries by release and focus on user-visible behavior, operational changes, and compatibility notes.
 
+## v1.9.0 - Unreleased
+
+### Changed
+
+- Strengthened short-but-risky `opencode` prompt detection so brief architecture, queue/backpressure, and rollout-planning requests escalate out of cheap lanes earlier instead of being flattened by generic short-query heuristics
+- Expanded route-preview explainability with structured complexity reasons plus explicit `why_not_selected` guidance for cheaper alternatives, so operators can now see why a lower-cost lane lost on reasoning depth, benchmark fit, freshness, or runtime pressure
+
 ## v1.8.0 - 2026-03-22
 
 ### Changed

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -678,6 +678,80 @@ def _trace_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _alternative_loss_reasons(
+    *,
+    selected: dict[str, Any],
+    alternative: dict[str, Any],
+    request_insights: dict[str, Any],
+    routing_posture: str,
+) -> list[str]:
+    reasons: list[str] = []
+    selected_cost = float(selected.get("estimated_request_cost_usd") or 0.0)
+    alternative_cost = float(alternative.get("estimated_request_cost_usd") or 0.0)
+    selected_reasoning = str(selected.get("reasoning_strength") or "")
+    alternative_reasoning = str(alternative.get("reasoning_strength") or "")
+    selected_quality = str(selected.get("quality_tier") or "")
+    alternative_quality = str(alternative.get("quality_tier") or "")
+    selected_benchmark = int(selected.get("benchmark_request_score") or 0)
+    alternative_benchmark = int(alternative.get("benchmark_request_score") or 0)
+    complexity_profile = str(request_insights.get("complexity_profile") or "")
+    signal_groups = [str(item) for item in (request_insights.get("signal_groups") or []) if item]
+
+    if alternative_cost > 0 and selected_cost > 0 and alternative_cost <= (selected_cost * 0.6):
+        if alternative_benchmark < selected_benchmark:
+            reasons.append(
+                "Cheaper, but benchmark fit was weaker for "
+                + (", ".join(signal_groups) if signal_groups else "the current request")
+                + "."
+            )
+        elif alternative_reasoning and alternative_reasoning != selected_reasoning:
+            reasons.append("Cheaper, but reasoning depth was weaker for this request.")
+        else:
+            reasons.append("Cheaper, but the overall route fit still ranked lower.")
+
+    strength_rank = {"low": 1, "mid": 2, "high": 3, "variable": 2}
+    if strength_rank.get(alternative_reasoning, 0) < strength_rank.get(selected_reasoning, 0):
+        reasons.append("Reasoning strength was lower than the selected lane.")
+
+    quality_rank = {
+        "free": 1,
+        "budget": 2,
+        "mid": 3,
+        "high": 4,
+        "premium": 5,
+        "variable": 3,
+    }
+    if quality_rank.get(alternative_quality, 0) < quality_rank.get(selected_quality, 0):
+        if routing_posture in {"quality", "balanced", "auto"} or complexity_profile in {
+            "medium",
+            "high",
+        }:
+            reasons.append("Quality tier was lower than the chosen lane.")
+
+    if alternative_benchmark < selected_benchmark and signal_groups:
+        reasons.append("Benchmark cluster matched fewer request signals than the selected lane.")
+
+    if (
+        str(alternative.get("freshness_status") or "") == "stale"
+        and str(selected.get("freshness_status") or "") != "stale"
+    ):
+        reasons.append("Benchmark and cost assumptions were staler.")
+
+    if int(alternative.get("runtime_penalty") or 0) > 0:
+        reasons.append("Runtime penalty or cooldown pressure was active.")
+
+    if (
+        routing_posture == "quality"
+        and str(selected.get("route_type") or "") == "direct"
+        and str(alternative.get("route_type") or "") == "aggregator"
+    ):
+        reasons.append("Quality posture kept the direct route ahead of an aggregator path.")
+
+    if not reasons and alternative.get("reason"):
+        reasons.append(str(alternative.get("reason") or ""))
+    return reasons
+
+
 def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
     details = dict(decision.details or {})
     request_insights = dict(details.get("request_insights") or {})
@@ -697,6 +771,11 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         "benchmark_cluster": str(
             details.get("benchmark_cluster") or selected_row.get("benchmark_cluster") or ""
         ),
+        "quality_tier": str(details.get("quality_tier") or selected_row.get("quality_tier") or ""),
+        "reasoning_strength": str(
+            details.get("reasoning_strength") or selected_row.get("reasoning_strength") or ""
+        ),
+        "benchmark_request_score": int(selected_row.get("benchmark_request_score") or 0),
         "cost_tier": str(details.get("cost_tier") or selected_row.get("cost_tier") or ""),
         "estimated_request_cost_usd": float(selected_row.get("estimated_request_cost_usd") or 0.0),
         "freshness_status": str(
@@ -733,6 +812,8 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         why_selected.append(
             "Simple-query routing was suppressed because the request looked riskier."
         )
+    for note in request_insights.get("complexity_reasons") or []:
+        why_selected.append(str(note))
     if selected.get("benchmark_cluster") and request_insights.get("signal_groups"):
         why_selected.append(
             f"Benchmark fit favored {selected['benchmark_cluster']} for "
@@ -756,6 +837,7 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         )
 
     alternatives: list[dict[str, Any]] = []
+    why_cheaper_lanes_lost: list[str] = []
     selected_score = None
     if rankings:
         for row in rankings:
@@ -790,15 +872,29 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
                 "route_type": str(row.get("route_type") or ""),
                 "lane_cluster": str(row.get("lane_cluster") or ""),
                 "benchmark_cluster": str(row.get("benchmark_cluster") or ""),
+                "quality_tier": str(row.get("quality_tier") or ""),
+                "reasoning_strength": str(row.get("reasoning_strength") or ""),
+                "benchmark_request_score": int(row.get("benchmark_request_score") or 0),
                 "cost_tier": str(row.get("cost_tier") or ""),
                 "estimated_request_cost_usd": float(row.get("estimated_request_cost_usd") or 0.0),
                 "freshness_status": str(row.get("freshness_status") or ""),
                 "review_age_days": int(row.get("review_age_days") or -1),
+                "runtime_penalty": int(row.get("runtime_penalty") or 0),
                 "reason": ", ".join(reason_bits)
                 if reason_bits
                 else "ranked below the selected route",
             }
         )
+        alternatives[-1]["why_not_selected"] = _alternative_loss_reasons(
+            selected=selected,
+            alternative=alternatives[-1],
+            request_insights=request_insights,
+            routing_posture=str(details.get("routing_posture") or ""),
+        )
+        if float(alternatives[-1].get("estimated_request_cost_usd") or 0.0) > 0 and float(
+            alternatives[-1].get("estimated_request_cost_usd") or 0.0
+        ) <= max(0.0, float(selected.get("estimated_request_cost_usd") or 0.0) * 0.6):
+            why_cheaper_lanes_lost.extend(alternatives[-1]["why_not_selected"])
         if len(alternatives) >= 3:
             break
 
@@ -887,9 +983,11 @@ def _build_route_summary(decision: RoutingDecision) -> dict[str, Any]:
         "complexity_score": int(request_insights.get("complexity_score") or 0),
         "signal_groups": list(request_insights.get("signal_groups") or []),
         "matched_signals": list(request_insights.get("matched_signals") or []),
+        "complexity_reasons": list(request_insights.get("complexity_reasons") or []),
         "matched_keywords": list(heuristic_match.get("matched_keywords") or []),
         "selected": selected,
         "why_selected": why_selected,
+        "why_cheaper_lanes_lost": list(dict.fromkeys(why_cheaper_lanes_lost)),
         "alternatives": alternatives,
         "next_actions": next_actions,
     }

--- a/faigate/router.py
+++ b/faigate/router.py
@@ -17,6 +17,10 @@ _OPENCODE_COMPLEXITY_HINTS = (
     "architecture",
     "tradeoff",
     "trade-off",
+    "system design",
+    "design review",
+    "implementation plan",
+    "rollout plan",
     "rollback",
     "idempot",
     "backpressure",
@@ -27,6 +31,11 @@ _OPENCODE_COMPLEXITY_HINTS = (
     "refactor",
     "debug",
     "code review",
+    "event processing",
+    "under load",
+    "throughput",
+    "queue",
+    "consistency",
     "performance bottleneck",
     "race condition",
     "deadlock",
@@ -47,6 +56,8 @@ _OPENCODE_COMPLEXITY_RULE_KEYWORDS = {
     "deadlock",
     "tradeoff",
     "trade-off",
+    "system design",
+    "implementation plan",
     "migration",
     "rollback",
     "idempotency",
@@ -55,7 +66,14 @@ _OPENCODE_COMPLEXITY_RULE_KEYWORDS = {
     "reliability",
 }
 _OPENCODE_SIGNAL_GROUPS = {
-    "architecture": ("architecture", "tradeoff", "trade-off", "design pattern"),
+    "architecture": (
+        "architecture",
+        "tradeoff",
+        "trade-off",
+        "design pattern",
+        "system design",
+        "design review",
+    ),
     "change-risk": (
         "migration",
         "rollback",
@@ -63,10 +81,27 @@ _OPENCODE_SIGNAL_GROUPS = {
         "failure mode",
         "failure modes",
         "reliability",
+        "consistency",
     ),
-    "concurrency": ("concurrency", "race condition", "deadlock", "backpressure"),
+    "concurrency": (
+        "concurrency",
+        "race condition",
+        "deadlock",
+        "backpressure",
+        "queue",
+        "throughput",
+        "under load",
+        "event processing",
+    ),
     "debugging": ("debug", "memory leak", "type error", "performance bottleneck"),
-    "quality": ("refactor", "code review", "optimize", "security vulnerability"),
+    "quality": (
+        "refactor",
+        "code review",
+        "optimize",
+        "security vulnerability",
+        "implementation plan",
+        "rollout plan",
+    ),
 }
 
 
@@ -445,11 +480,26 @@ def _build_request_insights(
     """Summarize request complexity signals for routing and operator surfaces."""
     search_text = (last_user_message or "").lower()
     opencode_hits = _collect_keyword_hits(search_text, _OPENCODE_COMPLEXITY_HINTS)
-    signal_groups = [
-        group
+    signal_hits = {
+        group: _collect_keyword_hits(search_text, keywords)
         for group, keywords in _OPENCODE_SIGNAL_GROUPS.items()
-        if _collect_keyword_hits(search_text, keywords)
-    ]
+    }
+    signal_hits = {group: hits for group, hits in signal_hits.items() if hits}
+    signal_groups = list(signal_hits.keys())
+    planning_terms = _collect_keyword_hits(
+        search_text,
+        (
+            "plan",
+            "strategy",
+            "approach",
+            "design",
+            "review",
+            "safely",
+            "safe",
+        ),
+    )
+    short_complex = total_tokens < 80 and len(signal_groups) >= 2
+    architecture_risk = bool({"architecture", "change-risk"} & set(signal_groups))
 
     score = 0
     score += min(4, len(opencode_hits))
@@ -464,6 +514,12 @@ def _build_request_insights(
         score += 1
     if client_profile == "opencode" and opencode_hits:
         score += 1
+    if short_complex:
+        score += 2
+    if client_profile == "opencode" and planning_terms and signal_groups:
+        score += 1
+    if architecture_risk and planning_terms:
+        score += 1
 
     if score >= 6:
         complexity_profile = "high"
@@ -472,13 +528,35 @@ def _build_request_insights(
     else:
         complexity_profile = "low"
 
+    complexity_reasons: list[str] = []
+    if short_complex:
+        complexity_reasons.append(
+            "Brief prompt, but multiple risk-heavy coding signal groups are present."
+        )
+    if architecture_risk:
+        complexity_reasons.append(
+            "Architecture and change-risk signals suggest a higher-cost mistake surface."
+        )
+    if planning_terms and signal_groups:
+        complexity_reasons.append(
+            "Planning or design language appears together with implementation-risk signals."
+        )
+    if has_tools:
+        complexity_reasons.append("Tool usage raises the likelihood of multi-step coding work.")
+
     return {
         "complexity_profile": complexity_profile,
         "complexity_score": score,
         "signal_groups": signal_groups,
+        "signal_hits": signal_hits,
         "matched_signals": opencode_hits,
         "length_bucket": _request_length_bucket(total_tokens),
         "tool_context": bool(has_tools),
+        "planning_context": bool(planning_terms),
+        "planning_terms": planning_terms,
+        "short_complex": short_complex,
+        "architecture_risk": architecture_risk,
+        "complexity_reasons": complexity_reasons,
         "opencode_bias_eligible": client_profile == "opencode"
         and complexity_profile
         in {
@@ -1670,10 +1748,13 @@ class Router:
                     "score_total": details["score_total"],
                     "routing_posture": details["routing_posture"],
                     "lane_family": details["lane_family"],
+                    "lane_name": details["lane_name"],
                     "canonical_model": details["canonical_model"],
                     "route_type": details["route_type"],
                     "lane_cluster": details["lane_cluster"],
                     "benchmark_cluster": details["benchmark_cluster"],
+                    "quality_tier": details["quality_tier"],
+                    "reasoning_strength": details["reasoning_strength"],
                     "benchmark_request_score": details["benchmark_request_score"],
                     "cost_score": details["cost_score"],
                     "estimated_request_cost_usd": details["estimated_request_cost_usd"],
@@ -1893,7 +1974,22 @@ class Router:
             if (
                 ctx.client_profile == "opencode"
                 and complexity_profile == "high"
-                and any(token in rule_name.lower() for token in ("complex", "reason", "debug"))
+                and any(
+                    token in rule_name.lower()
+                    for token in ("complex", "reason", "debug", "review", "plan", "design")
+                )
+                and matched_keywords
+            ):
+                min_matches = max(1, int(min_matches) - 1)
+                opencode_bias_applied = True
+
+            if (
+                ctx.client_profile == "opencode"
+                and bool(request_insights.get("short_complex"))
+                and any(
+                    token in rule_name.lower()
+                    for token in ("complex", "reason", "debug", "review", "plan", "design")
+                )
                 and matched_keywords
             ):
                 min_matches = max(1, int(min_matches) - 1)
@@ -1917,6 +2013,7 @@ class Router:
                     "suppressed_for_complexity": suppressed_for_complexity,
                     "complexity_profile": complexity_profile,
                     "signal_groups": signal_groups,
+                    "short_complex": bool(request_insights.get("short_complex")),
                 }
             )
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -502,6 +502,7 @@ metrics:
     assert body["decision"]["provider"] == "deepseek-reasoner"
     assert body["route_summary"]["complexity_profile"] in {"medium", "high"}
     assert "architecture" in body["route_summary"]["matched_keywords"]
+    assert body["route_summary"]["complexity_reasons"]
     assert body["route_summary"]["selected"]["canonical_model"] == "deepseek/reasoner"
     assert body["route_summary"]["selected"]["benchmark_cluster"] == "reasoning-coding"
     assert body["route_summary"]["selected"]["cost_tier"] == "standard"
@@ -518,6 +519,12 @@ metrics:
     )
     assert body["route_summary"]["alternatives"][0]["provider"] == "gemini-flash-lite"
     assert body["route_summary"]["alternatives"][0]["estimated_request_cost_usd"] > 0
+    assert body["route_summary"]["alternatives"][0]["why_not_selected"]
+    assert any(
+        "Cheaper" in item or "Reasoning strength" in item or "Benchmark cluster" in item
+        for item in body["route_summary"]["alternatives"][0]["why_not_selected"]
+    )
+    assert body["route_summary"]["why_cheaper_lanes_lost"]
     assert body["route_summary"]["next_actions"]
     assert any(
         item["kind"] == "cost-review" and item["path"] == "Client Scenarios or Client Wizard"

--- a/tests/test_routing_dimensions.py
+++ b/tests/test_routing_dimensions.py
@@ -1223,3 +1223,91 @@ metrics:
     )
 
     assert decision.provider_name == "deepseek-reasoner"
+
+
+@pytest.mark.asyncio
+async def test_opencode_short_complex_prompt_reduces_complex_rule_threshold(tmp_path):
+    cfg = load_config(
+        _write_config(
+            tmp_path,
+            """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  deepseek-reasoner:
+    backend: openai-compat
+    base_url: "https://reasoner.example.com/v1"
+    api_key: "secret"
+    model: "reasoner"
+    tier: reasoning
+  gemini-flash-lite:
+    backend: google-genai
+    base_url: "https://google.example.com/v1beta"
+    api_key: "secret"
+    model: "gemini-2.5-flash-lite"
+    tier: cheap
+heuristic_rules:
+  enabled: true
+  rules:
+    - name: complex-code
+      match:
+        message_keywords:
+          any_of: ["architecture", "debug"]
+          min_matches: 2
+      route_to: deepseek-reasoner
+    - name: simple-query
+      match:
+        message_keywords:
+          any_of: ["hello", "hi"]
+          min_matches: 1
+      route_to: gemini-flash-lite
+fallback_chain:
+  - deepseek-reasoner
+metrics:
+  enabled: false
+""",
+        )
+    )
+    router = Router(cfg)
+
+    generic_decision = await router.route(
+        [
+            {
+                "role": "user",
+                "content": "hi, need a safe architecture plan for queue backpressure",
+            }
+        ],
+        model_requested="auto",
+        client_profile="generic",
+        profile_hints={},
+        provider_health={
+            "deepseek-reasoner": {"healthy": True},
+            "gemini-flash-lite": {"healthy": True},
+        },
+    )
+    opencode_decision = await router.route(
+        [
+            {
+                "role": "user",
+                "content": "hi, need a safe architecture plan for queue backpressure",
+            }
+        ],
+        model_requested="auto",
+        client_profile="opencode",
+        profile_hints={"routing_mode": "auto"},
+        provider_health={
+            "deepseek-reasoner": {"healthy": True},
+            "gemini-flash-lite": {"healthy": True},
+        },
+    )
+
+    assert generic_decision.provider_name == "gemini-flash-lite"
+    assert opencode_decision.provider_name == "deepseek-reasoner"
+    assert opencode_decision.details["request_insights"]["short_complex"] is True
+    assert "architecture" in opencode_decision.details["request_insights"]["signal_groups"]
+    assert "concurrency" in opencode_decision.details["request_insights"]["signal_groups"]
+    assert (
+        opencode_decision.details["heuristic_match"]["effective_min_matches"]
+        < opencode_decision.details["heuristic_match"]["original_min_matches"]
+    )


### PR DESCRIPTION
## Summary
- strengthen short-but-risky opencode complexity detection for architecture, rollout, and queue/backpressure prompts
- carry richer request insight signals into route preview and explain why cheaper alternatives lost
- document the new 1.9.0 progress in the changelog

## Testing
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_routing_dimensions.py -k "opencode_medium_complexity_suppresses_simple_query_and_promotes_complex_rule or opencode_complexity_bias_promotes_single_strong_architecture_hit or opencode_short_complex_prompt_reduces_complex_rule_threshold"
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_api_hardening.py -k route_preview_includes_route_summary_for_opencode_complexity
- ./.venv-check-313/bin/ruff check faigate/router.py faigate/main.py tests/test_routing_dimensions.py tests/test_api_hardening.py
- ./.venv-check-313/bin/ruff format --check faigate/router.py faigate/main.py tests/test_routing_dimensions.py tests/test_api_hardening.py
