### PR TITLE
feat: add Cohere and Mistral providers (v2.6.1)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -70,7 +70,7 @@ jobs:
             gh release edit "$TAG" --notes-file filtered-notes.md
             echo "updated existing release $TAG"
           else
-            gh release create "$TAG" --title "$TAG" --notes-file filtered-notes.md
+            gh release create "$TAG" --title "fusionAIze Gate $TAG" --notes-file filtered-notes.md
             echo "created release $TAG"
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # fusionAIze Gate Changelog
 
+## v2.6.1 - 2026-05-04
+
+### Added
+
+- **Cohere provider** — Command A/R via OpenAI-compat endpoint (`${COHERE_API_KEY}`)
+- **Mistral provider** — Mistral Large via OpenAI-compat endpoint (`${MISTRAL_API_KEY}`)
+- Catalog entries for Cohere (catalog.v1.json + provider_catalog.py)
+
+### Fixed
+
+- Removed duplicate `cohere` block in commented section (active block now lives with other API-key providers)
+- `last_reviewed` date refreshed on Cohere and Mistral catalog entries
+
 ## v2.6.0 - 2026-05-04
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1199,6 +1199,30 @@ providers:
       profile: free-generative
       requires_api_key: false
 
+  # ── Additional API-key providers ──────────────────────────────────────────
+
+  # Cohere – Command A/R series, OpenAI-compat compatibility endpoint
+  cohere:
+    api_key: ${COHERE_API_KEY}
+    backend: openai-compat
+    base_url: ${COHERE_BASE_URL:-https://api.cohere.com/compatibility/v1}
+    model: command-a-03-2025
+    tier: default
+    timeout:
+      connect_s: 10
+      read_s: 60
+
+  # Mistral AI – Mistral Large, Codestral, etc.
+  mistral:
+    api_key: ${MISTRAL_API_KEY}
+    backend: openai-compat
+    base_url: ${MISTRAL_BASE_URL:-https://api.mistral.ai/v1}
+    model: mistral-large-latest
+    tier: default
+    timeout:
+      connect_s: 10
+      read_s: 90
+
   # ── Local runtimes (uncomment and configure) ──────────────────────────────
   # ollama:
   #   api_key: ""

--- a/faigate/__init__.py
+++ b/faigate/__init__.py
@@ -1,3 +1,3 @@
 """fusionAIze Gate package."""
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/faigate/assets/metadata/catalog.v1.json
+++ b/faigate/assets/metadata/catalog.v1.json
@@ -626,32 +626,32 @@
       }
     },
     "groq": {
-      "recommended_model": "llama-3.3-70b-versatile",
+      "recommended_model": "groq/llama-3.3-70b",
       "aliases": [
-        "llama-3.3-70b-versatile",
-        "groq/llama",
-        "mixtral-8x7b"
+        "groq",
+        "groq/llama-3.3-70b",
+        "llama-3.3-70b"
       ],
-      "track": "stable",
-      "offer_track": "direct",
+      "track": "free",
+      "offer_track": "free",
       "provider_type": "direct",
       "auth_modes": [
         "api_key"
       ],
       "volatility": "low",
       "evidence_level": "official",
-      "official_source_url": "https://console.groq.com/docs/models",
-      "signup_url": "https://console.groq.com/",
+      "official_source_url": "https://console.groq.com/",
+      "signup_url": "https://console.groq.com/keys",
       "watch_sources": [],
-      "notes": "Groq \u2013 ultra-fast inference (LPU), Llama / DeepSeek models.",
-      "last_reviewed": "2026-04-01",
+      "notes": "Groq ultra-fast LPU inference \u2014 300-500 tok/s. Free tier: 30 RPM, 14,400 RPD, 6K TPM.",
+      "last_reviewed": "2026-05-04",
       "pricing": {
         "source_type": "provider-docs",
-        "source_url": "https://console.groq.com/docs/pricing",
-        "refreshed_at": "2026-04-01T12:00:00Z",
+        "source_url": "https://console.groq.com/docs/rate-limits",
+        "refreshed_at": "2026-05-04T00:00:00Z",
         "freshness_status": "fresh",
-        "input_cost_per_1m": 0.05,
-        "output_cost_per_1m": 0.1
+        "input_cost_per_1m": 0.0,
+        "output_cost_per_1m": 0.0
       }
     },
     "mistral": {
@@ -889,30 +889,31 @@
       }
     },
     "cerebras": {
-      "recommended_model": "llama3.3-70b",
+      "recommended_model": "cerebras/qwen3-235b",
       "aliases": [
-        "llama3.3-70b"
+        "cerebras",
+        "cerebras/qwen3-235b"
       ],
-      "track": "stable",
-      "offer_track": "direct",
+      "track": "free",
+      "offer_track": "free",
       "provider_type": "direct",
       "auth_modes": [
         "api_key"
       ],
       "volatility": "low",
       "evidence_level": "official",
-      "official_source_url": "https://docs.cerebras.ai/",
-      "signup_url": "https://cerebras.ai/",
+      "official_source_url": "https://cloud.cerebras.ai/",
+      "signup_url": "https://cloud.cerebras.ai/",
       "watch_sources": [],
-      "notes": "Cerebras \u2013 fast inference, zai-glm-4.7 / zai-glm-4.6 compatible",
-      "last_reviewed": "2026-04-01",
+      "notes": "Cerebras wafer-scale inference ~2600 tok/s. Free tier: 30 RPM, 1M TPD.",
+      "last_reviewed": "2026-05-04",
       "pricing": {
-        "source_type": "registry-default",
-        "source_url": "",
-        "refreshed_at": "2026-04-01T02:22:11Z",
+        "source_type": "provider-docs",
+        "source_url": "https://cloud.cerebras.ai/",
+        "refreshed_at": "2026-05-04T00:00:00Z",
         "freshness_status": "fresh",
-        "input_cost_per_1m": 0.1,
-        "output_cost_per_1m": 0.1
+        "input_cost_per_1m": 0.0,
+        "output_cost_per_1m": 0.0
       }
     },
     "github-copilot": {
@@ -1144,17 +1145,23 @@
     },
     "pollinations": {
       "recommended_model": "pollinations/openai",
-      "aliases": ["pollinations", "pol", "pollinations/openai"],
+      "aliases": [
+        "pollinations",
+        "pol",
+        "pollinations/openai"
+      ],
       "track": "free",
       "offer_track": "free",
       "provider_type": "aggregator",
-      "auth_modes": ["none"],
+      "auth_modes": [
+        "none"
+      ],
       "volatility": "high",
       "evidence_level": "official",
       "official_source_url": "https://pollinations.ai/",
       "signup_url": "https://enter.pollinations.ai",
       "watch_sources": [],
-      "notes": "Pollinations free text+image+video+audio — no API key required. Supports GPT-5, Claude, Llama 4.",
+      "notes": "Pollinations free text+image+video+audio \u2014 no API key required. Supports GPT-5, Claude, Llama 4.",
       "last_reviewed": "2026-05-04",
       "pricing": {
         "source_type": "provider-docs",
@@ -1165,59 +1172,19 @@
         "output_cost_per_1m": 0.0
       }
     },
