### PR TITLE
Release v2.4.0 with metadata catalog refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # fusionAIze Gate Changelog
 
+## v2.4.0 - 2026-04-26
+
+### Added
+
+- **Metadata catalog sync loop**: the gateway now runs a lazy startup refresh plus an optional 24h background tick for the public/private metadata catalog. Failed syncs back off through 5m/15m/1h windows and persist sync state alongside the cached catalog.
+- **Catalog sync alerts**: provider catalog, health, dashboard, and API surfaces now feed sync failures, stale caches, invalid payloads, and auth issues through the existing `build_catalog_alerts` alert path.
+- **Kilo Auto profile examples**: the shipped config and OpenCode example now expose `kilo-auto/frontier`, `kilo-auto/balanced`, `kilo-auto/free`, and `kilo-auto/small` for FAIGate-backed OpenCode/Codenomad use.
+- **Fresh bundled catalog snapshot**: refreshed the embedded metadata catalog with newly verified Opus 4.7, Haiku 4.5, GPT-5.5, DeepSeek V4, and OpenRouter Auto pricing metadata.
+
 ## v2.3.0 - 2026-04-19
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,11 @@ auto_update:
     enabled: false
     rollback_command: ''
     timeout_seconds: 30
+metadata:
+  enabled: true
+  on_startup: false
+  refresh_interval_hours: 24
+  timeout_seconds: 10
 client_profiles:
   default: generic
   enabled: true
@@ -782,6 +787,58 @@ providers:
     max_tokens: 8000
     model: z-ai/glm-5:free
     tier: fallback
