### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # fusionAIze Gate Changelog
 
-## v1.12.0 - Unreleased
+## v1.12.0 - 2026-03-29
 
 ### Added
 

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.11.2"
+__version__ = "1.12.0"

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -1810,7 +1810,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="fusionAIze Gate",
-    version="1.11.2",
+    version=__version__,
     description="Local OpenAI-compatible routing gateway for OpenClaw and other clients.",
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.11.2"
+version = "1.12.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/faigate-release
+++ b/scripts/faigate-release
@@ -96,7 +96,10 @@ def update_changelog(new_version: str, *, dry_run: bool = False) -> bool:
     today = date.today().isoformat()
     content = CHANGELOG.read_text(encoding="utf-8")
     version_pattern = rf"## v{re.escape(new_version)} - \d{{4}}-\d{{2}}-\d{{2}}"
-    if re.search(version_pattern, content):
+    unreleased_pattern = rf"## v{re.escape(new_version)} - Unreleased"
+    if re.search(unreleased_pattern, content):
+        new_content = re.sub(unreleased_pattern, f"## v{new_version} - {today}", content)
+    elif re.search(version_pattern, content):
         new_content = re.sub(version_pattern, f"## v{new_version} - {today}", content)
     else:
         header_end = content.find("\n\n")
@@ -136,19 +139,32 @@ def verify_local(*, dry_run: bool = False, skip_verify: bool = False) -> bool:
 
 
 def render_next_steps(new_version: str) -> list[str]:
+    add_targets = " ".join(
+        str(path.relative_to(ROOT))
+        for path in (PYPROJECT, PACKAGE_INIT, CHANGELOG)
+    )
     return [
-        f"git add {PYPROJECT.relative_to(ROOT)} {PACKAGE_INIT.relative_to(ROOT)} {CHANGELOG.relative_to(ROOT)}",
+        f"git add {add_targets}",
         f'git commit -m "chore: release v{new_version}"',
         f'git tag -a v{new_version} -m "fusionAIze Gate v{new_version}"',
         "git push origin main --tags",
-        f"Publish the GitHub Release for v{new_version}; notify-tap will dispatch the Homebrew update to {TAP_REPO_URL}.",
+        (
+            f"Publish the GitHub Release for v{new_version}; notify-tap will dispatch "
+            f"the Homebrew update to {TAP_REPO_URL}."
+        ),
     ]
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Prepare a fusionAIze Gate release bump.")
+    parser = argparse.ArgumentParser(
+        description="Prepare a fusionAIze Gate release bump."
+    )
     parser.add_argument("--version", help="New version number (for example 1.11.3)")
-    parser.add_argument("--dry-run", action="store_true", help="Print changes without writing files")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print changes without writing files",
+    )
     parser.add_argument(
         "--allow-dirty",
         action="store_true",

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -8,6 +8,10 @@ import pytest
 import faigate.main as main_module
 
 
+def test_fastapi_app_version_matches_package_version():
+    assert main_module.app.version == main_module.__version__
+
+
 def test_main_uses_explicit_config_arg(monkeypatch):
     captured: dict[str, object] = {}
 

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -61,6 +61,25 @@ def test_release_script_updates_changelog_header(tmp_path, monkeypatch):
     assert "### Added" in content
 
 
+def test_release_script_promotes_existing_version_unreleased_section(tmp_path, monkeypatch):
+    module = _load_release_module()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## v1.12.0 - Unreleased\n\n### Added\n\n- Keep going\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "CHANGELOG", changelog)
+
+    changed = module.update_changelog("1.12.0")
+
+    content = changelog.read_text(encoding="utf-8")
+    assert changed is True
+    assert "## v1.12.0 - Unreleased" not in content
+    assert "## v1.12.0 -" in content
+    assert content.count("## v1.12.0 -") == 1
+
+
 def test_release_script_next_steps_reference_tap_repo():
     module = _load_release_module()
 


### PR DESCRIPTION
Summary:\n- prepare the v1.12.0 release bump\n- keep FastAPI app version tied to __version__ so release bumps do not drift again\n- harden the release helper around an existing version-specific Unreleased changelog block\n\nTesting:\n- rtk ruff check scripts/faigate-release tests/test_release_scripts.py faigate/main.py tests/test_main_cli.py\n- env PYTHONPATH=. ./.venv-check-313/bin/pytest -q tests/test_release_scripts.py tests/test_main_cli.py\n- python3 -m py_compile scripts/faigate-release scripts/faigate-verify\n- python3 scripts/faigate-release --version 1.12.0 --dry-run