### PR TITLE
fix(release): restore python 3.10 update compatibility

### DIFF
--- a/faigate/updates.py
+++ b/faigate/updates.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python 3.10 compatibility
+    UTC = timezone.utc  # noqa: UP017
 
 
 def _normalize_version(value: str) -> tuple[int, ...]:

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -18,6 +18,11 @@ from faigate.updates import (
     release_age_hours,
     select_release_payload,
 )
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python 3.10 compatibility
+    UTC = timezone.utc  # noqa: UP017
 
 
 class _FakeResponse:


### PR DESCRIPTION
## Summary
- restore Python 3.10 compatibility for the release update helpers by falling back cleanly when datetime.UTC is unavailable
- keep Ruff happy on newer runtimes with an explicit compatibility-only fallback
- cover the fix through update tests and a small main-cli import smoke

## Testing
- ./.venv-check-313/bin/ruff check faigate/updates.py tests/test_updates.py
- ./.venv-check-313/bin/ruff format --check faigate/updates.py tests/test_updates.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_updates.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_main_cli.py -k "help or version or status"
- git diff --check
