### PR TITLE
chore: release v1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # fusionAIze Gate Changelog
 
+## v1.11.2 - 2026-03-29
+
+### Changed
+
+- Restored Python 3.10 compatibility for the release update helpers by falling back cleanly when `datetime.UTC` is unavailable, which fixes the release CI collection failure that blocked the `v1.11.x` line
+- Realigned the runtime version surfaces so package metadata, `faigate --version`, and the FastAPI app version all move together again instead of reporting mixed `1.10.1` / `1.11.x` values
+
 ## v1.11.1 - 2026-03-29
 
 ### Added

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.10.1"
+__version__ = "1.11.2"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1702,7 +1702,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.10.1",
+    version="1.11.2",
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.11.1"
+version = "1.11.2"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the package and runtime version surfaces to v1.11.2
- document the Python 3.10 release-compatibility fix in the changelog
- keep the release cut small and focused so the v1.11.x line can ship cleanly again

## Testing
- ./.venv-check-313/bin/ruff check pyproject.toml faigate/__init__.py faigate/main.py faigate/updates.py tests/test_updates.py tests/test_main_cli.py
- ./.venv-check-313/bin/ruff format --check faigate/__init__.py faigate/main.py faigate/updates.py tests/test_updates.py tests/test_main_cli.py
- PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_updates.py tests/test_main_cli.py
- ./.venv-check-313/bin/python -m build --no-isolation
- ./.venv-check-313/bin/python -m twine check dist/faigate-1.11.2.tar.gz dist/faigate-1.11.2-py3-none-any.whl
- git diff --check