+    timeout:
+      connect_s: 10
+      read_s: 60
+  kilo-auto/frontier:
+    api_key: ${KILOCODE_API_KEY}
+    backend: openai-compat
+    base_url: ${KILOCODE_BASE_URL:-https://api.kilo.ai/api/gateway}
+    capabilities:
+      cost_tier: premium
+      latency_tier: balanced
+    max_tokens: 32000
+    model: kilo-auto/frontier
+    tier: premium
+    timeout:
+      connect_s: 10
+      read_s: 120
+  kilo-auto/balanced:
+    api_key: ${KILOCODE_API_KEY}
+    backend: openai-compat
+    base_url: ${KILOCODE_BASE_URL:-https://api.kilo.ai/api/gateway}
+    capabilities:
+      cost_tier: mid
+      latency_tier: balanced
+    max_tokens: 16000
+    model: kilo-auto/balanced
+    tier: mid
+    timeout:
+      connect_s: 10
+      read_s: 90
+  kilo-auto/free:
+    api_key: ${KILOCODE_API_KEY}
+    backend: openai-compat
+    base_url: ${KILOCODE_BASE_URL:-https://api.kilo.ai/api/gateway}
+    capabilities:
+      cost_tier: free
+      latency_tier: balanced
+    max_tokens: 8000
+    model: kilo-auto/free
+    tier: fallback
+    timeout:
+      connect_s: 10
+      read_s: 60
+  kilo-auto/small:
+    api_key: ${KILOCODE_API_KEY}
+    backend: openai-compat
+    base_url: ${KILOCODE_BASE_URL:-https://api.kilo.ai/api/gateway}
+    capabilities:
+      cost_tier: cheap
+      latency_tier: fast
+    max_tokens: 8000
+    model: kilo-auto/small
+    tier: cheap
     timeout:
       connect_s: 10
       read_s: 60

--- a/docs/CATALOG-UPDATER.md
+++ b/docs/CATALOG-UPDATER.md
@@ -107,13 +107,36 @@ print(resolved.source, len(resolved.payload["providers"]))
 # "public", 41
 ```
 
-## Daemon-tick refresh (planned)
+## Daemon-tick refresh
 
-Phase-3 ships the resolver and CLI; the background tick that calls
-`resolver.resolve(force_refresh=True)` every `refresh_interval_hours` is on
-the roadmap (see `docs/blueprints/model-updater/prd.json` task `CODE-007`).
-Until then, refresh happens lazily on the first request after a cache
-miss, plus whenever a developer runs `faigate-models update`.
+The gateway starts a background metadata refresh task when `metadata.enabled`
+is true and `metadata.refresh_interval_hours` is greater than zero. The
+default interval is 24h. Set the interval to `0` to disable the daemon tick
+and rely on lazy cache resolution plus manual `faigate-models update`.
+
+```yaml
+metadata:
+  enabled: true
+  refresh_interval_hours: 24
+  timeout_seconds: 10
+```
+
+Scheduled failures do not crash the gateway. The loop backs off through 5m,
+15m, and 1h retry delays, then returns to the configured interval after a
+successful refresh.
+
+## Sync alerts
+
+Metadata sync state is written next to each cache tier and surfaced through
+the existing catalog alert pipeline:
+
+- `sync-stale` — last successful sync is older than 7 days, or no sync has
+  ever succeeded.
+- `sync-invalid` — remote JSON parsed but failed catalog validation.
+- `sync-auth` — private metadata request returned 401/403.
+
+The alerts appear in `/api/provider-catalog`, dashboard summaries, and any
+surface already consuming `build_catalog_alerts`.
 
 ## Troubleshooting
 

--- a/docs/blueprints/model-updater/prd.json
+++ b/docs/blueprints/model-updater/prd.json
@@ -1,7 +1,7 @@
 {
   "projectName": "faigate-model-updater",
   "version": "1.0",
-  "status": "draft",
+  "status": "ready-for-review",
   "created": "2026-04-26",
   "execution_recommendation": {
     "mode": "complex",
@@ -24,7 +24,9 @@
       "estimatedEffort": "1",
       "dependsOn": [],
       "type": "data",
-      "required_capabilities": ["code_generation"],
+      "required_capabilities": [
+        "code_generation"
+      ],
       "passes": false
     },
     {
@@ -40,8 +42,13 @@
       "estimatedEffort": "1",
       "dependsOn": [],
       "type": "data",
-      "required_capabilities": ["research", "code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "research",
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "INFRA-001",
@@ -56,7 +63,9 @@
       "estimatedEffort": "1",
       "dependsOn": [],
       "type": "infrastructure",
-      "required_capabilities": ["infrastructure"],
+      "required_capabilities": [
+        "infrastructure"
+      ],
       "passes": false
     },
     {
@@ -71,9 +80,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["INFRA-001"],
+      "dependsOn": [
+        "INFRA-001"
+      ],
       "type": "infrastructure",
-      "required_capabilities": ["infrastructure"],
+      "required_capabilities": [
+        "infrastructure"
+      ],
       "passes": false
     },
     {
@@ -87,9 +100,13 @@
       ],
       "priority": "medium",
       "estimatedEffort": "1",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "docs",
-      "required_capabilities": ["code_generation"],
+      "required_capabilities": [
+        "code_generation"
+      ],
       "passes": false
     },
     {
@@ -104,9 +121,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "schema",
-      "required_capabilities": ["code_generation"],
+      "required_capabilities": [
+        "code_generation"
+      ],
       "passes": false
     },
     {
@@ -122,9 +143,14 @@
       ],
       "priority": "high",
       "estimatedEffort": "3",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -139,9 +165,14 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-001"],
+      "dependsOn": [
+        "CODE-001"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -156,9 +187,14 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-002"],
+      "dependsOn": [
+        "CODE-002"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -173,9 +209,15 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["CODE-003", "SCHEMA-001"],
+      "dependsOn": [
+        "CODE-003",
+        "SCHEMA-001"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -190,9 +232,14 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-003"],
+      "dependsOn": [
+        "CODE-003"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -208,9 +255,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-005"],
+      "dependsOn": [
+        "CODE-005"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation"],
+      "required_capabilities": [
+        "code_generation"
+      ],
       "passes": false
     },
     {
@@ -225,10 +276,17 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-005"],
+      "dependsOn": [
+        "CODE-005"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation", "testing"],
-      "passes": false
+      "required_capabilities": [
+        "code_generation",
+        "testing"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "CODE-008",
@@ -241,10 +299,16 @@
       ],
       "priority": "medium",
       "estimatedEffort": "1",
-      "dependsOn": ["CODE-007"],
+      "dependsOn": [
+        "CODE-007"
+      ],
       "type": "feature",
-      "required_capabilities": ["code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "CAT-001",
@@ -258,10 +322,17 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "data",
-      "required_capabilities": ["research", "code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "research",
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "CAT-002",
@@ -274,10 +345,17 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "data",
-      "required_capabilities": ["research", "code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "research",
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "CAT-003",
@@ -290,10 +368,17 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["INFRA-002"],
+      "dependsOn": [
+        "INFRA-002"
+      ],
       "type": "data",
-      "required_capabilities": ["research", "code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "research",
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     },
     {
       "id": "TEST-001",
@@ -307,9 +392,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "2",
-      "dependsOn": ["CODE-007"],
+      "dependsOn": [
+        "CODE-007"
+      ],
       "type": "test",
-      "required_capabilities": ["testing"],
+      "required_capabilities": [
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -324,9 +413,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["CODE-003"],
+      "dependsOn": [
+        "CODE-003"
+      ],
       "type": "test",
-      "required_capabilities": ["testing"],
+      "required_capabilities": [
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -340,9 +433,13 @@
       ],
       "priority": "high",
       "estimatedEffort": "1",
-      "dependsOn": ["CODE-001"],
+      "dependsOn": [
+        "CODE-001"
+      ],
       "type": "test",
-      "required_capabilities": ["testing"],
+      "required_capabilities": [
+        "testing"
+      ],
       "passes": false
     },
     {
@@ -357,10 +454,17 @@
       ],
       "priority": "medium",
       "estimatedEffort": "1",
-      "dependsOn": ["CODE-006", "CODE-007"],
+      "dependsOn": [
+        "CODE-006",
+        "CODE-007"
+      ],
       "type": "docs",
-      "required_capabilities": ["code_generation"],
-      "passes": false
+      "required_capabilities": [
+        "code_generation"
+      ],
+      "passes": true,
+      "completed_at": "2026-04-26",
+      "status": "done"
     }
   ],
   "roadmap": [
@@ -383,6 +487,11 @@
       "id": "ROADMAP-004",
       "title": "Schema v2 with capability matrix per model",
       "rationale": "vision/audio/tools/json-mode flags per model — enables smarter routing"
+    },
+    {
+      "id": "ROADMAP-005",
+      "title": "Outcarve Gate Bar into its own repo/package track",
+      "rationale": "Gate Bar is a useful helper prototype, but keeping the gateway product clean argues for a separate repo and release/cask lifecycle."
     }
   ]
 }

--- a/docs/blueprints/model-updater/progress.txt
+++ b/docs/blueprints/model-updater/progress.txt
@@ -26,12 +26,18 @@ CODE-004, CODE-005, CODE-006, CAT-001, CAT-002, CAT-003, TEST-001, TEST-002,
 TEST-003, DOCS-001, plus the bundled-snapshot piece (added during execution
 when we discovered the wheel had no fallback today).
 
+### Tasks completed in follow-up
+- 2026-04-26 / iter 4 — Completed remaining v1 sync work:
+  CODE-007 daemon tick with 24h default, disable-by-zero config, and
+  5m/15m/1h error backoff; CODE-008 sync alerts via build_catalog_alerts
+  (`sync-stale`, `sync-invalid`, `sync-auth`); HOT-002 OpenRouter audit
+  against official OpenRouter pricing/auto-router docs; pricing verified for
+  Opus 4.7, Haiku 4.5, GPT-5.5, and DeepSeek V4. Bundled snapshot refreshed
+  from the public catalog.
+
 ### Tasks deferred to follow-up
-- HOT-002: openrouter audit (needs live pricing research)
 - INFRA-003: standalone PAT-setup screenshots (covered briefly in
   CATALOG-UPDATER.md; full doc deferred)
-- CODE-007: 24h daemon-tick (lazy refresh + manual CLI works for now)
-- CODE-008: alert integration via build_catalog_alerts
 
 ### Key Decisions
 - D-001 Catalog sync is a NEW layer next to existing ProviderCatalogRefresher,
@@ -51,4 +57,6 @@ when we discovered the wheel had no fallback today).
 ### Open Questions
 - Should we publish a stable Raw URL via githubusercontent.com or use
   jsdelivr CDN from day one? (jsdelivr has better caching but adds dep)
-- Daemon tick interval default — confirm 24h is right for OSS users.
+- Gate Bar should likely be carved out into its own repo/package track; it is
+  useful as a helper prototype, but should not make the gateway core feel like
+  a desktop app repo.

--- a/docs/examples/opencode-faigate.json
+++ b/docs/examples/opencode-faigate.json
@@ -60,6 +60,34 @@
             "context": 128000,
             "output": 8000
           }
+        },
+        "kilo-auto/frontier": {
+          "name": "Kilo Auto Frontier",
+          "limit": {
+            "context": 200000,
+            "output": 32000
+          }
+        },
+        "kilo-auto/balanced": {
+          "name": "Kilo Auto Balanced",
+          "limit": {
+            "context": 200000,
+            "output": 16000
+          }
+        },
+        "kilo-auto/free": {
+          "name": "Kilo Auto Free",
+          "limit": {
+            "context": 128000,
+            "output": 8000
+          }
+        },
+        "kilo-auto/small": {
+          "name": "Kilo Auto Small",
+          "limit": {
+            "context": 128000,
+            "output": 8000
+          }
         }
       }
     }

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"

--- a/faigate/assets/metadata/catalog.v1.json
+++ b/faigate/assets/metadata/catalog.v1.json
@@ -25,16 +25,16 @@
       "official_source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
       "signup_url": "https://console.anthropic.com/",
       "watch_sources": [],
-      "notes": "Anthropic Claude models (Opus, Sonnet, Haiku) - direct API. Recommended bumped to Opus 4.7 on 2026-04-26.",
+      "notes": "Anthropic Claude Opus 4.7 direct API pricing verified from the official Opus page on 2026-04-26.",
       "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://www.anthropic.com/pricing#api",
+        "source_url": "https://www.anthropic.com/claude/opus",
         "refreshed_at": "2026-04-26T00:00:00Z",
-        "freshness_status": "stale",
-        "input_cost_per_1m": 15.0,
-        "output_cost_per_1m": 75.0,
-        "cache_read_cost_per_1m": 1.5
+        "freshness_status": "fresh",
+        "input_cost_per_1m": 5.0,
+        "output_cost_per_1m": 25.0,
+        "cache_read_cost_per_1m": 0.5
       }
     },
     "anthropic-haiku": {
@@ -56,16 +56,16 @@
       "official_source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
       "signup_url": "https://console.anthropic.com/",
       "watch_sources": [],
-      "notes": "Anthropic Claude Haiku 4.5 - fast, cost-effective model for general tasks. Pricing carried forward from 3.5; verify against provider docs.",
+      "notes": "Anthropic Claude Haiku 4.5 pricing verified from the official Haiku page on 2026-04-26.",
       "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://www.anthropic.com/pricing#api",
+        "source_url": "https://www.anthropic.com/claude/haiku",
         "refreshed_at": "2026-04-26T00:00:00Z",
-        "freshness_status": "stale",
-        "input_cost_per_1m": 0.8,
-        "output_cost_per_1m": 4.0,
-        "cache_read_cost_per_1m": 0.08
+        "freshness_status": "fresh",
+        "input_cost_per_1m": 1.0,
+        "output_cost_per_1m": 5.0,
+        "cache_read_cost_per_1m": 0.1
       }
     },
     "anthropic-sonnet": {
@@ -116,16 +116,16 @@
       "official_source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
       "signup_url": "https://console.anthropic.com/",
       "watch_sources": [],
-      "notes": "Anthropic Claude Opus 4.6 - premium reasoning and quality for complex tasks.",
-      "last_reviewed": "2026-04-01",
+      "notes": "Anthropic Claude Opus 4.7 direct API pricing verified from the official Opus page on 2026-04-26.",
+      "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://www.anthropic.com/pricing#api",
-        "refreshed_at": "2026-04-01T12:00:00Z",
+        "source_url": "https://www.anthropic.com/claude/opus",
+        "refreshed_at": "2026-04-26T00:00:00Z",
         "freshness_status": "fresh",
-        "input_cost_per_1m": 15.0,
-        "output_cost_per_1m": 75.0,
-        "cache_read_cost_per_1m": 1.5
+        "input_cost_per_1m": 5.0,
+        "output_cost_per_1m": 25.0,
+        "cache_read_cost_per_1m": 0.5
       }
     },
     "openai": {
@@ -360,11 +360,13 @@
       }
     },
     "deepseek-chat": {
-      "recommended_model": "deepseek-chat",
+      "recommended_model": "deepseek-v4-flash",
       "aliases": [
         "deepseek-chat",
         "ds-v4",
-        "ds-v3"
+        "ds-v3",
+        "deepseek-v4-flash",
+        "deepseek:chat"
       ],
       "track": "stable",
       "offer_track": "direct",
@@ -378,23 +380,25 @@
       "official_source_url": "https://api-docs.deepseek.com/",
       "signup_url": "https://platform.deepseek.com/",
       "watch_sources": [],
-      "notes": "DeepSeek Chat (V4 backing as of 2026-04). API model name stays 'deepseek-chat'; underlying weights/pricing may shift across versions. Verify pricing against api-docs.deepseek.com.",
+      "notes": "DeepSeek V4 Flash pricing verified from official DeepSeek API pricing on 2026-04-26; OpenAI-format base URL remains https://api.deepseek.com.",
       "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
         "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
         "refreshed_at": "2026-04-26T00:00:00Z",
-        "freshness_status": "stale",
+        "freshness_status": "fresh",
         "input_cost_per_1m": 0.14,
         "output_cost_per_1m": 0.28,
-        "cache_read_cost_per_1m": 0.014
+        "cache_read_cost_per_1m": 0.028
       }
     },
     "deepseek-reasoner": {
-      "recommended_model": "deepseek-reasoner",
+      "recommended_model": "deepseek-v4-pro",
       "aliases": [
         "deepseek-reasoner",
-        "r1"
+        "r1",
+        "deepseek-v4-pro",
+        "deepseek:reasoner"
       ],
       "track": "stable",
       "offer_track": "direct",
@@ -408,16 +412,16 @@
       "official_source_url": "https://api-docs.deepseek.com/",
       "signup_url": "https://platform.deepseek.com/",
       "watch_sources": [],
-      "notes": "DeepSeek Reasoner (V4 backing as of 2026-04). High-reasoning model. Verify pricing against api-docs.deepseek.com.",
+      "notes": "DeepSeek V4 Pro pricing verified from official DeepSeek API pricing on 2026-04-26; supports thinking and non-thinking modes.",
       "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
         "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
         "refreshed_at": "2026-04-26T00:00:00Z",
-        "freshness_status": "stale",
-        "input_cost_per_1m": 0.5,
-        "output_cost_per_1m": 1.0,
-        "cache_read_cost_per_1m": 0.05
+        "freshness_status": "fresh",
+        "input_cost_per_1m": 1.74,
+        "output_cost_per_1m": 3.48,
+        "cache_read_cost_per_1m": 0.145
       }
     },
     "blackbox-free": {
@@ -486,7 +490,9 @@
     "openrouter-fallback": {
       "recommended_model": "openrouter/auto",
       "aliases": [
-        "openrouter/auto"
+        "openrouter/auto",
+        "openrouter:auto",
+        "auto-router"
       ],
       "track": "stable",
       "offer_track": "byok",
@@ -497,19 +503,18 @@
       ],
       "volatility": "medium",
       "evidence_level": "official",
-      "official_source_url": "https://openrouter.ai/docs/features/provider-routing",
+      "official_source_url": "https://openrouter.ai/openrouter/auto",
       "signup_url": "https://openrouter.ai/",
       "watch_sources": [],
-      "notes": "OpenRouter fallback path with official provider routing and BYOK support.",
-      "last_reviewed": "2026-04-01",
+      "notes": "OpenRouter Auto Router pricing audited 2026-04-26: openrouter/auto is billed at the routed model rate; OpenRouter states posted model pricing is not marked up and failed/fallback attempts are not billed.",
+      "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://openrouter.ai/pricing",
-        "refreshed_at": "2026-04-01T12:00:00Z",
+        "source_url": "https://openrouter.ai/openrouter/auto",
+        "refreshed_at": "2026-04-26T00:00:00Z",
         "freshness_status": "fresh",
-        "input_cost_per_1m": 0.5,
-        "output_cost_per_1m": 1.5,
-        "cache_read_cost_per_1m": 0.1
+        "routed_model_pricing": true,
+        "platform_fee": "Pay-as-you-go lists a 5.5% platform fee; BYOK has monthly included request allowances, then OpenRouter fee policy applies."
       }
     },
     "openai-codex": {
@@ -533,13 +538,15 @@
       "official_source_url": "https://platform.openai.com/docs/models",
       "signup_url": "https://platform.openai.com/",
       "watch_sources": [],
-      "notes": "OpenAI Codex via OAuth. GPT-5.5-codex ships in 3 reasoning tiers (low/medium/high) — alias suffix selects the tier. Pricing per tier pending verification.",
+      "notes": "OpenAI Codex GPT-5.5 pricing verified from the official GPT-5.5 release page on 2026-04-26. Low/medium/high are reasoning-effort profiles with the same base text-token API price; reasoning tokens are billed as output tokens.",
       "last_reviewed": "2026-04-26",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://openai.com/api/pricing/",
+        "source_url": "https://openai.com/index/introducing-gpt-5-5/",
         "refreshed_at": "2026-04-26T00:00:00Z",
-        "freshness_status": "stale"
+        "freshness_status": "fresh",
+        "input_cost_per_1m": 5.0,
+        "output_cost_per_1m": 30.0
       }
     },
     "opencode": {

--- a/faigate/catalog_cache.py
+++ b/faigate/catalog_cache.py
@@ -30,6 +30,17 @@ class CachedCatalog:
     tier: str
 
 
+@dataclass
+class SyncState:
+    tier: str
+    last_attempt_at: float
+    last_success_at: float | None
+    last_status: str
+    last_error: str
+    success_count: int = 0
+    failure_count: int = 0
+
+
 class CatalogCache:
     """Per-tier filesystem cache. Tier name is e.g. 'public' or 'private'."""
 
@@ -47,6 +58,9 @@ class CatalogCache:
 
     def _lock_path(self, tier: str) -> Path:
         return self._tier_dir(tier) / "catalog.v1.json.lock"
+
+    def _state_path(self, tier: str) -> Path:
+        return self._tier_dir(tier) / "sync-state.json"
 
     def load(self, tier: str) -> CachedCatalog | None:
         path = self._catalog_path(tier)
@@ -107,7 +121,7 @@ class CatalogCache:
         )
 
     def clear(self, tier: str) -> None:
-        for path in (self._catalog_path(tier), self._etag_path(tier)):
+        for path in (self._catalog_path(tier), self._etag_path(tier), self._state_path(tier)):
             if path.exists():
                 path.unlink()
 
@@ -116,6 +130,68 @@ class CatalogCache:
         if not path.exists():
             return None
         return time.time() - path.stat().st_mtime
+
+    def load_state(self, tier: str) -> SyncState | None:
+        path = self._state_path(tier)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("sync state load failed tier=%s err=%s", tier, exc)
+            return None
+        return SyncState(
+            tier=tier,
+            last_attempt_at=float(data.get("last_attempt_at") or 0.0),
+            last_success_at=(float(data["last_success_at"]) if data.get("last_success_at") not in (None, "") else None),
+            last_status=str(data.get("last_status") or ""),
+            last_error=str(data.get("last_error") or ""),
+            success_count=int(data.get("success_count") or 0),
+            failure_count=int(data.get("failure_count") or 0),
+        )
+
+    def save_state(
+        self,
+        tier: str,
+        *,
+        status: str,
+        success: bool,
+        error: str = "",
+        when: float | None = None,
+    ) -> SyncState:
+        tier_dir = self._tier_dir(tier)
+        tier_dir.mkdir(parents=True, exist_ok=True)
+        previous = self.load_state(tier)
+        now = float(when or time.time())
+        state = SyncState(
+            tier=tier,
+            last_attempt_at=now,
+            last_success_at=now if success else (previous.last_success_at if previous else None),
+            last_status=status,
+            last_error="" if success else error,
+            success_count=(previous.success_count if previous else 0) + (1 if success else 0),
+            failure_count=(previous.failure_count if previous else 0) + (0 if success else 1),
+        )
+        path = self._state_path(tier)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(
+                {
+                    "tier": state.tier,
+                    "last_attempt_at": state.last_attempt_at,
+                    "last_success_at": state.last_success_at,
+                    "last_status": state.last_status,
+                    "last_error": state.last_error,
+                    "success_count": state.success_count,
+                    "failure_count": state.failure_count,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, path)
+        return state
 
     @contextmanager
     def _locked(self, tier: str) -> Iterator[None]:

--- a/faigate/catalog_resolver.py
+++ b/faigate/catalog_resolver.py
@@ -41,6 +41,8 @@ ENV_PUBLIC_URL = "FAIGATE_METADATA_PUBLIC_URL"
 ENV_PRIVATE_URL = "FAIGATE_METADATA_PRIVATE_URL"
 ENV_REFRESH_INTERVAL = "FAIGATE_METADATA_REFRESH_INTERVAL_SECONDS"
 
+_SUCCESS_STATUSES = {SyncStatus.FRESH, SyncStatus.NOT_MODIFIED}
+
 
 @dataclass
 class ResolverConfig:
@@ -186,6 +188,12 @@ class CatalogResolver:
             token=token,
             timeout_seconds=self._config.timeout_seconds,
         )
+        self._cache.save_state(
+            tier,
+            status=result.status.value,
+            success=result.status in _SUCCESS_STATUSES,
+            error=result.error,
+        )
 
         if result.status == SyncStatus.FRESH and result.payload is not None:
             saved = self._cache.save(tier, result.payload, result.etag)
@@ -242,6 +250,17 @@ class CatalogResolver:
                 "age_seconds": time.time() - cached.written_at,
                 "providers_count": len(cached.payload.get("providers", {})),
             }
+            state = self._cache.load_state(tier)
+            if state is not None:
+                out["tiers"][tier]["sync"] = {
+                    "last_attempt_at": state.last_attempt_at,
+                    "last_success_at": state.last_success_at,
+                    "last_status": state.last_status,
+                    "last_error": state.last_error,
+                    "success_count": state.success_count,
+                    "failure_count": state.failure_count,
+                    "seconds_since_success": (time.time() - state.last_success_at if state.last_success_at else None),
+                }
         bundled = _load_bundled_snapshot()
         out["bundled_present"] = bundled is not None
         if bundled is not None:

--- a/faigate/config.py
+++ b/faigate/config.py
@@ -1838,6 +1838,41 @@ def _normalize_provider_source_refresh(data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _normalize_metadata_sync(data: dict[str, Any]) -> dict[str, Any]:
+    raw = data.get("metadata") or {}
+    if not isinstance(raw, dict):
+        raise ConfigError("'metadata' must be a mapping")
+
+    refresh_interval_hours = raw.get("refresh_interval_hours", 24)
+    if isinstance(refresh_interval_hours, bool) or not isinstance(refresh_interval_hours, int | float):
+        raise ConfigError("'metadata.refresh_interval_hours' must be a number")
+    if float(refresh_interval_hours) < 0:
+        raise ConfigError("'metadata.refresh_interval_hours' must be non-negative")
+
+    timeout_seconds = raw.get("timeout_seconds", 10.0)
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, int | float):
+        raise ConfigError("'metadata.timeout_seconds' must be a number")
+    if float(timeout_seconds) <= 0:
+        raise ConfigError("'metadata.timeout_seconds' must be positive")
+
+    public_url = raw.get("public_catalog_url", "")
+    private_url = raw.get("private_catalog_url", "")
+    for key, value in (("public_catalog_url", public_url), ("private_catalog_url", private_url)):
+        if value not in ("", None) and not isinstance(value, str):
+            raise ConfigError(f"'metadata.{key}' must be a string")
+
+    normalized = dict(data)
+    normalized["metadata"] = {
+        "enabled": bool(raw.get("enabled", True)),
+        "public_catalog_url": str(public_url or "").strip(),
+        "private_catalog_url": str(private_url or "").strip(),
+        "refresh_interval_hours": float(refresh_interval_hours),
+        "timeout_seconds": float(timeout_seconds),
+        "on_startup": bool(raw.get("on_startup", False)),
+    }
+    return normalized
+
+
 def _normalize_api_surfaces(data: dict[str, Any]) -> dict[str, Any]:
     """Validate top-level API-surface toggles.
 
@@ -2090,6 +2125,20 @@ class Config:
         )
 
     @property
+    def metadata(self) -> dict:
+        return self._data.get(
+            "metadata",
+            {
+                "enabled": True,
+                "public_catalog_url": "",
+                "private_catalog_url": "",
+                "refresh_interval_hours": 24.0,
+                "timeout_seconds": 10.0,
+                "on_startup": False,
+            },
+        )
+
+    @property
     def quota_poll(self) -> dict:
         """Quota balance poller settings (Phase 2 of the quota-tracking work).
 
@@ -2170,21 +2219,23 @@ def load_config(path: str | Path | None = None) -> Config:
     with path.open() as f:
         raw = yaml.safe_load(f)
 
-    expanded = _normalize_provider_source_refresh(
-        _normalize_api_surfaces(
-            _normalize_anthropic_bridge(
-                _normalize_provider_catalog_check(
-                    _normalize_security(
-                        _normalize_auto_update(
-                            _normalize_update_check(
-                                _normalize_request_hooks(
-                                    _validate_routing_mode_references(
-                                        _normalize_model_shortcuts(
-                                            _normalize_routing_modes(
-                                                _normalize_client_profiles(
-                                                    _normalize_routing_policies(
-                                                        _normalize_fallback_chain(
-                                                            _normalize_providers(_walk_expand(raw))
+    expanded = _normalize_metadata_sync(
+        _normalize_provider_source_refresh(
+            _normalize_api_surfaces(
+                _normalize_anthropic_bridge(
+                    _normalize_provider_catalog_check(
+                        _normalize_security(
+                            _normalize_auto_update(
+                                _normalize_update_check(
+                                    _normalize_request_hooks(
+                                        _validate_routing_mode_references(
+                                            _normalize_model_shortcuts(
+                                                _normalize_routing_modes(
+                                                    _normalize_client_profiles(
+                                                        _normalize_routing_policies(
+                                                            _normalize_fallback_chain(
+                                                                _normalize_providers(_walk_expand(raw))
+                                                            )
                                                         )
                                                     )
                                                 )

--- a/faigate/dashboard.py
+++ b/faigate/dashboard.py
@@ -10,6 +10,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from .catalog_resolver import CatalogResolver
 from .lane_registry import get_route_add_recommendations
 from .metrics import MetricsStore
 from .provider_catalog import (
@@ -207,6 +208,7 @@ def _provider_catalog_summary(db_path: str) -> dict[str, Any]:
     store.init()
     try:
         summary = build_catalog_summary(store)
+        summary["metadata_sync"] = CatalogResolver().status().get("tiers", {})
         summary["alerts"] = build_catalog_alerts(summary)
         summary["alert_summary"] = build_catalog_alert_summary(list(summary.get("alerts") or []))
         return summary

--- a/faigate/main.py
+++ b/faigate/main.py
@@ -40,6 +40,7 @@ from .bridges.anthropic import (
     openai_sse_to_anthropic,
 )
 from .canonical import CanonicalChatRequest, CanonicalChatResponse, CanonicalResponseMessage
+from .catalog_resolver import CatalogResolver, ResolverConfig
 from .config import Config, load_config
 from .dashboard import _metadata_catalogs_summary, _metadata_packages_detail
 from .dashboard_web import DASHBOARD_HTML
@@ -96,6 +97,7 @@ _update_checker: UpdateChecker
 _adaptive_state: AdaptiveRouteState = AdaptiveRouteState()
 _provider_catalog_store: ProviderCatalogStore | None = None
 _provider_catalog_refresh_task: asyncio.Task[None] | None = None
+_metadata_catalog_sync_task: asyncio.Task[None] | None = None
 _quota_poll_task: asyncio.Task[None] | None = None
 
 
@@ -465,6 +467,68 @@ async def _provider_source_refresh_loop() -> None:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.warning("Provider source catalog scheduled refresh skipped: %s", exc)
+
+
+def _metadata_resolver_config() -> ResolverConfig:
+    metadata_cfg = _config.metadata
+    config = ResolverConfig.from_env()
+    public_url = str(metadata_cfg.get("public_catalog_url") or "").strip()
+    private_url = str(metadata_cfg.get("private_catalog_url") or "").strip()
+    refresh_hours = float(metadata_cfg.get("refresh_interval_hours") or 0.0)
+    timeout_seconds = float(metadata_cfg.get("timeout_seconds") or config.timeout_seconds)
+    return ResolverConfig(
+        public_url=public_url or config.public_url,
+        private_url=private_url or config.private_url,
+        token=config.token,
+        refresh_interval_seconds=refresh_hours * 3600,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+async def _refresh_metadata_catalog(*, force: bool = False) -> dict[str, Any]:
+    """Refresh the curated metadata catalog cache outside the request path."""
+    metadata_cfg = _config.metadata
+    if not metadata_cfg.get("enabled", True):
+        return {"skipped": True, "reason": "disabled"}
+    refresh_hours = float(metadata_cfg.get("refresh_interval_hours") or 0.0)
+    if refresh_hours <= 0:
+        return {"skipped": True, "reason": "refresh disabled"}
+
+    resolver = CatalogResolver(config=_metadata_resolver_config())
+    resolved = await asyncio.to_thread(resolver.resolve, force_refresh=force)
+    provider_count = len(resolved.payload.get("providers", {}))
+    logger.info(
+        "Metadata catalog refresh completed: source=%s providers=%s%s",
+        resolved.source,
+        provider_count,
+        " force" if force else "",
+    )
+    return {
+        "source": resolved.source,
+        "providers": provider_count,
+        "etag": resolved.etag,
+        "notes": resolved.notes,
+    }
+
+
+async def _metadata_catalog_sync_loop() -> None:
+    """Refresh remote metadata catalog on the configured cadence with backoff."""
+    refresh_hours = float(_config.metadata.get("refresh_interval_hours") or 0.0)
+    interval_seconds = max(int(refresh_hours * 3600), 0)
+    if interval_seconds <= 0:
+        return
+    backoff_steps = [300, 900, 3600]
+    failure_count = 0
+    while True:
+        await asyncio.sleep(interval_seconds if failure_count == 0 else backoff_steps[min(failure_count - 1, 2)])
+        try:
+            await _refresh_metadata_catalog(force=True)
+            failure_count = 0
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            failure_count += 1
+            logger.warning("Metadata catalog scheduled refresh failed: %s", exc)
 
 
 def _collect_routing_headers(request: Request) -> dict[str, str]:
@@ -2260,7 +2324,7 @@ async def _resolve_image_route_preview(
 async def lifespan(app: FastAPI):
     """Startup / shutdown lifecycle."""
     global _config, _providers, _router, _metrics, _update_checker, _adaptive_state
-    global _provider_catalog_store, _provider_catalog_refresh_task
+    global _provider_catalog_store, _provider_catalog_refresh_task, _metadata_catalog_sync_task
     global _quota_poll_task
 
     logging.basicConfig(
@@ -2328,6 +2392,23 @@ async def lifespan(app: FastAPI):
     except Exception as exc:  # noqa: BLE001
         logger.warning("Provider source catalog startup refresh skipped: %s", exc)
 
+    try:
+        metadata_cfg = _config.metadata
+        refresh_hours = float(metadata_cfg.get("refresh_interval_hours") or 0.0)
+        if metadata_cfg.get("enabled", True) and refresh_hours > 0:
+            if metadata_cfg.get("on_startup"):
+                try:
+                    await _refresh_metadata_catalog(force=True)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Metadata catalog startup refresh failed: %s", exc)
+            _metadata_catalog_sync_task = asyncio.create_task(
+                _metadata_catalog_sync_loop(),
+                name="faigate-metadata-catalog-sync",
+            )
+            logger.info("Metadata catalog sync started (interval=%.2fh)", refresh_hours)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Metadata catalog sync startup skipped: %s", exc)
+
     # Quota balance poller (Phase 2: DeepSeek + Kilo). Disabled by default —
     # only activates when config.quota_poll.enabled is true AND at least one
     # api_poll package is present in the external catalog. Missing API keys
@@ -2378,6 +2459,11 @@ async def lifespan(app: FastAPI):
         with suppress(asyncio.CancelledError):
             await _provider_catalog_refresh_task
         _provider_catalog_refresh_task = None
+    if _metadata_catalog_sync_task is not None:
+        _metadata_catalog_sync_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _metadata_catalog_sync_task
+        _metadata_catalog_sync_task = None
     if _quota_poll_task is not None:
         _quota_poll_task.cancel()
         with suppress(asyncio.CancelledError):
@@ -2499,6 +2585,7 @@ async def provider_catalog():
             _provider_catalog_store,
             provider_ids=list(_config.provider_source_refresh.get("providers") or []),
         )
+        source_catalog["metadata_sync"] = CatalogResolver().status().get("tiers", {})
         source_catalog["alerts"] = build_catalog_alerts(source_catalog)
         source_catalog["alert_summary"] = build_catalog_alert_summary(list(source_catalog.get("alerts") or []))
     return {

--- a/faigate/provider_catalog_refresh.py
+++ b/faigate/provider_catalog_refresh.py
@@ -111,6 +111,69 @@ def _catalog_change_suggestion(event: dict[str, Any]) -> str:
     return f"Review recent provider catalog changes for {provider_id}."
 
 
+def _sync_alert_action(kind: str, severity: str) -> str:
+    if severity in {"critical", "warning"} and kind in {"sync-invalid", "sync-auth"}:
+        return "fix-now"
+    if severity in {"critical", "warning"}:
+        return "review-now"
+    return "inspect"
+
+
+def _build_sync_alert(tier: str, sync: dict[str, Any]) -> dict[str, Any] | None:
+    status = str(sync.get("last_status") or "")
+    last_error = str(sync.get("last_error") or "")
+    seconds_since_success = sync.get("seconds_since_success")
+    age = float(seconds_since_success) if seconds_since_success is not None else None
+
+    kind = ""
+    severity = ""
+    headline = ""
+    detail = ""
+    suggestion = ""
+
+    if status == "invalid":
+        kind = "sync-invalid"
+        severity = "critical"
+        headline = f"Metadata catalog sync returned invalid {tier} payload"
+        detail = last_error or "The latest remote payload failed validation and was not swapped into cache."
+        suggestion = "Fix the remote catalog JSON/schema before trusting synced provider metadata."
+    elif status == "auth_failed":
+        kind = "sync-auth"
+        severity = "warning"
+        headline = f"Metadata catalog auth failed for {tier}"
+        detail = last_error or "The metadata catalog request was rejected by the remote."
+        suggestion = (
+            "Check FAIGATE_METADATA_TOKEN permissions or remove the private URL/token if public metadata is enough."
+        )
+    elif age is not None and age > 7 * 86400:
+        kind = "sync-stale"
+        severity = "warning"
+        headline = f"Metadata catalog cache is stale for {tier}"
+        detail = f"The last successful metadata sync for {tier} was {int(age)}s ago."
+        suggestion = "Run faigate-models update --diff and inspect remote catalog availability."
+    elif status in {"error", "not_found"} and not sync.get("last_success_at"):
+        kind = "sync-stale"
+        severity = "warning"
+        headline = f"Metadata catalog sync has not succeeded for {tier}"
+        detail = last_error or f"Latest status: {status}"
+        suggestion = "Run faigate-models update --diff and verify metadata catalog URLs."
+
+    if not kind:
+        return None
+    return {
+        "kind": kind,
+        "severity": severity,
+        "action": _sync_alert_action(kind, severity),
+        "provider_id": f"metadata:{tier}",
+        "headline": headline,
+        "detail": detail,
+        "suggestion": suggestion,
+        "source_kind": "metadata-sync",
+        "sync_tier": tier,
+        "last_status": status,
+    }
+
+
 def build_catalog_alerts(
     summary: dict[str, Any],
     *,
@@ -118,6 +181,11 @@ def build_catalog_alerts(
 ) -> list[dict[str, Any]]:
     """Return structured provider source alerts ordered by urgency."""
     alerts: list[dict[str, Any]] = []
+    for tier, entry in dict(summary.get("metadata_sync") or {}).items():
+        sync = dict(entry.get("sync") or {})
+        alert = _build_sync_alert(str(tier), sync)
+        if alert is not None:
+            alerts.append(alert)
     for item in list(summary.get("items") or []):
         provider_id = str(item.get("provider_id") or "")
         status = str(item.get("status") or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "2.3.0"
+version = "2.4.0"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -389,6 +389,43 @@ def test_provider_source_refresh_defaults_are_exposed():
     }
 
 
+def test_metadata_sync_defaults_are_exposed():
+    cfg = load_config(SHIPPED_CONFIG)
+    assert cfg.metadata == {
+        "enabled": True,
+        "public_catalog_url": "",
+        "private_catalog_url": "",
+        "refresh_interval_hours": 24.0,
+        "timeout_seconds": 10.0,
+        "on_startup": False,
+    }
+
+
+def test_metadata_sync_can_be_disabled_with_zero_interval(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+server:
+  host: "127.0.0.1"
+  port: 8090
+providers:
+  cloud-default:
+    backend: openai-compat
+    base_url: "https://api.example.com/v1"
+    api_key: "secret"
+    model: "chat-model"
+metadata:
+  refresh_interval_hours: 0
+fallback_chain: []
+metrics:
+  enabled: false
+"""
+    )
+
+    cfg = load_config(path)
+    assert cfg.metadata["refresh_interval_hours"] == 0.0
+
+
 def test_provider_source_refresh_rejects_invalid_interval(tmp_path):
     path = tmp_path / "config.yaml"
     path.write_text(

--- a/tests/test_metadata_catalog_sync.py
+++ b/tests/test_metadata_catalog_sync.py
@@ -15,6 +15,7 @@ from faigate.metadata_catalog_sync import (
     MetadataCatalogSync,
     SyncStatus,
 )
+from faigate.provider_catalog_refresh import build_catalog_alerts
 
 # ── fakes ─────────────────────────────────────────────────────────────
 
@@ -199,6 +200,23 @@ def test_cache_age_seconds(tmp_path: Path):
     assert age is not None and age >= 0
 
 
+def test_cache_records_sync_state(tmp_path: Path):
+    cache = CatalogCache(root=tmp_path)
+    cache.save_state("public", status="invalid", success=False, error="schema mismatch", when=100.0)
+    state = cache.load_state("public")
+    assert state is not None
+    assert state.last_status == "invalid"
+    assert state.last_error == "schema mismatch"
+    assert state.failure_count == 1
+
+    cache.save_state("public", status="fresh", success=True, when=200.0)
+    state = cache.load_state("public")
+    assert state is not None
+    assert state.last_success_at == 200.0
+    assert state.success_count == 1
+    assert state.failure_count == 1
+
+
 # ── CatalogResolver chain ─────────────────────────────────────────────
 
 
@@ -345,3 +363,59 @@ def test_resolver_status_reports_cache_state(tmp_path: Path):
     assert status["tiers"]["public"]["present"] is True
     assert status["tiers"]["public"]["providers_count"] == 1
     assert status["tiers"]["private"]["present"] is False
+    assert status["tiers"]["public"]["sync"]["last_status"] == "fresh"
+
+
+def test_build_catalog_alerts_includes_metadata_sync_invalid():
+    alerts = build_catalog_alerts(
+        {
+            "metadata_sync": {
+                "public": {
+                    "sync": {
+                        "last_status": "invalid",
+                        "last_error": "schema mismatch",
+                        "last_success_at": None,
+                        "seconds_since_success": None,
+                    }
+                }
+            }
+        }
+    )
+    assert alerts[0]["kind"] == "sync-invalid"
+    assert alerts[0]["severity"] == "critical"
+
+
+def test_build_catalog_alerts_includes_metadata_sync_auth():
+    alerts = build_catalog_alerts(
+        {
+            "metadata_sync": {
+                "private": {
+                    "sync": {
+                        "last_status": "auth_failed",
+                        "last_error": "http 403",
+                        "last_success_at": None,
+                        "seconds_since_success": None,
+                    }
+                }
+            }
+        }
+    )
+    assert alerts[0]["kind"] == "sync-auth"
+
+
+def test_build_catalog_alerts_includes_metadata_sync_stale():
+    alerts = build_catalog_alerts(
+        {
+            "metadata_sync": {
+                "public": {
+                    "sync": {
+                        "last_status": "fresh",
+                        "last_error": "",
+                        "last_success_at": 1.0,
+                        "seconds_since_success": 8 * 86400,
+                    }
+                }
+            }
+        }
+    )
+    assert alerts[0]["kind"] == "sync-stale"


### PR DESCRIPTION
## Summary
- add the metadata catalog 24h refresh tick with persisted sync state and retry backoff
- surface sync issues through build_catalog_alerts for health, dashboard, and API consumers
- add Kilo Auto FAIGate profiles for OpenCode/Codenomad examples
- refresh the bundled catalog snapshot with verified pricing metadata
- bump fusionAIze Gate to v2.4.0 and update CHANGELOG

## Verification
- PYTHONPATH=. python3 -m pytest tests/test_config.py tests/test_metadata_catalog_sync.py tests/test_provider_catalog_api.py -q
- PYTHONPATH=. python3 -m ruff check faigate/config.py faigate/catalog_cache.py faigate/catalog_resolver.py faigate/dashboard.py faigate/main.py faigate/provider_catalog_refresh.py tests/test_config.py tests/test_metadata_catalog_sync.py
- PYTHONPATH=. python3 -m ruff format --check faigate/config.py faigate/catalog_cache.py faigate/catalog_resolver.py faigate/dashboard.py faigate/main.py faigate/provider_catalog_refresh.py tests/test_config.py tests/test_metadata_catalog_sync.py
- rtk git diff --check

## Notes
- Gate Bar / quota-helper local work is intentionally excluded from this PR; it should move to a separate companion repo such as faigate-bar.