### PR TITLE
Bump version to v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # fusionAIze Gate Changelog
 
+## v1.20.0 - 2026-04-02
+
+### Added
+
+- External metadata integration: promotion alerts, source badges, provider-mix analytics endpoint (Issue #186)
+- Route explainability dashboard and metrics: route_summary column, decision history panel, why_selected and alternatives display (Issue #188)
+- Added `/api/analytics/provider-mix` endpoint for comparing providers based on external catalog pricing
+- Enhanced dashboard Routes view with "Route decision history" table showing routing explanations
+- Added `route_summary` field to metrics DB and `/api/traces` endpoint
+
+### Changed
+
+- Updated config.yaml metrics db_path default to `./faigate.db` and enabled metrics by default
+- Extended `_build_route_summary` function to populate why_selected and alternatives
+- Updated all six `log_request` calls to include route_summary
+
+### Fixed
+
+- No breaking changes; existing routing behavior remains compatible
+
 ## v1.17.0 - 2026-04-01
 
 ### Added

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "1.18.0"
+__version__ = "1.20.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "1.18.0"
+version = "1.20.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Update pyproject.toml version to 1.20.0
- Update faigate/__init__.py __version__ to 1.20.0
- Update CHANGELOG.md with v1.20.0 release notes

## Related Issues
Part of #188 (Route Explainability) and #186 (External metadata integration)

## Testing
- No functional changes, only version bump and documentation