### PR TITLE
chore: release v2.2.0

### DIFF
--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "2.1.6"
+__version__ = "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "2.1.6"
+version = "2.2.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the quota-tracking feature release shipped in #210.

Changes:
- \`faigate/__init__.py\`: \`__version__ = "2.2.0"\`
- \`pyproject.toml\`: \`version = "2.2.0"\`

Once merged, tag \`v2.2.0\` on main and push it — that kicks off \`.github/workflows/release-artifacts.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)