### PR TITLE
feat(release): harden release automation

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -8,12 +8,27 @@ on:
       - "Dockerfile"
       - ".dockerignore"
       - "pyproject.toml"
+      - "faigate/__init__.py"
       - "README.md"
       - "RELEASES.md"
+      - "docs/PUBLISHING.md"
+      - "scripts/faigate-release"
+      - "scripts/faigate-verify"
+      - ".github/workflows/notify-tap.yml"
       - ".github/workflows/publish-dry-run.yml"
       - ".github/workflows/release-artifacts.yml"
 
 jobs:
+  release-helper-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Exercise release helper in dry-run mode
+        run: python scripts/faigate-release --dry-run --version 9.9.9
+
   python-publish-dry-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -6,7 +6,41 @@ on:
       - "v*"
 
 jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate release tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+          content = Path("pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'^version = "([^"]+)"$', content, flags=re.MULTILINE)
+          if not match:
+              raise SystemExit("pyproject.toml version not found")
+          print(match.group(1))
+          PY
+          )"
+          PACKAGE_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+          content = Path("faigate/__init__.py").read_text(encoding="utf-8")
+          match = re.search(r'^__version__ = "([^"]+)"$', content, flags=re.MULTILINE)
+          if not match:
+              raise SystemExit("faigate/__init__.py version not found")
+          print(match.group(1))
+          PY
+          )"
+          test "$TAG_VERSION" = "$PYPROJECT_VERSION"
+          test "$TAG_VERSION" = "$PACKAGE_VERSION"
+
   python-dist:
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +51,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip build
           python -m build
+      - name: Validate Python artifacts
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
       - name: Upload Python artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -24,6 +62,7 @@ jobs:
           path: dist/*
 
   ghcr:
+    needs: validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,19 +92,21 @@ jobs:
 
   pypi:
     if: ${{ vars.PYPI_PUBLISH == 'true' }}
+    needs:
+      - validate-release
+      - python-dist
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     environment:
       name: pypi
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Download built Python artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.12"
-      - name: Build sdist and wheel
-        run: |
-          python -m pip install --upgrade pip build
-          python -m build
+          name: python-dist
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,8 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
 8. Confirm that README plus the relevant docs pages still match the shipped runtime behavior.
 9. If packaging or Docker changed shortly before the release, run the publish dry run first.
 10. For hardening-heavy releases, keep the API functional tests green alongside unit and config coverage.
-11. If the Homebrew formula changed, bump `Formula/faigate.rb` in the separate [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap) repo to the new release tag and update its `sha256`.
+11. Publish the GitHub Release so [`notify-tap`](./.github/workflows/notify-tap.yml) can dispatch the Homebrew tap update automatically.
+12. If the tap dispatch fails or the formula needs manual follow-up, bump `Formula/faigate.rb` in the separate [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap) repo to the new release tag and update its `sha256`.
 
 ## Example
 
@@ -29,7 +30,7 @@ git push origin v1.8.0
 
 Then open GitHub Releases and publish a release for `v1.8.0`.
 
-If the release changes the Homebrew package, follow it with a tap update in [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap):
+Publishing the GitHub Release should trigger the tap notification automatically. If the tap still needs a manual follow-up, use [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap):
 
 ```bash
 git clone https://github.com/fusionAIze/homebrew-tap.git
@@ -43,15 +44,19 @@ git push origin main
 
 Tagged releases now trigger [release-artifacts](./.github/workflows/release-artifacts.yml):
 
+- validate that the Git tag matches both `pyproject.toml` and `faigate/__init__.py`
 - always build `sdist` and `wheel`
+- run `twine check dist/*` before artifacts are uploaded or published
 - push the container image to GHCR
 - publish to PyPI only when `PYPI_PUBLISH=true` is set and GitHub trusted publishing is configured for the `pypi` environment
+- publish the already-built `python-dist` artifact to PyPI instead of rebuilding it in a second job
 
 The repo also includes [publish-dry-run](./.github/workflows/publish-dry-run.yml):
 
 - build Python distributions without publishing them
 - run `twine check`
 - build the GHCR image without pushing it
+- exercise `scripts/faigate-release --dry-run` when release automation files change
 
 ## Versioning Guidance
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -24,12 +24,14 @@ The repo includes [publish-dry-run](../.github/workflows/publish-dry-run.yml):
 - builds the Python package
 - runs `twine check dist/*`
 - builds the container image through `docker/build-push-action`
+- exercises `scripts/faigate-release --dry-run`
 - does not push to GHCR
 - does not publish to PyPI
 
 ### Local
 
 ```bash
+python scripts/faigate-release --dry-run --version 1.11.3
 python -m pip install --upgrade build twine
 python -m build
 python -m twine check dist/*
@@ -41,12 +43,22 @@ docker build -t faigate:dry-run .
 The real publish flow stays tag-driven through [release-artifacts](../.github/workflows/release-artifacts.yml):
 
 1. cut the release PR and merge it to `main`
-2. tag the release from `main`
-3. push the tag
-4. let `release-artifacts` build Python distributions and the GHCR image
-5. publish the GitHub Release
-6. optionally allow PyPI publication through trusted publishing
-7. publish the separate npm CLI package only when you are ready to version the Node-facing surface independently
+2. run `python scripts/faigate-release --version x.y.z`
+3. tag the release from `main`
+4. push the tag
+5. let `release-artifacts` validate the tag/version match, build Python distributions, and push the GHCR image
+6. publish the GitHub Release
+7. let `notify-tap` dispatch the Homebrew update to [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap)
+8. optionally allow PyPI publication through trusted publishing
+9. publish the separate npm CLI package only when you are ready to version the Node-facing surface independently
+
+The local release helper now updates:
+
+- `pyproject.toml`
+- `faigate/__init__.py`
+- `CHANGELOG.md`
+
+It no longer rewrites a Homebrew formula inside this repo because the tap lives in the separate [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap) repository.
 
 ## Trust Boundaries
 

--- a/scripts/faigate-release
+++ b/scripts/faigate-release
@@ -1,160 +1,212 @@
 #!/usr/bin/env python3
-"""
-faigate-release: Automate the version bump and documentation updates for fusionAIze Gate.
+"""Prepare a fusionAIze Gate release bump in a repeatable, testable way."""
 
-Usage:
-    ./scripts/faigate-release [--version <new_version>] [--dry-run]
-"""
+from __future__ import annotations
 
 import argparse
-import os
 import re
 import subprocess
 import sys
 from datetime import date
 from pathlib import Path
 
-# Paths
 ROOT = Path(__file__).parent.parent.resolve()
 PYPROJECT = ROOT / "pyproject.toml"
+PACKAGE_INIT = ROOT / "faigate" / "__init__.py"
 CHANGELOG = ROOT / "CHANGELOG.md"
-FORMULA = ROOT / "Formula" / "faigate.rb"
+VERIFY_SCRIPT = ROOT / "scripts" / "faigate-verify"
+TAP_REPO_URL = "https://github.com/fusionAIze/homebrew-tap"
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
 
-def get_current_version():
-    content = PYPROJECT.read_text(encoding="utf-8")
-    match = re.search(r'version = "([^"]+)"', content)
-    if not match:
+def validate_version(version: str) -> str:
+    token = str(version or "").strip()
+    if not SEMVER_RE.fullmatch(token):
+        raise ValueError(f"Invalid version '{version}'. Expected x.y.z.")
+    return token
+
+
+def _replace_first(pattern: str, replacement: str, content: str, *, path: Path) -> str:
+    updated, count = re.subn(pattern, replacement, content, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError(f"Could not update expected version field in {path}")
+    return updated
+
+
+def read_project_versions() -> dict[str, str]:
+    pyproject_content = PYPROJECT.read_text(encoding="utf-8")
+    package_content = PACKAGE_INIT.read_text(encoding="utf-8")
+
+    pyproject_match = re.search(r'^version = "([^"]+)"$', pyproject_content, flags=re.MULTILINE)
+    package_match = re.search(
+        r'^__version__ = "([^"]+)"$',
+        package_content,
+        flags=re.MULTILINE,
+    )
+    if not pyproject_match:
         raise ValueError("Could not find version in pyproject.toml")
-    return match.group(1)
+    if not package_match:
+        raise ValueError("Could not find __version__ in faigate/__init__.py")
+    return {
+        "pyproject": pyproject_match.group(1),
+        "package": package_match.group(1),
+    }
 
 
-def bump_version(new_version, dry_run=False):
-    print(f"Bumping version in pyproject.toml to {new_version}...")
-    lines = PYPROJECT.read_text(encoding="utf-8").splitlines()
-    new_lines = []
-    found = False
-    for i, line in enumerate(lines):
-        # Only replace 'version' in the first 15 lines (package metadata)
-        if not found and line.startswith('version = "') and i < 15:
-            new_lines.append(f'version = "{new_version}"')
-            found = True
-        else:
-            new_lines.append(line)
-
-    if not dry_run:
-        PYPROJECT.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    else:
-        print("[DRY RUN] Would write pyproject.toml")
+def ensure_version_alignment() -> str:
+    versions = read_project_versions()
+    if versions["pyproject"] != versions["package"]:
+        raise ValueError(
+            "Version mismatch: pyproject.toml has "
+            f"{versions['pyproject']}, but faigate/__init__.py has {versions['package']}."
+        )
+    return versions["pyproject"]
 
 
-def update_changelog(new_version, dry_run=False):
-    print(f"Updating CHANGELOG.md for {new_version}...")
+def sync_version_files(new_version: str, *, dry_run: bool = False) -> list[Path]:
+    changed: list[Path] = []
+    pyproject_content = PYPROJECT.read_text(encoding="utf-8")
+    package_content = PACKAGE_INIT.read_text(encoding="utf-8")
+
+    new_pyproject = _replace_first(
+        r'^version = "[^"]+"$',
+        f'version = "{new_version}"',
+        pyproject_content,
+        path=PYPROJECT,
+    )
+    new_package = _replace_first(
+        r'^__version__ = "[^"]+"$',
+        f'__version__ = "{new_version}"',
+        package_content,
+        path=PACKAGE_INIT,
+    )
+
+    if new_pyproject != pyproject_content:
+        changed.append(PYPROJECT)
+        if not dry_run:
+            PYPROJECT.write_text(new_pyproject, encoding="utf-8")
+    if new_package != package_content:
+        changed.append(PACKAGE_INIT)
+        if not dry_run:
+            PACKAGE_INIT.write_text(new_package, encoding="utf-8")
+    return changed
+
+
+def update_changelog(new_version: str, *, dry_run: bool = False) -> bool:
     today = date.today().isoformat()
     content = CHANGELOG.read_text(encoding="utf-8")
-
-    # Look for a placeholder or the latest version section
-    # If v1.11.0 is already there (manually added), we just ensure the date is correct
     version_pattern = rf"## v{re.escape(new_version)} - \d{{4}}-\d{{2}}-\d{{2}}"
     if re.search(version_pattern, content):
         new_content = re.sub(version_pattern, f"## v{new_version} - {today}", content)
     else:
-        # Insert a new section at the top (after the header)
-        header_end = content.find("\n\n") + 2
+        header_end = content.find("\n\n")
+        if header_end == -1:
+            raise ValueError("CHANGELOG.md is missing the expected intro header block")
+        header_end += 2
         new_section = f"## v{new_version} - {today}\n\n### Added\n\n- (New release baseline)\n\n"
         new_content = content[:header_end] + new_section + content[header_end:]
 
+    if new_content == content:
+        return False
     if not dry_run:
         CHANGELOG.write_text(new_content, encoding="utf-8")
-    else:
-        print("[DRY RUN] Would write CHANGELOG.md")
+    return True
 
 
-def update_formula(new_version, dry_run=False):
-    if not FORMULA.exists():
-        print(f"Skipping formula update: {FORMULA} not found")
-        return
-
-    print(f"Updating Homebrew formula to {new_version}...")
-    content = FORMULA.read_text(encoding="utf-8")
-    
-    # Update version
-    new_content = re.sub(r'version "([^"]+)"', f'version "{new_version}"', content)
-    # Update URL (assuming standard tag URL)
-    new_content = re.sub(
-        r'url "https://github.com/fusionAIze/faigate/archive/refs/tags/v[^"]+\.tar\.gz"',
-        f'url "https://github.com/fusionAIze/faigate/archive/refs/tags/v{new_version}.tar.gz"',
-        new_content
+def is_worktree_dirty() -> bool:
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
     )
-    # Note: sha256 update usually requires a downloaded tarball from the future tag.
-    # We will leave a comment reminder.
-    if 'sha256' in new_content:
-        new_content = re.sub(r'(sha256 "[^"]+")', r'\1 # IMPORTANT: Update this after tagging!', new_content, count=1)
-
-    if not dry_run:
-        FORMULA.write_text(new_content, encoding="utf-8")
-    else:
-        print("[DRY RUN] Would write Formula/faigate.rb")
+    return bool(result.stdout.strip())
 
 
-def verify_local(dry_run=False):
-    if dry_run:
-        print("[DRY RUN] Skipping local verification")
+def verify_local(*, dry_run: bool = False, skip_verify: bool = False) -> bool:
+    if dry_run or skip_verify:
+        return True
+    if not VERIFY_SCRIPT.exists():
+        print("Warning: scripts/faigate-verify not found; skipping local verification.")
         return True
 
-    print("Running local verification script...")
-    verify_script = ROOT / "scripts" / "faigate-verify"
-    if not verify_script.exists():
-        print("Warning: faigate-verify script not found!")
-        return True
-
-    # Use sys.executable to ensure we use the same python environment
-    result = subprocess.run([sys.executable, str(verify_script)], cwd=ROOT)
+    result = subprocess.run([sys.executable, str(VERIFY_SCRIPT)], cwd=ROOT)
     return result.returncode == 0
 
 
-def main():
-    parser = argparse.ArgumentParser(description="faigate release tool")
-    parser.add_argument("--version", help="New version number (e.g., 1.11.0)")
-    parser.add_argument("--dry-run", action="store_true", help="Don't write any files")
-    args = parser.parse_args()
+def render_next_steps(new_version: str) -> list[str]:
+    return [
+        f"git add {PYPROJECT.relative_to(ROOT)} {PACKAGE_INIT.relative_to(ROOT)} {CHANGELOG.relative_to(ROOT)}",
+        f'git commit -m "chore: release v{new_version}"',
+        f'git tag -a v{new_version} -m "fusionAIze Gate v{new_version}"',
+        "git push origin main --tags",
+        f"Publish the GitHub Release for v{new_version}; notify-tap will dispatch the Homebrew update to {TAP_REPO_URL}.",
+    ]
 
-    try:
-        current = get_current_version()
-        print(f"Current version: {current}")
 
-        if not args.version:
-            # Simple auto-bump (patch) if no version provided
-            parts = current.split(".")
-            parts[-1] = str(int(parts[-1]) + 1)
-            new_version = ".".join(parts)
-            print(f"No version provided, proposing auto-bump: {new_version}")
-        else:
-            new_version = args.version
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare a fusionAIze Gate release bump.")
+    parser.add_argument("--version", help="New version number (for example 1.11.3)")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without writing files")
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow release prep to run even when the git worktree is dirty",
+    )
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the local release verification helper",
+    )
+    return parser.parse_args()
 
-        print(f"Target version: {new_version}")
 
-        # Safety check first!
-        if not verify_local(args.dry_run):
-            print("\n❌ Local verification failed! Aborting release.")
-            sys.exit(1)
+def main() -> int:
+    args = parse_args()
+    current_version = ensure_version_alignment()
+    print(f"Current version: {current_version}")
 
-        bump_version(new_version, args.dry_run)
-        update_changelog(new_version, args.dry_run)
-        update_formula(new_version, args.dry_run)
+    if not args.version:
+        parts = current_version.split(".")
+        parts[-1] = str(int(parts[-1]) + 1)
+        new_version = ".".join(parts)
+        print(f"No version provided, proposing patch bump: {new_version}")
+    else:
+        new_version = args.version
+    new_version = validate_version(new_version)
+    print(f"Target version: {new_version}")
 
-        print("\nRelease preparation complete.")
-        print("Next steps:")
-        print(f"1. git add .")
-        print(f"2. git commit -m \"chore: release v{new_version}\"")
-        print(f"3. git tag v{new_version}")
-        print(f"4. git push origin main --tags")
-        print(f"5. Update the sha256 in Formula/faigate.rb after the archive is available.")
+    if is_worktree_dirty() and not (args.allow_dirty or args.dry_run):
+        raise SystemExit(
+            "Refusing to prepare a release from a dirty worktree. Commit or stash changes, "
+            "or rerun with --allow-dirty if you really intend that."
+        )
 
-    except Exception as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    if not verify_local(dry_run=args.dry_run, skip_verify=args.skip_verify):
+        raise SystemExit("Local verification failed; aborting release preparation.")
+
+    changed_files = sync_version_files(new_version, dry_run=args.dry_run)
+    changelog_changed = update_changelog(new_version, dry_run=args.dry_run)
+
+    if args.dry_run:
+        print("[DRY RUN] Would update:")
+        for path in changed_files:
+            print(f"  - {path.relative_to(ROOT)}")
+        if changelog_changed:
+            print(f"  - {CHANGELOG.relative_to(ROOT)}")
+    else:
+        print("Updated:")
+        for path in changed_files:
+            print(f"  - {path.relative_to(ROOT)}")
+        if changelog_changed:
+            print(f"  - {CHANGELOG.relative_to(ROOT)}")
+
+    print("\nNext steps:")
+    for index, step in enumerate(render_next_steps(new_version), start=1):
+        print(f"{index}. {step}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/faigate-verify
+++ b/scripts/faigate-verify
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""
-faigate-verify: Simulate GitHub Actions checks locally.
-"""
+"""Run the local checks that should stay aligned with release publishing."""
 
-import os
+from __future__ import annotations
+
+import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -11,89 +12,83 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent.resolve()
 
 
-def run(cmd, cwd=ROOT, env=None):
+def run(cmd: list[str], *, cwd: Path = ROOT) -> bool:
     print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=env)
-    if result.returncode != 0:
-        print(f"FAILED: {' '.join(cmd)}")
-        if result.stdout:
-            print(result.stdout)
-        if result.stderr:
-            print(result.stderr)
-        return False
-    return True
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if result.returncode == 0:
+        return True
+    print(f"FAILED: {' '.join(cmd)}")
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+    return False
 
 
-def check_repo_safety():
-    print("Checking repo safety (forbidden files)...")
-    # Simulation of repo-safety.yml
-    # git ls-files | egrep '(^\.ssh/|\.db($|-)|\.sqlite|\.log$)'
+def check_repo_safety() -> bool:
+    print("Checking repo safety (forbidden tracked files)...")
     try:
         files = subprocess.check_output(["git", "ls-files"], cwd=ROOT, text=True).splitlines()
-        forbidden_patterns = [r"^\.ssh/", r"\.db($|-)", r"\.sqlite", r"\.log$"]
-        import re
-        
-        failed = False
-        for f in files:
-            for p in forbidden_patterns:
-                if re.search(p, f):
-                    print(f"ERROR: Forbidden file tracked: {f}")
-                    failed = True
-        return not failed
-    except Exception as e:
-        print(f"Error checking repo safety: {e}")
+    except Exception as exc:
+        print(f"Error checking repo safety: {exc}")
         return False
 
+    forbidden_patterns = [r"^\.ssh/", r"\.db($|-)", r"\.sqlite", r"\.log$"]
+    failed = False
+    for path in files:
+        for pattern in forbidden_patterns:
+            if re.search(pattern, path):
+                print(f"ERROR: Forbidden file tracked: {path}")
+                failed = True
+    return not failed
 
-def main():
+
+def main() -> int:
     success = True
 
-    # 1. Ruff check
-    if not run(["ruff", "check", "."]):
-        success = False
+    python = sys.executable
+    dist_dir = ROOT / "dist"
+    shutil.rmtree(dist_dir, ignore_errors=True)
 
-    # 2. Ruff format check
-    if not run(["ruff", "format", "--check", "."]):
-        success = False
-
-    # 3. Pytest
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(ROOT)
-    if not run(["pytest", "tests/"], env=env):
-        success = False
-
-    # 4. Bash syntax check
-    scripts = list((ROOT / "scripts").glob("*"))
-    for s in scripts:
-        if not s.is_file():
-            continue
-            
-        # Skip Python files (by extension or shebang)
-        if s.suffix == ".py":
-            continue
-            
-        try:
-            with open(s, "r") as f:
-                first_line = f.readline()
-                if "python" in first_line:
-                    continue
-        except Exception:
-            pass
-
-        if not run(["bash", "-n", str(s)]):
+    commands = [
+        [python, "-m", "ruff", "check", "."],
+        [python, "-m", "ruff", "format", "--check", "."],
+        [python, "-m", "pytest", "tests/"],
+        [python, "-m", "build"],
+    ]
+    for command in commands:
+        if not run(command):
             success = False
 
-    # 5. Repo safety
+    dist_files = sorted(str(path) for path in dist_dir.glob("*"))
+    if dist_files:
+        if not run([python, "-m", "twine", "check", *dist_files]):
+            success = False
+    else:
+        print("FAILED: python -m twine check dist/*")
+        print("dist/ is empty after build")
+        success = False
+
+    for script in sorted((ROOT / "scripts").iterdir()):
+        if not script.is_file():
+            continue
+        if script.suffix == ".py":
+            continue
+        first_line = script.read_text(encoding="utf-8", errors="ignore").splitlines()[:1]
+        if first_line and "python" in first_line[0]:
+            continue
+        if not run(["bash", "-n", str(script)]):
+            success = False
+
     if not check_repo_safety():
         success = False
 
     if success:
-        print("\n✅ All checks passed locally!")
-        sys.exit(0)
-    else:
-        print("\n❌ Some checks failed. Please fix them before committing.")
-        sys.exit(1)
+        print("\nAll release verification checks passed.")
+        return 0
+    print("\nRelease verification failed.")
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+def _load_release_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "faigate-release"
+    loader = SourceFileLoader("faigate_release", str(script_path))
+    spec = importlib.util.spec_from_loader("faigate_release", loader)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_script_rejects_invalid_versions():
+    module = _load_release_module()
+
+    assert module.validate_version("1.11.3") == "1.11.3"
+    try:
+        module.validate_version("v1.11.3")
+    except ValueError as exc:
+        assert "Expected x.y.z" in str(exc)
+    else:
+        raise AssertionError("Expected invalid version to raise")
+
+
+def test_release_script_syncs_pyproject_and_package_version(tmp_path, monkeypatch):
+    module = _load_release_module()
+    pyproject = tmp_path / "pyproject.toml"
+    package_init = tmp_path / "__init__.py"
+    pyproject.write_text('[project]\nversion = "1.11.2"\n', encoding="utf-8")
+    package_init.write_text('__version__ = "1.11.2"\n', encoding="utf-8")
+
+    monkeypatch.setattr(module, "PYPROJECT", pyproject)
+    monkeypatch.setattr(module, "PACKAGE_INIT", package_init)
+
+    changed = module.sync_version_files("1.11.3")
+
+    assert pyproject.read_text(encoding="utf-8") == '[project]\nversion = "1.11.3"\n'
+    assert package_init.read_text(encoding="utf-8") == '__version__ = "1.11.3"\n'
+    assert pyproject in changed
+    assert package_init in changed
+
+
+def test_release_script_updates_changelog_header(tmp_path, monkeypatch):
+    module = _load_release_module()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## Unreleased\n\n- Keep going\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "CHANGELOG", changelog)
+
+    changed = module.update_changelog("1.11.3")
+
+    content = changelog.read_text(encoding="utf-8")
+    assert changed is True
+    assert "## v1.11.3 -" in content
+    assert "### Added" in content
+
+
+def test_release_script_next_steps_reference_tap_repo():
+    module = _load_release_module()
+
+    steps = module.render_next_steps("1.11.3")
+
+    assert 'git tag -a v1.11.3 -m "fusionAIze Gate v1.11.3"' in steps[2]
+    assert "homebrew-tap" in steps[-1]
+    assert "Formula/faigate.rb" not in steps[-1]


### PR DESCRIPTION
## Summary
- harden the local release helper and verification flow
- validate release tags against package versions in CI
- publish PyPI from prebuilt artifacts and document the tap handoff

## Testing
- python3 -m py_compile scripts/faigate-release scripts/faigate-verify
- env PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_release_scripts.py
- python3 scripts/faigate-release --dry-run --version 1.11.3 --allow-dirty --skip-verify