-    "groq": {
-      "recommended_model": "groq/llama-3.3-70b",
-      "aliases": ["groq", "groq/llama-3.3-70b", "llama-3.3-70b"],
-      "track": "free",
-      "offer_track": "free",
-      "provider_type": "direct",
-      "auth_modes": ["api_key"],
-      "volatility": "low",
-      "evidence_level": "official",
-      "official_source_url": "https://console.groq.com/",
-      "signup_url": "https://console.groq.com/keys",
-      "watch_sources": [],
-      "notes": "Groq ultra-fast LPU inference — 300-500 tok/s. Free tier: 30 RPM, 14,400 RPD, 6K TPM.",
-      "last_reviewed": "2026-05-04",
-      "pricing": {
-        "source_type": "provider-docs",
-        "source_url": "https://console.groq.com/docs/rate-limits",
-        "refreshed_at": "2026-05-04T00:00:00Z",
-        "freshness_status": "fresh",
-        "input_cost_per_1m": 0.0,
-        "output_cost_per_1m": 0.0
-      }
-    },
-    "cerebras": {
-      "recommended_model": "cerebras/qwen3-235b",
-      "aliases": ["cerebras", "cerebras/qwen3-235b"],
-      "track": "free",
-      "offer_track": "free",
-      "provider_type": "direct",
-      "auth_modes": ["api_key"],
-      "volatility": "low",
-      "evidence_level": "official",
-      "official_source_url": "https://cloud.cerebras.ai/",
-      "signup_url": "https://cloud.cerebras.ai/",
-      "watch_sources": [],
-      "notes": "Cerebras wafer-scale inference ~2600 tok/s. Free tier: 30 RPM, 1M TPD.",
-      "last_reviewed": "2026-05-04",
-      "pricing": {
-        "source_type": "provider-docs",
-        "source_url": "https://cloud.cerebras.ai/",
-        "refreshed_at": "2026-05-04T00:00:00Z",
-        "freshness_status": "fresh",
-        "input_cost_per_1m": 0.0,
-        "output_cost_per_1m": 0.0
-      }
-    },
     "longcat": {
       "recommended_model": "longcat/flash-lite",
-      "aliases": ["longcat", "lc", "longcat/flash-lite"],
+      "aliases": [
+        "longcat",
+        "lc",
+        "longcat/flash-lite"
+      ],
       "track": "free",
       "offer_track": "free",
       "provider_type": "direct",
-      "auth_modes": ["api_key"],
+      "auth_modes": [
+        "api_key"
+      ],
       "volatility": "high",
       "evidence_level": "official",
       "official_source_url": "https://longcat.ai/",
@@ -1236,11 +1203,17 @@
     },
     "nvidia-nim": {
       "recommended_model": "nvidia/nemotron",
-      "aliases": ["nvidia-nim", "nvidia", "nim"],
+      "aliases": [
+        "nvidia-nim",
+        "nvidia",
+        "nim"
+      ],
       "track": "free",
       "offer_track": "free",
       "provider_type": "direct",
-      "auth_modes": ["api_key"],
+      "auth_modes": [
+        "api_key"
+      ],
       "volatility": "medium",
       "evidence_level": "official",
       "official_source_url": "https://build.nvidia.com/",
@@ -1259,17 +1232,23 @@
     },
     "kiro": {
       "recommended_model": "kiro/claude-sonnet",
-      "aliases": ["kiro", "kr", "kiro/claude-sonnet"],
+      "aliases": [
+        "kiro",
+        "kr",
+        "kiro/claude-sonnet"
+      ],
       "track": "free",
       "offer_track": "free",
       "provider_type": "aggregator",
-      "auth_modes": ["oauth"],
+      "auth_modes": [
+        "oauth"
+      ],
       "volatility": "high",
       "evidence_level": "official",
       "official_source_url": "https://kiro.dev/",
       "signup_url": "https://kiro.dev/",
       "watch_sources": [],
-      "notes": "Kiro free tier via AWS Builder ID OAuth — Claude Sonnet 4.5 and Haiku 4.5 unlimited.",
+      "notes": "Kiro free tier via AWS Builder ID OAuth \u2014 Claude Sonnet 4.5 and Haiku 4.5 unlimited.",
       "last_reviewed": "2026-05-04",
       "pricing": {
         "source_type": "provider-docs",
@@ -1282,17 +1261,23 @@
     },
     "qoder": {
       "recommended_model": "qoder/kimi-k2",
-      "aliases": ["qoder", "qoder/kimi-k2", "qd"],
+      "aliases": [
+        "qoder",
+        "qoder/kimi-k2",
+        "qd"
+      ],
       "track": "free",
       "offer_track": "free",
       "provider_type": "aggregator",
-      "auth_modes": ["oauth"],
+      "auth_modes": [
+        "oauth"
+      ],
       "volatility": "high",
       "evidence_level": "official",
       "official_source_url": "https://qoder.ai/",
       "signup_url": "https://qoder.ai/",
       "watch_sources": [],
-      "notes": "Qoder free via Google OAuth — kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 unlimited.",
+      "notes": "Qoder free via Google OAuth \u2014 kimi-k2-thinking, qwen3-coder-plus, deepseek-r1 unlimited.",
       "last_reviewed": "2026-05-04",
       "pricing": {
         "source_type": "provider-docs",
@@ -1301,6 +1286,32 @@
         "freshness_status": "fresh",
         "input_cost_per_1m": 0.0,
         "output_cost_per_1m": 0.0
+      }
+    },
+    "cohere": {
+      "recommended_model": "command-a-03-2025",
+      "aliases": [
+        "cohere",
+        "command-a",
+        "command-r"
+      ],
+      "track": "stable",
+      "offer_track": "direct",
+      "provider_type": "direct",
+      "auth_modes": [
+        "api_key"
+      ],
+      "volatility": "low",
+      "evidence_level": "official",
+      "official_source_url": "https://docs.cohere.com/",
+      "signup_url": "https://dashboard.cohere.com/",
+      "watch_sources": [],
+      "notes": "Cohere Command A/R \u2014 enterprise-grade LLM with tool use",
+      "last_reviewed": "2026-05-04",
+      "pricing": {
+        "input_cost_per_1m": 0.5,
+        "output_cost_per_1m": 1.5,
+        "currency": "USD"
       }
     }
   }

