### PR TITLE
fix(ci): release title uses 'fusionAIze Gate vX.Y.Z' convention

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -70,7 +70,7 @@ jobs:
             gh release edit "$TAG" --notes-file filtered-notes.md
             echo "updated existing release $TAG"
           else
-            gh release create "$TAG" --title "$TAG" --notes-file filtered-notes.md
+            gh release create "$TAG" --title "fusionAIze Gate $TAG" --notes-file filtered-notes.md
             echo "created release $TAG"
           fi
 


### PR DESCRIPTION
The prerelease workflow created GitHub releases with bare tag as title (vX.Y.Z). The notify-tap workflow requires 'fusionAIze Gate vX.Y.Z' format, causing silent failure on every release. Fixed at creation time so no manual `gh release edit` fix-up needed.