### PR TITLE
chore: release v2.2.1 — packaging robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # fusionAIze Gate Changelog
 
+## v2.2.1 - 2026-04-18
+
+### Fixed
+
+- **Slow `brew upgrade` / `pip install` caused by source-only pydantic-core**: `pyproject.toml` now caps `pydantic`, `fastapi`, `httpx`, and `uvicorn` to version ranges that ship prebuilt wheels for all supported Python versions (3.10–3.13) and platforms (incl. macOS 15 Tahoe arm64). Without these caps pip could drift onto a bleeding-edge pydantic-core release with no wheel, forcing a 3–5 minute Rust/cargo source build during upgrade. This is a packaging-only change — no runtime behavior difference.
+
 ## v2.2.0 - 2026-04-18
 
 ### Added

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "2.2.0"
+version = "2.2.1"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,9 +22,14 @@ classifiers = [
     "Topic :: Internet :: Proxy Servers",
 ]
 dependencies = [
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.32.0",
-    "httpx>=0.27.0",
+    # Upper bounds on fastapi/pydantic/httpx keep us on versions that ship
+    # prebuilt wheels (esp. pydantic-core) for all supported Python/macOS/Linux
+    # combinations. Without these caps, `brew upgrade` and fresh `pip install`
+    # can drift onto source-only releases and trigger a 3–5 min cargo build.
+    "fastapi>=0.115.0,<0.120",
+    "uvicorn[standard]>=0.32.0,<0.40",
+    "httpx>=0.27.0,<0.29",
+    "pydantic>=2.9,<2.14",
     "pyyaml>=6.0.2",
     "python-dotenv>=1.0.1",
     "python-multipart>=0.0.9",


### PR DESCRIPTION
## Summary

- Caps `pydantic`, `fastapi`, `httpx`, `uvicorn` to version ranges that ship prebuilt wheels for Python 3.10–3.13 across linux/macos (incl. Tahoe arm64)
- Bumps `__version__` + `pyproject.toml` to `2.2.1`
- CHANGELOG entry documenting the packaging-only fix

## Why

Fresh `brew upgrade faigate` post-2.2.0 hung for 3–5 min on a Rust/cargo build of `pydantic-core 2.46.2` (no wheel for macOS 15 Tahoe arm64). Caps keep pip on wheel-friendly versions so upgrades stay < 1 min.

No runtime behavior change — pure packaging robustness.

## Test plan

- [ ] CI green across 3.10 / 3.11 / 3.12 / 3.13
- [ ] Tag `v2.2.1` after merge triggers release-artifacts workflow
- [ ] Next `brew upgrade faigate` completes in < 1 min on Tahoe arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)