--- a/faigate/provider_catalog.py
+++ b/faigate/provider_catalog.py
@@ -539,6 +539,22 @@ _CATALOG: dict[str, dict[str, Any]] = {
         ),
         "last_reviewed": "2026-05-04",
     },
+    # ── Cohere ────────────────────────────────────────────────────────────────
+    "cohere": {
+        "recommended_model": "command-a-03-2025",
+        "aliases": ["cohere", "command-a", "command-r"],
+        "track": "stable",
+        "offer_track": "direct",
+        "provider_type": "direct",
+        "auth_modes": ["api_key"],
+        "volatility": "low",
+        "evidence_level": "official",
+        "official_source_url": "https://docs.cohere.com/",
+        "signup_url": "https://dashboard.cohere.com/",
+        "watch_sources": [],
+        "notes": "Cohere Command A/R — enterprise-grade LLM with tool use",
+        "last_reviewed": "2026-05-04",
+    },
     "openai-gpt4o": {
         "recommended_model": "gpt-4o",
         "aliases": ["gpt-4o"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faigate"
-version = "2.6.0"
+version = "2.6.1"
 description = "Local OpenAI-compatible routing gateway for OpenClaw and other AI-native clients."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v2.6.1

### Added
- **Cohere** — Command A/R via OpenAI-compat, `${COHERE_API_KEY}`
- **Mistral** — Mistral Large via OpenAI-compat, `${MISTRAL_API_KEY}`
- Catalog entries + routing integration

### Fixed
- Duplicate Cohere block removed from commented section