### PR TITLE
docs(release): require explicit `--title` and re-run notify-tap on edits

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -5,7 +5,7 @@
 - [ ] Version number and release tag are aligned (for example `v0.5.0`)
 - [ ] Version tag is created from `main`
 - [ ] Tag is pushed to GitHub
-- [ ] GitHub Release is created from the tag
+- [ ] GitHub Release is created from the tag with title `fusionAIze Gate vX.Y.Z` (notify-tap rejects any other shape)
 - [ ] Release artifacts workflow completed for Python distributions and GHCR image
 - [ ] Release notes summarize user-visible changes
 - [ ] README and relevant docs pages match the shipped behavior

--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -2,7 +2,10 @@ name: Notify Homebrew Tap
 
 on:
   release:
-    types: [published]
+    # `edited` lets a `gh release edit --title` retroactively unblock the
+    # title-convention check after a `published` event failed validation,
+    # without needing to delete and recreate the release.
+    types: [published, edited]
 
 jobs:
   notify:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,7 +13,8 @@ This repo does not require a heavy release process. Use lightweight tags plus Gi
    - This is the trigger for the release pipeline: `.github/workflows/release-artifacts.yml` runs on `push` for tags matching `v*`.
 5. Let the release-artifacts workflow build Python distributions and the GHCR image.
 6. Create a GitHub Release from that tag.
-   - Publishing the GitHub Release is the separate trigger for `.github/workflows/notify-tap.yml`.
+   - The release title must be exactly `fusionAIze Gate vX.Y.Z` — `notify-tap` validates it and refuses to dispatch the Homebrew update otherwise. When using the `gh` CLI, always pass `--title` explicitly because some `gh` versions default the title to just the tag name (`vX.Y.Z`) when only `--notes-from-tag` is given.
+   - Publishing the GitHub Release is the separate trigger for `.github/workflows/notify-tap.yml`. The same workflow also runs on `edited`, so a `gh release edit --title` on an existing release is enough to retroactively unblock the dispatch.
 7. Use the changelog entry as the release notes, then add any short upgrade notes if needed.
 8. Confirm that README plus the relevant docs pages still match the shipped runtime behavior.
 9. If packaging or Docker changed shortly before the release, run the publish dry run first.
@@ -31,7 +32,19 @@ git tag -a v1.8.0 -m "fusionAIze Gate v1.8.0"
 git push origin v1.8.0
 ```
 
-Then open GitHub Releases and publish a release for `v1.8.0`.
+Then publish a GitHub Release for `v1.8.0`. From the CLI, always pass `--title` so the title matches the convention `notify-tap` enforces:
+
+```bash
+gh release create v1.8.0 \
+  --title "fusionAIze Gate v1.8.0" \
+  --notes-from-tag
+```
+
+If a release was already published with the wrong title, fix it in place — `notify-tap` re-runs on `edited`:
+
+```bash
+gh release edit v1.8.0 --title "fusionAIze Gate v1.8.0"
+```
 
 The tag push should trigger the release-artifacts bot automatically. Publishing the GitHub Release should then trigger the tap notification automatically. If the tap still needs a manual follow-up, use [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap):
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -48,8 +48,9 @@ The real publish flow stays tag-driven through [release-artifacts](../.github/wo
 4. push the tag
    - this is the release-bot trigger; `.github/workflows/release-artifacts.yml` runs automatically for `v*` tags
 5. let `release-artifacts` validate the tag/version match, build Python distributions, and push the GHCR image
-6. publish the GitHub Release
-   - this is the separate tap trigger; `.github/workflows/notify-tap.yml` runs when the release is published
+6. publish the GitHub Release with the title `fusionAIze Gate vX.Y.Z`
+   - this is the separate tap trigger; `.github/workflows/notify-tap.yml` runs when the release is `published` or `edited`
+   - `notify-tap` rejects any other title shape, so when using `gh release create` always pass `--title "fusionAIze Gate vX.Y.Z"` alongside `--notes-from-tag`; some `gh` versions otherwise default the title to just the tag name and fail validation
 7. let `notify-tap` dispatch the Homebrew update to [`fusionAIze/homebrew-tap`](https://github.com/fusionAIze/homebrew-tap)
 8. optionally allow PyPI publication through trusted publishing
 9. publish the separate npm CLI package only when you are ready to version the Node-facing surface independently

--- a/scripts/faigate-release
+++ b/scripts/faigate-release
@@ -149,8 +149,11 @@ def render_next_steps(new_version: str) -> list[str]:
         f'git tag -a v{new_version} -m "fusionAIze Gate v{new_version}"',
         "git push origin main --tags",
         (
-            f"Publish the GitHub Release for v{new_version}; notify-tap will dispatch "
-            f"the Homebrew update to {TAP_REPO_URL}."
+            f'gh release create v{new_version} --title "fusionAIze Gate v{new_version}" '
+            f"--notes-from-tag  # title must match exactly; notify-tap rejects bare 'v{new_version}'"
+        ),
+        (
+            f"After publishing, notify-tap will dispatch the Homebrew update to {TAP_REPO_URL}."
         ),
     ]
 

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -88,3 +88,16 @@ def test_release_script_next_steps_reference_tap_repo():
     assert 'git tag -a v1.11.3 -m "fusionAIze Gate v1.11.3"' in steps[2]
     assert "homebrew-tap" in steps[-1]
     assert "Formula/faigate.rb" not in steps[-1]
+
+
+def test_release_script_next_steps_specify_release_title():
+    """notify-tap rejects any title other than 'fusionAIze Gate vX.Y.Z',
+    so the rendered `gh release create` step must pass --title explicitly."""
+    module = _load_release_module()
+
+    steps = module.render_next_steps("1.11.3")
+    gh_step = next((s for s in steps if "gh release create" in s), None)
+
+    assert gh_step is not None, "expected a `gh release create` step"
+    assert '--title "fusionAIze Gate v1.11.3"' in gh_step
+    assert "--notes-from-tag" in gh_step


### PR DESCRIPTION
## Summary

- `notify-tap` validates the GitHub Release title against `fusionAIze Gate vX.Y.Z`. Some `gh` versions default the title to just the tag name (`vX.Y.Z`) when only `--notes-from-tag` is given, which silently breaks the Homebrew tap dispatch. The v2.3.0 release tripped this twice today.
- Docs (`RELEASES.md`, `docs/PUBLISHING.md`, `.github/RELEASE_TEMPLATE.md`) now explicitly require the `--title` flag, and `scripts/faigate-release` surfaces the full `gh release create` command in its next-steps output with a test that locks in the convention.
- `.github/workflows/notify-tap.yml` now also runs on `release: edited`, so a `gh release edit --title` after the fact unblocks the dispatch without needing a delete + recreate.

## Test plan

- [x] `pytest tests/test_release_scripts.py` (all 6 pass, including the new title-shape assertion)
- [x] Full `pytest -q` run — pre-existing 13 `ruamel`-import failures in `test_dashboard_settings.py` / `test_metrics_traces.py` are unrelated to this change
- [ ] Next release: confirm `gh release create` renders the full `fusionAIze Gate vX.Y.Z` title and that `notify-tap` dispatches on first try
- [ ] Optional: edit the v2.3.0 release title in place and confirm the new `edited` trigger fires the dispatch retroactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)